### PR TITLE
[TLE] Optimize flashmla_sparse

### DIFF
--- a/src/flaggems_vllm/ops/flashmla_sparse.py
+++ b/src/flaggems_vllm/ops/flashmla_sparse.py
@@ -1,8 +1,29 @@
+import os
 from typing import Optional, Tuple
 
 import torch
 import triton
 import triton.language as tl
+
+from flaggems_vllm.utils.triton_version_utils import has_triton_tle
+
+if has_triton_tle(3, 6, 0):
+    try:
+        import triton.experimental.tle.language as tle
+
+        HAS_TLE_FLASHMLA_SPARSE = True
+    except ImportError:
+        tle = None
+        HAS_TLE_FLASHMLA_SPARSE = False
+else:
+    tle = None
+    HAS_TLE_FLASHMLA_SPARSE = False
+
+
+TLE_FLASHMLA_PREFILL_BK = 64
+TLE_FLASHMLA_PREFILL_BH = 64
+TLE_FLASHMLA_PREFILL_PAIR_BLOCKS = 2
+TLE_FLASHMLA_PREFILL_WORKER_NUM_WARPS = 4
 
 
 @triton.autotune(
@@ -158,6 +179,1015 @@ def triton_flash_mla_sparse_fwd(
     tl.store(o_ptr + BDP, out_vals1.to(tl.bfloat16))
 
 
+if HAS_TLE_FLASHMLA_SPARSE:
+
+    @triton.jit
+    def _tle_flashmla_prefill_producer(
+        k0_l_writer,
+        k0_r_writer,
+        k1_l_writer,
+        k1_r_writer,
+        valid_writer,
+        kv_base,
+        tkv_base,
+        t_base,
+        topk_len_ptr,
+        D: tl.constexpr,
+        TD: tl.constexpr,
+        DPH: tl.constexpr,
+        TDP: tl.constexpr,
+        VG: tl.constexpr,
+        SKV,
+        TOPK: tl.constexpr,
+        HAVE_TOPK_LENGTH: tl.constexpr,
+        HAVE_TAIL: tl.constexpr,
+        BK: tl.constexpr,
+    ):
+        topk_len = tl.load(topk_len_ptr) if HAVE_TOPK_LENGTH else TOPK
+        max_col = SKV - 1
+        stride_kvn: tl.constexpr = VG * (TD + D)
+        NK = tl.cdiv(topk_len, BK)
+        NPAIRS = tl.cdiv(NK, 2)
+        offs_t = tl.arange(0, BK)
+        offs_tile = tl.arange(0, 64)
+        kv_tile_rows = tl.broadcast_to(offs_t[:, None], (BK, 64))
+        for pair in tl.range(NPAIRS):
+            ck0 = pair * 2
+            ck1 = ck0 + 1
+            t_offs0 = BK * ck0 + offs_t
+            t_msk0 = t_offs0 < topk_len
+            kv_ids0 = tl.load(t_base + t_offs0, t_msk0, other=-1)
+            valid0 = t_msk0 & (kv_ids0 <= max_col) & (kv_ids0 >= 0)
+            kv_offsets0 = tl.where(valid0, kv_ids0, 0).to(tl.int64) * stride_kvn
+
+            t_offs1 = BK * ck1 + offs_t
+            t_msk1 = t_offs1 < topk_len
+            kv_ids1 = tl.load(t_base + t_offs1, t_msk1, other=-1)
+            valid1 = t_msk1 & (kv_ids1 <= max_col) & (kv_ids1 >= 0)
+            kv_offsets1 = tl.where(valid1, kv_ids1, 0).to(tl.int64) * stride_kvn
+
+            k0_l_slot = k0_l_writer.acquire(pair)
+            for tile in tl.static_range(0, DPH, 64):
+                k_cols = tile + offs_tile
+                k_cols_b = tl.broadcast_to(k_cols[None, :], (BK, 64))
+                k0_l_ptr = kv_base + kv_offsets0[:, None] + k_cols[None, :]
+                k0_l_msk = valid0[:, None] & (k_cols < D)[None, :]
+                k0_l_blk = tl.load(
+                    k0_l_ptr,
+                    mask=k0_l_msk,
+                    other=0.0,
+                    eviction_policy="evict_last",
+                )
+                tl.store(
+                    tle.gpu.local_ptr(k0_l_slot.sK, (kv_tile_rows, k_cols_b)),
+                    k0_l_blk,
+                    mask=k0_l_msk,
+                )
+            k0_l_writer.commit(pair)
+
+            k1_r_slot = k1_r_writer.acquire(pair)
+            for tile in tl.static_range(0, DPH, 64):
+                k_cols = DPH + tile + offs_tile
+                k_cols_b = tl.broadcast_to(k_cols[None, :], (BK, 64))
+                k1_r_ptr = kv_base + kv_offsets1[:, None] + k_cols[None, :]
+                k1_r_msk = valid1[:, None] & (k_cols < D)[None, :]
+                k1_r_blk = tl.load(
+                    k1_r_ptr,
+                    mask=k1_r_msk,
+                    other=0.0,
+                    eviction_policy="evict_last",
+                )
+                tl.store(
+                    tle.gpu.local_ptr(k1_r_slot.sK, (kv_tile_rows, k_cols_b)),
+                    k1_r_blk,
+                    mask=k1_r_msk,
+                )
+            if HAVE_TAIL:
+                offs_td = tl.arange(0, TDP)
+                k1_r_tail_ptr = tkv_base + kv_offsets1[:, None] + offs_td[None, :]
+                k1_r_tail_msk = valid1[:, None] & (offs_td < TD)[None, :]
+                k1_r_tail_blk = tl.load(
+                    k1_r_tail_ptr,
+                    mask=k1_r_tail_msk,
+                    other=0.0,
+                    eviction_policy="evict_last",
+                )
+                tl.store(
+                    tle.gpu.local_ptr(k1_r_slot.sK_tail),
+                    k1_r_tail_blk,
+                    mask=k1_r_tail_msk,
+                )
+            k1_r_writer.commit(pair)
+
+            k0_r_slot = k0_r_writer.acquire(pair)
+            for tile in tl.static_range(0, DPH, 64):
+                k_cols = DPH + tile + offs_tile
+                k_cols_b = tl.broadcast_to(k_cols[None, :], (BK, 64))
+                k0_r_ptr = kv_base + kv_offsets0[:, None] + k_cols[None, :]
+                k0_r_msk = valid0[:, None] & (k_cols < D)[None, :]
+                k0_r_blk = tl.load(
+                    k0_r_ptr,
+                    mask=k0_r_msk,
+                    other=0.0,
+                    eviction_policy="evict_last",
+                )
+                tl.store(
+                    tle.gpu.local_ptr(k0_r_slot.sK, (kv_tile_rows, k_cols_b)),
+                    k0_r_blk,
+                    mask=k0_r_msk,
+                )
+            if HAVE_TAIL:
+                offs_td = tl.arange(0, TDP)
+                k0_r_tail_ptr = tkv_base + kv_offsets0[:, None] + offs_td[None, :]
+                k0_r_tail_msk = valid0[:, None] & (offs_td < TD)[None, :]
+                k0_r_tail_blk = tl.load(
+                    k0_r_tail_ptr,
+                    mask=k0_r_tail_msk,
+                    other=0.0,
+                    eviction_policy="evict_last",
+                )
+                tl.store(
+                    tle.gpu.local_ptr(k0_r_slot.sK_tail),
+                    k0_r_tail_blk,
+                    mask=k0_r_tail_msk,
+                )
+            k0_r_writer.commit(pair)
+
+            k1_l_slot = k1_l_writer.acquire(pair)
+            for tile in tl.static_range(0, DPH, 64):
+                k_cols = tile + offs_tile
+                k_cols_b = tl.broadcast_to(k_cols[None, :], (BK, 64))
+                k1_l_ptr = kv_base + kv_offsets1[:, None] + k_cols[None, :]
+                k1_l_msk = valid1[:, None] & (k_cols < D)[None, :]
+                k1_l_blk = tl.load(
+                    k1_l_ptr,
+                    mask=k1_l_msk,
+                    other=0.0,
+                    eviction_policy="evict_last",
+                )
+                tl.store(
+                    tle.gpu.local_ptr(k1_l_slot.sK, (kv_tile_rows, k_cols_b)),
+                    k1_l_blk,
+                    mask=k1_l_msk,
+                )
+            k1_l_writer.commit(pair)
+
+            valid_slot = valid_writer.acquire(pair)
+            valid_row0 = tl.full([BK], 0, dtype=tl.int32)
+            valid_row1 = tl.full([BK], 1, dtype=tl.int32)
+            valid_ptr0 = tle.gpu.local_ptr(
+                valid_slot.is_kv_valid, (valid_row0, offs_t)
+            )
+            valid_ptr1 = tle.gpu.local_ptr(
+                valid_slot.is_kv_valid, (valid_row1, offs_t)
+            )
+            tl.store(valid_ptr0, valid0.to(tl.int8))
+            tl.store(valid_ptr1, valid1.to(tl.int8))
+            valid_writer.commit(pair)
+
+    @triton.jit
+    def _tle_flashmla_prefill_consumer0(
+        q_writer,
+        q_reader,
+        q_desc,
+        tq_desc,
+        k0_l_reader,
+        k0_r_qk_reader,
+        k1_l_remote_reader,
+        valid_reader,
+        sM_wg0_writer,
+        sM_wg1_reader,
+        sS0_writer,
+        sS1_reader,
+        sL_wg0_writer,
+        sL_wg1_reader,
+        output_desc,
+        output_row,
+        h_base,
+        topk_len_ptr,
+        attn_sink_base,
+        log_scale: tl.constexpr,
+        D: tl.constexpr,
+        TD: tl.constexpr,
+        OUT_DTYPE: tl.constexpr,
+        HAVE_ATTN_SINK: tl.constexpr,
+        TOPK: tl.constexpr,
+        HAVE_TOPK_LENGTH: tl.constexpr,
+        HAVE_TAIL: tl.constexpr,
+        BK: tl.constexpr,
+        BH: tl.constexpr,
+        DPH: tl.constexpr,
+        TDP: tl.constexpr,
+        G: tl.constexpr,
+    ):
+        topk_len = tl.load(topk_len_ptr) if HAVE_TOPK_LENGTH else TOPK
+        offs_h = tl.arange(0, BH)
+        offs_dh = tl.arange(0, DPH)
+        mask_h = h_base + offs_h < G
+        mask_od_l = offs_dh < D
+        kv_rows = tl.broadcast_to(tl.arange(0, BK)[:, None], (BK, DPH))
+        kv_cols_l = tl.broadcast_to(offs_dh[None, :], (BK, DPH))
+        kv_cols_r = tl.broadcast_to((DPH + offs_dh)[None, :], (BK, DPH))
+
+        q_write_slot = q_writer.acquire(0)
+        tle.gpu.copy(q_desc, q_write_slot.sQ_l, [BH, DPH], [output_row, 0])
+        tle.gpu.copy(q_desc, q_write_slot.sQ_r, [BH, DPH], [output_row, DPH])
+        if HAVE_TAIL:
+            tle.gpu.copy(tq_desc, q_write_slot.sQ_tail, [BH, TDP], [output_row, 0])
+        q_writer.commit(0)
+
+        q_slot = q_reader.wait(0).slot
+        q_l_smem_ptr = tle.gpu.local_ptr(q_slot.sQ_l)
+        q_r_smem_ptr = tle.gpu.local_ptr(q_slot.sQ_r)
+        max_prev = tl.full([BH], -1.0e30, dtype=tl.float32)
+        sum_exp = tl.full([BH], 0.0, dtype=tl.float32)
+        acc_l = tl.zeros([BH, DPH], dtype=tl.float32)
+
+        NK = tl.cdiv(topk_len, BK)
+        NPAIRS = tl.cdiv(NK, 2)
+
+        for pair in tl.range(NPAIRS):
+            k0_l_wait = k0_l_reader.wait(pair)
+            k0_l_slot = k0_l_wait.slot
+
+            q_l_blk = tl.load(q_l_smem_ptr)
+            q_r_blk = tl.load(q_r_smem_ptr)
+            k0_l_blk = tl.load(
+                tle.gpu.local_ptr(k0_l_slot.sK, (kv_rows, kv_cols_l))
+            )
+
+            qk0 = tl.full([BH, BK], 0.0, dtype=tl.float32)
+            qk0 = tl.dot(q_l_blk, tl.trans(k0_l_blk), qk0, out_dtype=tl.float32)
+
+            k0_r_wait = k0_r_qk_reader.wait(pair)
+            k0_r_slot = k0_r_wait.slot
+            k0_r_blk = tl.load(
+                tle.gpu.local_ptr(k0_r_slot.sK, (kv_rows, kv_cols_r))
+            )
+            qk0 = tl.dot(q_r_blk, tl.trans(k0_r_blk), qk0, out_dtype=tl.float32)
+            if HAVE_TAIL:
+                q_tail_blk = tl.load(tle.gpu.local_ptr(q_slot.sQ_tail))
+                k0_t_blk = tl.load(tle.gpu.local_ptr(k0_r_slot.sK_tail))
+                qk0 = tl.dot(
+                    q_tail_blk, tl.trans(k0_t_blk), qk0, out_dtype=tl.float32
+                )
+
+            valid_wait = valid_reader.wait(pair)
+            row0 = tl.full([BK], 0, dtype=tl.int32)
+            valid0 = (
+                tl.load(
+                    tle.gpu.local_ptr(
+                        valid_wait.slot.is_kv_valid, (row0, tl.arange(0, BK))
+                    )
+                )
+                != 0
+            )
+            qk0 = tl.where(valid0[None, :], qk0, float("-inf"))
+            valid_reader.release(pair)
+
+            local_max = tl.maximum(max_prev, tl.max(qk0, axis=1))
+            alpha = tl.math.exp2((max_prev - local_max) * log_scale)
+            prob0 = tl.math.exp2(qk0 * log_scale - local_max[:, None] * log_scale)
+            sum_exp = sum_exp * alpha + tl.sum(prob0, axis=1)
+            acc_l = acc_l * alpha[:, None]
+            prob0_b = prob0.to(OUT_DTYPE)
+
+            sM_wg0_slot = sM_wg0_writer.acquire(pair)
+            tl.store(tle.gpu.local_ptr(sM_wg0_slot.sM), local_max)
+            sM_wg0_writer.commit(pair)
+
+            k0_l_blk = tl.load(
+                tle.gpu.local_ptr(k0_l_slot.sK, (kv_rows, kv_cols_l))
+            )
+            acc_l = tl.dot(prob0_b, k0_l_blk, acc_l, out_dtype=tl.float32)
+            k0_l_reader.release(pair)
+            k0_r_qk_reader.release(pair)
+
+            sM_wg1_wait = sM_wg1_reader.wait(pair)
+            max_next = tl.load(tle.gpu.local_ptr(sM_wg1_wait.slot.sM))
+            sM_wg1_reader.release(pair)
+
+            final_scale = tl.math.exp2((local_max - max_next) * log_scale)
+            sum_exp = sum_exp * final_scale
+            acc_l = acc_l * final_scale[:, None]
+
+            prob0_scaled = prob0 * final_scale[:, None]
+            sS0_slot = sS0_writer.acquire(pair)
+            tl.store(tle.gpu.local_ptr(sS0_slot.sS0), prob0_scaled.to(OUT_DTYPE))
+            sS0_writer.commit(pair)
+
+            sS1_wait = sS1_reader.wait(pair)
+            prob1 = tl.load(tle.gpu.local_ptr(sS1_wait.slot.sS1))
+            k1_l_wait = k1_l_remote_reader.wait(pair)
+            k1_l_blk = tl.load(
+                tle.gpu.local_ptr(k1_l_wait.slot.sK, (kv_rows, kv_cols_l))
+            )
+            acc_l = tl.dot(prob1, k1_l_blk, acc_l, out_dtype=tl.float32)
+            sS1_reader.release(pair)
+            k1_l_remote_reader.release(pair)
+
+            max_prev = max_next
+
+        sL_wg0_slot = sL_wg0_writer.acquire(0)
+        tl.store(tle.gpu.local_ptr(sL_wg0_slot.sL), sum_exp)
+        sL_wg0_writer.commit(0)
+        sL_wg1_wait = sL_wg1_reader.wait(1)
+        peer_sum = tl.load(tle.gpu.local_ptr(sL_wg1_wait.slot.sL))
+        total_sum = sum_exp + peer_sum
+        sL_wg1_reader.release(1)
+
+        is_no_valid_tokens = total_sum == 0.0
+        inv_total_sum = tl.fdiv(1.0, total_sum)
+        out_l_vals = acc_l * inv_total_sum[:, None]
+        if HAVE_ATTN_SINK:
+            fin_log = (max_prev * log_scale + tl.math.log2(total_sum)) * 0.6931471805599453
+            sink = tl.load(attn_sink_base + h_base + offs_h, mask_h, other=0.0)
+            sink_scale = tl.fdiv(1.0, 1.0 + tl.math.exp(sink - fin_log))
+            out_l_vals = out_l_vals * sink_scale[:, None]
+        out_l_vals = tl.where(is_no_valid_tokens[:, None], 0.0, out_l_vals)
+        o_l_msk = mask_h[:, None] & mask_od_l[None, :]
+        tl.store(q_l_smem_ptr, out_l_vals.to(OUT_DTYPE), o_l_msk)
+        tle.gpu.copy(q_slot.sQ_l, output_desc, [BH, DPH], [output_row, 0])
+
+    @triton.jit
+    def _tle_flashmla_prefill_consumer1(
+        q_reader,
+        k1_r_reader,
+        k1_l_qk_reader,
+        k0_r_remote_reader,
+        valid_reader,
+        sM_wg1_writer,
+        sM_wg0_reader,
+        sS1_writer,
+        sS0_reader,
+        sL_wg1_writer,
+        sL_wg0_reader,
+        final_max_logits_smem,
+        final_lse_smem,
+        output_desc,
+        output_row,
+        max_logits_base,
+        l_base,
+        h_base,
+        topk_len_ptr,
+        attn_sink_base,
+        log_scale: tl.constexpr,
+        D: tl.constexpr,
+        TD: tl.constexpr,
+        OUT_DTYPE: tl.constexpr,
+        HAVE_ATTN_SINK: tl.constexpr,
+        TOPK: tl.constexpr,
+        HAVE_TOPK_LENGTH: tl.constexpr,
+        HAVE_TAIL: tl.constexpr,
+        BK: tl.constexpr,
+        BH: tl.constexpr,
+        DPH: tl.constexpr,
+        TDP: tl.constexpr,
+        G: tl.constexpr,
+    ):
+        topk_len = tl.load(topk_len_ptr) if HAVE_TOPK_LENGTH else TOPK
+        offs_h = tl.arange(0, BH)
+        offs_dh = tl.arange(0, DPH)
+        mask_h = h_base + offs_h < G
+        mask_od_r = DPH + offs_dh < D
+        kv_rows = tl.broadcast_to(tl.arange(0, BK)[:, None], (BK, DPH))
+        kv_cols_l = tl.broadcast_to(offs_dh[None, :], (BK, DPH))
+        kv_cols_r = tl.broadcast_to((DPH + offs_dh)[None, :], (BK, DPH))
+        q_slot = q_reader.wait(0).slot
+        q_l_smem_ptr = tle.gpu.local_ptr(q_slot.sQ_l)
+        q_r_smem_ptr = tle.gpu.local_ptr(q_slot.sQ_r)
+        max_prev = tl.full([BH], -1.0e30, dtype=tl.float32)
+        sum_exp = tl.full([BH], 0.0, dtype=tl.float32)
+        acc_r = tl.zeros([BH, DPH], dtype=tl.float32)
+
+        NK = tl.cdiv(topk_len, BK)
+        NPAIRS = tl.cdiv(NK, 2)
+        for pair in tl.range(NPAIRS):
+            k1_r_wait = k1_r_reader.wait(pair)
+            k1_r_slot = k1_r_wait.slot
+
+            q_l_blk = tl.load(q_l_smem_ptr)
+            q_r_blk = tl.load(q_r_smem_ptr)
+            k1_r_blk = tl.load(
+                tle.gpu.local_ptr(k1_r_slot.sK, (kv_rows, kv_cols_r))
+            )
+
+            qk1 = tl.full([BH, BK], 0.0, dtype=tl.float32)
+            qk1 = tl.dot(q_r_blk, tl.trans(k1_r_blk), qk1, out_dtype=tl.float32)
+            if HAVE_TAIL:
+                q_tail_blk = tl.load(tle.gpu.local_ptr(q_slot.sQ_tail))
+                k1_t_blk = tl.load(tle.gpu.local_ptr(k1_r_slot.sK_tail))
+                qk1 = tl.dot(
+                    q_tail_blk, tl.trans(k1_t_blk), qk1, out_dtype=tl.float32
+                )
+            k1_l_wait = k1_l_qk_reader.wait(pair)
+            k1_l_slot = k1_l_wait.slot
+            k1_l_blk = tl.load(
+                tle.gpu.local_ptr(k1_l_slot.sK, (kv_rows, kv_cols_l))
+            )
+            qk1 = tl.dot(q_l_blk, tl.trans(k1_l_blk), qk1, out_dtype=tl.float32)
+
+            valid_wait = valid_reader.wait(pair)
+            row1 = tl.full([BK], 1, dtype=tl.int32)
+            valid1 = (
+                tl.load(
+                    tle.gpu.local_ptr(
+                        valid_wait.slot.is_kv_valid, (row1, tl.arange(0, BK))
+                    )
+                )
+                != 0
+            )
+            qk1 = tl.where(valid1[None, :], qk1, float("-inf"))
+            valid_reader.release(pair)
+
+            sM_wg0_wait = sM_wg0_reader.wait(pair)
+            candidate0 = tl.load(tle.gpu.local_ptr(sM_wg0_wait.slot.sM))
+            sM_wg0_reader.release(pair)
+
+            candidate1 = tl.maximum(max_prev, tl.max(qk1, axis=1))
+            max_next = tl.maximum(candidate1, candidate0)
+            sM_wg1_slot = sM_wg1_writer.acquire(pair)
+            tl.store(tle.gpu.local_ptr(sM_wg1_slot.sM), max_next)
+            sM_wg1_writer.commit(pair)
+
+            alpha = tl.math.exp2((max_prev - max_next) * log_scale)
+            prob1 = tl.math.exp2(qk1 * log_scale - max_next[:, None] * log_scale)
+            sum_exp = sum_exp * alpha + tl.sum(prob1, axis=1)
+            acc_r = acc_r * alpha[:, None]
+            prob1_b = prob1.to(OUT_DTYPE)
+
+            k1_l_qk_reader.release(pair)
+
+            acc_r = tl.dot(prob1_b, k1_r_blk, acc_r, out_dtype=tl.float32)
+
+            sS1_slot = sS1_writer.acquire(pair)
+            tl.store(tle.gpu.local_ptr(sS1_slot.sS1), prob1_b)
+            sS1_writer.commit(pair)
+
+            sS0_wait = sS0_reader.wait(pair)
+            prob0 = tl.load(tle.gpu.local_ptr(sS0_wait.slot.sS0))
+            k0_r_wait = k0_r_remote_reader.wait(pair)
+            k0_r_blk = tl.load(
+                tle.gpu.local_ptr(k0_r_wait.slot.sK, (kv_rows, kv_cols_r))
+            )
+            acc_r = tl.dot(prob0, k0_r_blk, acc_r, out_dtype=tl.float32)
+            k1_r_reader.release(pair)
+            sS0_reader.release(pair)
+            k0_r_remote_reader.release(pair)
+            max_prev = max_next
+
+        sL_wg1_slot = sL_wg1_writer.acquire(1)
+        tl.store(tle.gpu.local_ptr(sL_wg1_slot.sL), sum_exp)
+        sL_wg1_writer.commit(1)
+        sL_wg0_wait = sL_wg0_reader.wait(0)
+        peer_sum = tl.load(tle.gpu.local_ptr(sL_wg0_wait.slot.sL))
+        total_sum = sum_exp + peer_sum
+        sL_wg0_reader.release(0)
+
+        is_no_valid_tokens = total_sum == 0.0
+        inv_total_sum = tl.fdiv(1.0, total_sum)
+        out_r_vals = acc_r * inv_total_sum[:, None]
+        final_max_logits_log2 = max_prev * log_scale
+        final_max_logits = final_max_logits_log2 * 0.6931471805599453
+        fin_log = (
+            final_max_logits_log2 + tl.math.log2(total_sum)
+        ) * 0.6931471805599453
+        if HAVE_ATTN_SINK:
+            sink = tl.load(attn_sink_base + h_base + offs_h, mask_h, other=0.0)
+            sink_scale = tl.fdiv(1.0, 1.0 + tl.math.exp(sink - fin_log))
+            out_r_vals = out_r_vals * sink_scale[:, None]
+        out_r_vals = tl.where(is_no_valid_tokens[:, None], 0.0, out_r_vals)
+        o_r_msk = mask_h[:, None] & mask_od_r[None, :]
+        tl.store(q_r_smem_ptr, out_r_vals.to(OUT_DTYPE), o_r_msk)
+        tle.gpu.copy(q_slot.sQ_r, output_desc, [BH, DPH], [output_row, DPH])
+
+        final_max_logits = tl.where(
+            is_no_valid_tokens, float("-inf"), final_max_logits
+        )
+        fin_log = tl.where(is_no_valid_tokens, float("inf"), fin_log)
+        tl.store(tle.gpu.local_ptr(final_max_logits_smem), final_max_logits, mask_h)
+        tl.store(tle.gpu.local_ptr(final_lse_smem), fin_log, mask_h)
+        final_max_logits = tl.load(
+            tle.gpu.local_ptr(final_max_logits_smem), mask_h, other=float("-inf")
+        )
+        fin_log = tl.load(tle.gpu.local_ptr(final_lse_smem), mask_h, other=float("inf"))
+        tl.store(max_logits_base + offs_h, final_max_logits, mask_h)
+        tl.store(l_base + offs_h, fin_log, mask_h)
+
+    @triton.jit
+    def _tle_flashmla_prefill_fwd(
+        q_desc,
+        tq_desc,
+        output_desc,
+        kv,
+        indices,
+        attn_sink,
+        topk_length,
+        sm_scale: tl.constexpr,
+        output,
+        max_logits,
+        lse,
+        SQ,
+        H: tl.constexpr,
+        DQK: tl.constexpr,
+        SKV,
+        TOPK: tl.constexpr,
+        HAVE_ATTN_SINK: tl.constexpr,
+        HAVE_TOPK_LENGTH: tl.constexpr,
+        D: tl.constexpr,
+        TD: tl.constexpr,
+        DP: tl.constexpr,
+        TDP: tl.constexpr,
+        G: tl.constexpr,
+        VG: tl.constexpr,
+        RH: tl.constexpr,
+        HAVE_TAIL: tl.constexpr,
+        BK: tl.constexpr,
+        BH: tl.constexpr,
+        PAIR_BLOCKS: tl.constexpr,
+    ):
+        DPH: tl.constexpr = DP // 2
+        stride_kvg: tl.constexpr = TD + D
+        stride_kvn = VG * stride_kvg
+        stride_tg = TOPK
+        stride_tm = VG * stride_tg
+        stride_lm = H
+        stride_mm = H
+
+        i_sq = tl.program_id(0)
+        i_grh = tl.program_id(1)
+        i_g = i_grh // RH
+        i_rh = i_grh % RH
+        h_base = i_rh * BH
+        q_head_base = i_g * G + h_base
+        i_sq64 = i_sq.to(tl.int64)
+        i_g64 = i_g.to(tl.int64)
+        q_head_base64 = q_head_base.to(tl.int64)
+        kv_base = kv + i_g64 * stride_kvg
+        tkv_base = kv_base + D
+        t_base = indices + i_sq64 * stride_tm + i_g64 * stride_tg
+        topk_len_ptr = topk_length + i_sq64
+        max_logits_base = max_logits + i_sq64 * stride_mm + q_head_base64
+        l_base = lse + i_sq64 * stride_lm + q_head_base64
+        q_row = i_sq * H + q_head_base
+        _ = output
+        _ = SQ
+        _ = DQK
+
+        sQ_l_smem = tle.gpu.alloc(
+            [1, BH, DPH], dtype=kv.dtype.element_ty, layout=None, scope=tle.gpu.smem
+        )
+        sQ_r_smem = tle.gpu.alloc(
+            [1, BH, DPH], dtype=kv.dtype.element_ty, layout=None, scope=tle.gpu.smem
+        )
+        if HAVE_TAIL:
+            sQ_tail_smem = tle.gpu.alloc(
+                [1, BH, TDP],
+                dtype=kv.dtype.element_ty,
+                layout=None,
+                scope=tle.gpu.smem,
+            )
+            q_pipe = tle.pipe(
+                capacity=1,
+                scope="cta",
+                name="flashmla_sQ",
+                readers=("wg0", "wg1"),
+                one_shot=True,
+                sQ_l=sQ_l_smem,
+                sQ_r=sQ_r_smem,
+                sQ_tail=sQ_tail_smem,
+            )
+        else:
+            q_pipe = tle.pipe(
+                capacity=1,
+                scope="cta",
+                name="flashmla_sQ",
+                readers=("wg0", "wg1"),
+                one_shot=True,
+                sQ_l=sQ_l_smem,
+                sQ_r=sQ_r_smem,
+            )
+
+        sK0_smem = tle.gpu.alloc(
+            [1, BK, DP], dtype=kv.dtype.element_ty, layout=None, scope=tle.gpu.smem
+        )
+        sK1_smem = tle.gpu.alloc(
+            [1, BK, DP], dtype=kv.dtype.element_ty, layout=None, scope=tle.gpu.smem
+        )
+        if HAVE_TAIL:
+            sK0_tail_smem = tle.gpu.alloc(
+                [1, BK, TDP],
+                dtype=kv.dtype.element_ty,
+                layout=None,
+                scope=tle.gpu.smem,
+            )
+            sK1_tail_smem = tle.gpu.alloc(
+                [1, BK, TDP],
+                dtype=kv.dtype.element_ty,
+                layout=None,
+                scope=tle.gpu.smem,
+            )
+            sS0_smem = sK0_tail_smem
+        else:
+            sS0_smem = tle.gpu.alloc(
+                [1, BH, BK],
+                dtype=kv.dtype.element_ty,
+                layout=None,
+                scope=tle.gpu.smem,
+            )
+        is_kv_valid_smem = tle.gpu.alloc(
+            [1, PAIR_BLOCKS, BK],
+            dtype=tl.int8,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        k0_l_pipe = tle.pipe(
+            capacity=1, scope="cta", name="flashmla_sK0_l", sK=sK0_smem
+        )
+        if HAVE_TAIL:
+            k0_r_pipe = tle.pipe(
+                capacity=1,
+                scope="cta",
+                name="flashmla_sK0_r",
+                readers=("qk", "remote"),
+                sK=sK0_smem,
+                sK_tail=sK0_tail_smem,
+            )
+        else:
+            k0_r_pipe = tle.pipe(
+                capacity=1,
+                scope="cta",
+                name="flashmla_sK0_r",
+                readers=("qk", "remote"),
+                sK=sK0_smem,
+            )
+        k1_l_pipe = tle.pipe(
+            capacity=1,
+            scope="cta",
+            name="flashmla_sK1_l",
+            readers=("qk", "remote"),
+            sK=sK1_smem,
+        )
+        if HAVE_TAIL:
+            k1_r_pipe = tle.pipe(
+                capacity=1,
+                scope="cta",
+                name="flashmla_sK1_r",
+                sK=sK1_smem,
+                sK_tail=sK1_tail_smem,
+            )
+        else:
+            k1_r_pipe = tle.pipe(
+                capacity=1,
+                scope="cta",
+                name="flashmla_sK1_r",
+                sK=sK1_smem,
+            )
+        is_kv_valid_pipe = tle.pipe(
+            capacity=1,
+            scope="cta",
+            name="flashmla_is_kv_valid_ready",
+            readers=("wg0", "wg1"),
+            is_kv_valid=is_kv_valid_smem,
+        )
+
+        sM_smem = tle.gpu.alloc(
+            [1, BH],
+            dtype=tl.float32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        sS1_smem = tle.gpu.alloc(
+            [1, BH, BK], dtype=kv.dtype.element_ty, layout=None, scope=tle.gpu.smem
+        )
+        sL_smem = tle.gpu.alloc(
+            [2, BH],
+            dtype=tl.float32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        final_max_logits_smem = tle.gpu.alloc(
+            [BH],
+            dtype=tl.float32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        final_lse_smem = tle.gpu.alloc(
+            [BH],
+            dtype=tl.float32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        sM_wg0_pipe = tle.pipe(
+            capacity=1, scope="cta", name="flashmla_wg0_bunch_0_ready", sM=sM_smem
+        )
+        sM_wg1_pipe = tle.pipe(
+            capacity=1, scope="cta", name="flashmla_wg1_bunch_0_ready", sM=sM_smem
+        )
+        sS0_pipe = tle.pipe(
+            capacity=1, scope="cta", name="flashmla_sS0", sS0=sS0_smem
+        )
+        sS1_pipe = tle.pipe(
+            capacity=1, scope="cta", name="flashmla_sS1", sS1=sS1_smem
+        )
+        sL_wg0_pipe = tle.pipe(
+            capacity=2, scope="cta", name="flashmla_sL_wg0", sL=sL_smem
+        )
+        sL_wg1_pipe = tle.pipe(
+            capacity=2, scope="cta", name="flashmla_sL_wg1", sL=sL_smem
+        )
+
+        log_scale: tl.constexpr = sm_scale * 1.4426950408889634
+
+        tle.gpu.warp_specialize(
+            [
+                (
+                    _tle_flashmla_prefill_consumer0,
+                    (
+                        q_pipe.writer(),
+                        q_pipe.reader("wg0"),
+                        q_desc,
+                        tq_desc,
+                        k0_l_pipe.reader(),
+                        k0_r_pipe.reader("qk"),
+                        k1_l_pipe.reader("remote", fields=("sK",)),
+                        is_kv_valid_pipe.reader("wg0"),
+                        sM_wg0_pipe.writer(),
+                        sM_wg1_pipe.reader(),
+                        sS0_pipe.writer(),
+                        sS1_pipe.reader(),
+                        sL_wg0_pipe.writer(),
+                        sL_wg1_pipe.reader(),
+                        output_desc,
+                        q_row,
+                        h_base,
+                        topk_len_ptr,
+                        attn_sink,
+                        log_scale,
+                        D,
+                        TD,
+                        kv.dtype.element_ty,
+                        HAVE_ATTN_SINK,
+                        TOPK,
+                        HAVE_TOPK_LENGTH,
+                        HAVE_TAIL,
+                        BK,
+                        BH,
+                        DPH,
+                        TDP,
+                        G,
+                    ),
+                ),
+                (
+                    _tle_flashmla_prefill_consumer1,
+                    (
+                        q_pipe.reader("wg1"),
+                        k1_r_pipe.reader(),
+                        k1_l_pipe.reader("qk"),
+                        k0_r_pipe.reader("remote", fields=("sK",)),
+                        is_kv_valid_pipe.reader("wg1"),
+                        sM_wg1_pipe.writer(),
+                        sM_wg0_pipe.reader(),
+                        sS1_pipe.writer(),
+                        sS0_pipe.reader(),
+                        sL_wg1_pipe.writer(),
+                        sL_wg0_pipe.reader(),
+                        final_max_logits_smem,
+                        final_lse_smem,
+                        output_desc,
+                        q_row,
+                        max_logits_base,
+                        l_base,
+                        h_base,
+                        topk_len_ptr,
+                        attn_sink,
+                        log_scale,
+                        D,
+                        TD,
+                        kv.dtype.element_ty,
+                        HAVE_ATTN_SINK,
+                        TOPK,
+                        HAVE_TOPK_LENGTH,
+                        HAVE_TAIL,
+                        BK,
+                        BH,
+                        DPH,
+                        TDP,
+                        G,
+                    ),
+                ),
+                (
+                    _tle_flashmla_prefill_producer,
+                    (
+                        k0_l_pipe.writer(),
+                        k0_r_pipe.writer(),
+                        k1_l_pipe.writer(),
+                        k1_r_pipe.writer(),
+                        is_kv_valid_pipe.writer(),
+                        kv_base,
+                        tkv_base,
+                        t_base,
+                        topk_len_ptr,
+                        D,
+                        TD,
+                        DPH,
+                        TDP,
+                        VG,
+                        SKV,
+                        TOPK,
+                        HAVE_TOPK_LENGTH,
+                        HAVE_TAIL,
+                        BK,
+                    ),
+                ),
+            ],
+            [4, 4],
+            [216, 72],
+        )
+
+
+def _flash_mla_sparse_tle_enabled() -> bool:
+    value = os.environ.get("FLAGGEMS_VLLM_FLASHMLA_SPARSE_TLE", "1").lower()
+    return value not in {"0", "false", "off", "no"}
+
+
+def _can_use_tle_flash_mla_sparse_fwd(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    d_v: int,
+    topk_length: Optional[torch.Tensor] = None,
+) -> bool:
+    if not (HAS_TLE_FLASHMLA_SPARSE and _flash_mla_sparse_tle_enabled()):
+        return False
+    if q.device.type != "cuda":
+        return False
+    SQ, HQ, DQK = q.shape
+    _ = SQ
+    HKV = kv.shape[1]
+    TOPK = indices.shape[-1]
+    return (
+        d_v == 512
+        and HKV == 1
+        and DQK in (512, 576)
+        and HQ % TLE_FLASHMLA_PREFILL_BH == 0
+        and TOPK > 0
+        and TOPK % 128 == 0
+    )
+
+
+def _set_triton_descriptor_allocator(device: torch.device) -> None:
+    def alloc_fn(size: int, align: int, stream):
+        _ = align
+        _ = stream
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+
+
+def _flash_mla_sparse_fwd_tle(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    output: torch.Tensor,
+    max_logits: torch.Tensor,
+    lse: torch.Tensor,
+    d_v: int = 512,
+    attn_sink: Optional[torch.Tensor] = None,
+    topk_length: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    _set_triton_descriptor_allocator(q.device)
+    SQ, HQ, DQK = q.shape
+    SKV, HKV, _ = kv.shape
+    _, _, TOPK = indices.shape
+    D = d_v
+    TD = DQK - D
+    DP = triton.next_power_of_2(D)
+    HAVE_TAIL = TD > 0
+    TDP = triton.next_power_of_2(TD) if HAVE_TAIL else 1
+    G = HQ // HKV
+    BH = TLE_FLASHMLA_PREFILL_BH
+    RH = G // BH
+    BK = TLE_FLASHMLA_PREFILL_BK
+
+    attn_sink_arg = (
+        attn_sink
+        if attn_sink is not None
+        else torch.empty((1,), device=q.device, dtype=torch.float32)
+    )
+    topk_length_arg = topk_length if topk_length is not None else indices
+    q_flat = q.reshape(SQ * HQ, DQK)
+    output_flat = output.reshape(SQ * HQ, D)
+    q_desc = TensorDescriptor(
+        q_flat, shape=[SQ * HQ, D], strides=[DQK, 1], block_shape=[BH, DP // 2]
+    )
+    if HAVE_TAIL:
+        q_tail = q_flat[:, D:]
+        tq_desc = TensorDescriptor(
+            q_tail, shape=[SQ * HQ, TD], strides=[DQK, 1], block_shape=[BH, TDP]
+        )
+    else:
+        tq_desc = q_desc
+    output_desc = TensorDescriptor(
+        output_flat, shape=[SQ * HQ, D], strides=[D, 1], block_shape=[BH, DP // 2]
+    )
+
+    grid = (SQ, HKV * RH)
+    _tle_flashmla_prefill_fwd[grid](
+        q_desc,
+        tq_desc,
+        output_desc,
+        kv,
+        indices,
+        attn_sink_arg,
+        topk_length_arg,
+        sm_scale,
+        output,
+        max_logits,
+        lse,
+        SQ,
+        HQ,
+        DQK,
+        SKV,
+        TOPK,
+        attn_sink is not None,
+        topk_length is not None,
+        D,
+        TD,
+        DP,
+        TDP,
+        G,
+        HKV,
+        RH,
+        HAVE_TAIL,
+        BK,
+        BH,
+        TLE_FLASHMLA_PREFILL_PAIR_BLOCKS,
+        num_warps=TLE_FLASHMLA_PREFILL_WORKER_NUM_WARPS,
+        num_stages=1,
+    )
+    return output, max_logits, lse
+
+
+def _flash_mla_sparse_fwd_triton(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    output: torch.Tensor,
+    max_logits: torch.Tensor,
+    lse: torch.Tensor,
+    d_v: int = 512,
+    attn_sink: Optional[torch.Tensor] = None,
+    topk_length: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    SQ, HQ, DQK = q.shape
+    SKV, _, _ = kv.shape
+    _, _, TOPK = indices.shape
+    _ = d_v
+
+    def grid(META):
+        return (triton.cdiv(HQ, META["BH"]) * SQ,)
+
+    triton_flash_mla_sparse_fwd[grid](
+        q,
+        kv,
+        indices,
+        attn_sink,
+        topk_length,
+        sm_scale,
+        output,
+        max_logits,
+        lse,
+        q.stride(1),
+        q.stride(0),
+        kv.stride(1),
+        kv.stride(0),
+        indices.stride(1),
+        indices.stride(0),
+        output.stride(1),
+        output.stride(0),
+        max_logits.stride(0),
+        lse.stride(0),
+        SQ,
+        HQ,
+        DQK,
+        SKV,
+        TOPK,
+        attn_sink is not None,
+        topk_length is not None,
+    )
+    return output, max_logits, lse
+
+
 def flash_mla_sparse_fwd(
     q: torch.Tensor,
     kv: torch.Tensor,
@@ -223,39 +1253,33 @@ def flash_mla_sparse_fwd(
     assert HQ == 64 or HQ == 128, "Unsupported h_q"
     assert DQK == 576 or DQK == 512, "Unsupported d_qk"
 
+    _ = SKV
     output = torch.empty((SQ, HQ, DV), device=q.device, dtype=q.dtype)
     max_logits = torch.empty((SQ, HQ), device=q.device, dtype=torch.float32)
     lse = torch.empty((SQ, HQ), device=q.device, dtype=torch.float32)
+    if _can_use_tle_flash_mla_sparse_fwd(q, kv, indices, d_v, topk_length):
+        return _flash_mla_sparse_fwd_tle(
+            q,
+            kv,
+            indices,
+            sm_scale,
+            output,
+            max_logits,
+            lse,
+            d_v,
+            attn_sink,
+            topk_length,
+        )
 
-    def grid(META):
-        return (triton.cdiv(HQ, META["BH"]) * SQ,)
-
-    triton_flash_mla_sparse_fwd[grid](
+    return _flash_mla_sparse_fwd_triton(
         q,
         kv,
         indices,
-        attn_sink,
-        topk_length,
         sm_scale,
         output,
         max_logits,
         lse,
-        q.stride(1),
-        q.stride(0),
-        kv.stride(1),
-        kv.stride(0),
-        indices.stride(1),
-        indices.stride(0),
-        output.stride(1),
-        output.stride(0),
-        max_logits.stride(0),
-        lse.stride(0),
-        SQ,
-        HQ,
-        DQK,
-        SKV,
-        TOPK,
-        attn_sink is not None,
-        topk_length is not None,
+        d_v,
+        attn_sink,
+        topk_length,
     )
-    return output, max_logits, lse


### PR DESCRIPTION
### Summary
1. Add an optional TLE fast path for `flash_mla_sparse_fwd` while preserving the public Python interface and the existing Triton implementation as the fallback path.
2. Use a TLE warp-specialized prefill kernel with one producer and two consumers. The producer gathers sparse KV tiles into shared memory, while the consumers split the left/right output halves and exchange softmax metadata through TLE pipes.
3. Use `TensorDescriptor` based copies for Q/O tiles and local shared-memory pipes for Q, K, validity masks, softmax scores, and partial reductions.
4. Support both `d_qk=576` and `d_qk=512`. The `576` mode uses the `512 + 64` tail path; the `512` mode disables all tail copies, tail pipes, and tail shared-memory allocations.
5. Keep the TLE dependency optional. Normal import still works without TLE, and unsupported shapes or disabled TLE route to the Triton baseline.
6. Gate the TLE path on FlashMLA sparse constraints: `d_v=512`, `h_kv=1`, `d_qk in {512, 576}`, `h_q` divisible by 64, and `topk` divisible by 128.

### Interface declaration review
```python
def flash_mla_sparse_fwd(
    q: torch.Tensor,
    kv: torch.Tensor,
    indices: torch.Tensor,
    sm_scale: float,
    d_v: int = 512,
    attn_sink: Optional[torch.Tensor] = None,
    topk_length: Optional[torch.Tensor] = None,
) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
    """Sparse MLA prefill forward.

    Args:
        q: [s_q, h_q, d_qk], bfloat16, contiguous.
        kv: [s_kv, h_kv, d_qk], bfloat16, contiguous.
        indices: [s_q, h_kv, topk], int32, contiguous.
        sm_scale: attention scale.
        d_v: value dimension. Only 512 is supported.
        attn_sink: optional [h_q], float32, contiguous.
        topk_length: optional [s_q], int32, contiguous.

    Returns:
        (output, max_logits, lse)
        output: [s_q, h_q, d_v], bfloat16.
        max_logits: [s_q, h_q], float32.
        lse: [s_q, h_q], float32.
    """
```

### Performance test
- GPU: NVIDIA H800
- Environment: `conda run -n flagtree`, `PYTHONPATH=/root/repos/flagtree/python:/root/repos/FlagGems-vllm/src`
- Workload settings: `h_kv=1`, `d_v=512`, `sm_scale=0.5`, `attn_sink` provided, `topk_length=None`
- Benchmark settings: warmup=10, iter=30, median latency
- The 3-way benchmark uses the same performance cases and input generation pattern as `benchmark/test_flash_mla_sparse_fwd.py`.
- Performance ratios use throughput semantics: `baseline_latency / candidate_latency`, so larger is better.

### Performance vs vLLM and Triton

| s_q | s_kv | h_q | d_qk | topk | vLLM latency(ms) | Triton latency(ms) | TLE latency(ms) | Triton perf/vLLM | TLE perf/vLLM | TLE perf/Triton |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4096 | 8192 | 128 | 576 | 2048 | 3.732928 | 6.812048 | 4.376096 | 0.548x | 0.853x | 1.557x |
| 4096 | 32768 | 128 | 576 | 2048 | 3.949056 | 7.659808 | 4.752704 | 0.516x | 0.831x | 1.612x |
| 4096 | 65536 | 128 | 576 | 2048 | 4.649184 | 7.601408 | 5.257424 | 0.612x | 0.884x | 1.446x |
| 4096 | 98304 | 128 | 576 | 2048 | 4.979040 | 8.056160 | 5.345120 | 0.618x | 0.932x | 1.507x |
| 4096 | 131072 | 128 | 576 | 2048 | 4.701072 | 7.796000 | 5.780864 | 0.603x | 0.813x | 1.349x |
| 4096 | 8192 | 64 | 512 | 512 | 0.593408 | 0.980896 | 0.736800 | 0.605x | 0.805x | 1.331x |
| 4096 | 32768 | 64 | 512 | 512 | 0.627136 | 1.104384 | 0.770496 | 0.568x | 0.814x | 1.433x |
| 4096 | 49152 | 64 | 512 | 512 | 0.678400 | 1.136256 | 0.796352 | 0.597x | 0.852x | 1.427x |
| 4096 | 65536 | 64 | 512 | 512 | 0.716736 | 1.117440 | 0.824768 | 0.641x | 0.869x | 1.355x |
| 4096 | 8192 | 128 | 512 | 1024 | 1.935024 | 3.375264 | 2.112064 | 0.573x | 0.916x | 1.598x |
| 4096 | 32768 | 128 | 512 | 1024 | 2.095680 | 3.630528 | 2.282048 | 0.577x | 0.918x | 1.591x |
| 4096 | 49152 | 128 | 512 | 1024 | 2.268768 | 3.790912 | 2.457344 | 0.598x | 0.923x | 1.543x |
| 4096 | 65536 | 128 | 512 | 1024 | 2.336000 | 3.758208 | 2.579008 | 0.622x | 0.906x | 1.457x |
| **Avg** | - | - | - | - | **2.558649** | **4.370716** | **2.928545** | **0.590x** | **0.869x** | **1.474x** |

### Accuracy notes
The benchmark compares all returned tensors against vLLM for every row above. Observed TLE-vs-vLLM differences were:
- output max absolute diff: up to `2.441e-04`
- max_logits max absolute diff: `0.000e+00`
- lse max absolute diff: up to `1.431e-06`

### Validation
```bash
git diff --check
PYTHONPATH=/root/repos/flagtree/python:/root/repos/FlagGems-vllm/src \
  conda run -n flagtree python -m py_compile src/flaggems_vllm/ops/flashmla_sparse.py
```
Also ran the 3-way benchmark described above for all rows in the performance table.
