### PR TITLE
[TLE] Inline flashmla_sparse launch wrappers

### DIFF
--- a/src/flaggems_vllm/ops/flashmla_sparse.py
+++ b/src/flaggems_vllm/ops/flashmla_sparse.py
@@ -393,7 +393,7 @@ if HAS_TLE_FLASHMLA_SPARSE:
         tle.gpu.copy(q_desc, q_write_slot.sQ_l, [BH, DPH], [output_row, 0])
         tle.gpu.copy(q_desc, q_write_slot.sQ_r, [BH, DPH], [output_row, DPH])
         if HAVE_TAIL:
-            tle.gpu.copy(tq_desc, q_write_slot.sQ_tail, [BH, TDP], [output_row, 0])
+            tle.gpu.copy(tq_desc, q_write_slot.sQ_tail, [BH, TDP], [output_row, D])
         q_writer.commit(0)
 
         q_slot = q_reader.wait(0).slot
@@ -714,8 +714,10 @@ if HAS_TLE_FLASHMLA_SPARSE:
         stride_lm = H
         stride_mm = H
 
-        i_sq = tl.program_id(0)
-        i_grh = tl.program_id(1)
+        pid = tl.program_id(0)
+        programs_per_q: tl.constexpr = VG * RH
+        i_sq = pid // programs_per_q
+        i_grh = pid % programs_per_q
         i_g = i_grh // RH
         i_rh = i_grh % RH
         h_base = i_rh * BH
@@ -726,7 +728,8 @@ if HAS_TLE_FLASHMLA_SPARSE:
         kv_base = kv + i_g64 * stride_kvg
         tkv_base = kv_base + D
         t_base = indices + i_sq64 * stride_tm + i_g64 * stride_tg
-        topk_len_ptr = topk_length + i_sq64
+        topk_len_ptr = topk_length + i_sq64 if HAVE_TOPK_LENGTH else indices
+        attn_sink_base = attn_sink if HAVE_ATTN_SINK else max_logits
         max_logits_base = max_logits + i_sq64 * stride_mm + q_head_base64
         l_base = lse + i_sq64 * stride_lm + q_head_base64
         q_row = i_sq * H + q_head_base
@@ -927,7 +930,7 @@ if HAS_TLE_FLASHMLA_SPARSE:
                         q_row,
                         h_base,
                         topk_len_ptr,
-                        attn_sink,
+                        attn_sink_base,
                         log_scale,
                         D,
                         TD,
@@ -965,7 +968,7 @@ if HAS_TLE_FLASHMLA_SPARSE:
                         l_base,
                         h_base,
                         topk_len_ptr,
-                        attn_sink,
+                        attn_sink_base,
                         log_scale,
                         D,
                         TD,
@@ -1050,144 +1053,6 @@ def _set_triton_descriptor_allocator(device: torch.device) -> None:
     triton.set_allocator(alloc_fn)
 
 
-def _flash_mla_sparse_fwd_tle(
-    q: torch.Tensor,
-    kv: torch.Tensor,
-    indices: torch.Tensor,
-    sm_scale: float,
-    output: torch.Tensor,
-    max_logits: torch.Tensor,
-    lse: torch.Tensor,
-    d_v: int = 512,
-    attn_sink: Optional[torch.Tensor] = None,
-    topk_length: Optional[torch.Tensor] = None,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    from triton.tools.tensor_descriptor import TensorDescriptor
-
-    _set_triton_descriptor_allocator(q.device)
-    SQ, HQ, DQK = q.shape
-    SKV, HKV, _ = kv.shape
-    _, _, TOPK = indices.shape
-    D = d_v
-    TD = DQK - D
-    DP = triton.next_power_of_2(D)
-    HAVE_TAIL = TD > 0
-    TDP = triton.next_power_of_2(TD) if HAVE_TAIL else 1
-    G = HQ // HKV
-    BH = TLE_FLASHMLA_PREFILL_BH
-    RH = G // BH
-    BK = TLE_FLASHMLA_PREFILL_BK
-
-    attn_sink_arg = (
-        attn_sink
-        if attn_sink is not None
-        else torch.empty((1,), device=q.device, dtype=torch.float32)
-    )
-    topk_length_arg = topk_length if topk_length is not None else indices
-    q_flat = q.reshape(SQ * HQ, DQK)
-    output_flat = output.reshape(SQ * HQ, D)
-    q_desc = TensorDescriptor(
-        q_flat, shape=[SQ * HQ, D], strides=[DQK, 1], block_shape=[BH, DP // 2]
-    )
-    if HAVE_TAIL:
-        q_tail = q_flat[:, D:]
-        tq_desc = TensorDescriptor(
-            q_tail, shape=[SQ * HQ, TD], strides=[DQK, 1], block_shape=[BH, TDP]
-        )
-    else:
-        tq_desc = q_desc
-    output_desc = TensorDescriptor(
-        output_flat, shape=[SQ * HQ, D], strides=[D, 1], block_shape=[BH, DP // 2]
-    )
-
-    grid = (SQ, HKV * RH)
-    _tle_flashmla_prefill_fwd[grid](
-        q_desc,
-        tq_desc,
-        output_desc,
-        kv,
-        indices,
-        attn_sink_arg,
-        topk_length_arg,
-        sm_scale,
-        output,
-        max_logits,
-        lse,
-        SQ,
-        HQ,
-        DQK,
-        SKV,
-        TOPK,
-        attn_sink is not None,
-        topk_length is not None,
-        D,
-        TD,
-        DP,
-        TDP,
-        G,
-        HKV,
-        RH,
-        HAVE_TAIL,
-        BK,
-        BH,
-        TLE_FLASHMLA_PREFILL_PAIR_BLOCKS,
-        num_warps=TLE_FLASHMLA_PREFILL_WORKER_NUM_WARPS,
-        num_stages=1,
-    )
-    return output, max_logits, lse
-
-
-def _flash_mla_sparse_fwd_triton(
-    q: torch.Tensor,
-    kv: torch.Tensor,
-    indices: torch.Tensor,
-    sm_scale: float,
-    output: torch.Tensor,
-    max_logits: torch.Tensor,
-    lse: torch.Tensor,
-    d_v: int = 512,
-    attn_sink: Optional[torch.Tensor] = None,
-    topk_length: Optional[torch.Tensor] = None,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    SQ, HQ, DQK = q.shape
-    SKV, _, _ = kv.shape
-    _, _, TOPK = indices.shape
-    _ = d_v
-
-    def grid(META):
-        return (triton.cdiv(HQ, META["BH"]) * SQ,)
-
-    triton_flash_mla_sparse_fwd[grid](
-        q,
-        kv,
-        indices,
-        attn_sink,
-        topk_length,
-        sm_scale,
-        output,
-        max_logits,
-        lse,
-        q.stride(1),
-        q.stride(0),
-        kv.stride(1),
-        kv.stride(0),
-        indices.stride(1),
-        indices.stride(0),
-        output.stride(1),
-        output.stride(0),
-        max_logits.stride(0),
-        lse.stride(0),
-        SQ,
-        HQ,
-        DQK,
-        SKV,
-        TOPK,
-        attn_sink is not None,
-        topk_length is not None,
-    )
-    return output, max_logits, lse
-
-
 def flash_mla_sparse_fwd(
     q: torch.Tensor,
     kv: torch.Tensor,
@@ -1254,32 +1119,99 @@ def flash_mla_sparse_fwd(
     assert DQK == 576 or DQK == 512, "Unsupported d_qk"
 
     _ = SKV
+    D = DV
+    TD = DQK - D
+    DP = triton.next_power_of_2(D)
+    HAVE_TAIL = TD > 0
+    TDP = triton.next_power_of_2(TD) if HAVE_TAIL else 1
+    G = HQ // HKV
+    BH = TLE_FLASHMLA_PREFILL_BH
+    RH = G // BH
+    BK = TLE_FLASHMLA_PREFILL_BK
     output = torch.empty((SQ, HQ, DV), device=q.device, dtype=q.dtype)
     max_logits = torch.empty((SQ, HQ), device=q.device, dtype=torch.float32)
     lse = torch.empty((SQ, HQ), device=q.device, dtype=torch.float32)
+
+    def triton_grid(META):
+        return (triton.cdiv(HQ, META["BH"]) * SQ,)
+
     if _can_use_tle_flash_mla_sparse_fwd(q, kv, indices, d_v, topk_length):
-        return _flash_mla_sparse_fwd_tle(
-            q,
+        from triton.tools.tensor_descriptor import TensorDescriptor
+
+        _set_triton_descriptor_allocator(q.device)
+        q_desc = TensorDescriptor(
+            q, shape=[SQ * HQ, DQK], strides=[DQK, 1], block_shape=[BH, DP // 2]
+        )
+        if HAVE_TAIL:
+            tq_desc = TensorDescriptor(
+                q, shape=[SQ * HQ, DQK], strides=[DQK, 1], block_shape=[BH, TDP]
+            )
+        else:
+            tq_desc = q_desc
+        output_desc = TensorDescriptor(
+            output, shape=[SQ * HQ, D], strides=[D, 1], block_shape=[BH, DP // 2]
+        )
+        _tle_flashmla_prefill_fwd[triton_grid](
+            q_desc,
+            tq_desc,
+            output_desc,
             kv,
             indices,
+            attn_sink,
+            topk_length,
             sm_scale,
             output,
             max_logits,
             lse,
-            d_v,
-            attn_sink,
-            topk_length,
+            SQ,
+            HQ,
+            DQK,
+            SKV,
+            TOPK,
+            attn_sink is not None,
+            topk_length is not None,
+            D,
+            TD,
+            DP,
+            TDP,
+            G,
+            HKV,
+            RH,
+            HAVE_TAIL,
+            BK,
+            BH,
+            TLE_FLASHMLA_PREFILL_PAIR_BLOCKS,
+            num_warps=TLE_FLASHMLA_PREFILL_WORKER_NUM_WARPS,
+            num_stages=1,
         )
+        return output, max_logits, lse
 
-    return _flash_mla_sparse_fwd_triton(
+    triton_flash_mla_sparse_fwd[triton_grid](
         q,
         kv,
         indices,
+        attn_sink,
+        topk_length,
         sm_scale,
         output,
         max_logits,
         lse,
-        d_v,
-        attn_sink,
-        topk_length,
+        q.stride(1),
+        q.stride(0),
+        kv.stride(1),
+        kv.stride(0),
+        indices.stride(1),
+        indices.stride(0),
+        output.stride(1),
+        output.stride(0),
+        max_logits.stride(0),
+        lse.stride(0),
+        SQ,
+        HQ,
+        DQK,
+        SKV,
+        TOPK,
+        attn_sink is not None,
+        topk_length is not None,
     )
+    return output, max_logits, lse


### PR DESCRIPTION
### Summary
1. Inline the Python launch helpers for `flash_mla_sparse_fwd`: remove `_flash_mla_sparse_fwd_triton` and `_flash_mla_sparse_fwd_tle`.
2. Launch both the Triton baseline and the TLE fast path directly from the public wrapper.
3. Use the same Triton-style grid function for both paths:
   ```python
   def triton_grid(META):
       return (triton.cdiv(HQ, META["BH"]) * SQ,)
   ```
4. Update the TLE kernel to decode the 1D grid pid internally instead of using `program_id(1)`.
5. Compute shared launch metadata such as `TD`, `DP`, `TDP`, `G`, `RH`, `BH`, and `BK` once in the wrapper.
6. Remove wrapper-side `q.reshape(...)`, `output.reshape(...)`, and `q_tail` construction. TLE `TensorDescriptor`s now use the original `q` and `output` tensors directly; the tail path reads from offset `D` in the original Q descriptor.
7. Keep the public API and output allocation behavior unchanged.

### Performance test
- GPU: NVIDIA H800
- Environment: `conda run -n flagtree`, `PYTHONPATH=/root/repos/flagtree/python:/root/repos/FlagGems-vllm/src`
- Workload settings: `h_kv=1`, `d_v=512`, `sm_scale=0.5`, `attn_sink` provided, `topk_length=None`
- Benchmark settings: warmup=10, iter=30, median latency
- Performance ratios use throughput semantics: `baseline_latency / candidate_latency`, so larger is better.

### Performance vs vLLM and Triton

| s_q | s_kv | h_q | d_qk | topk | vLLM latency(ms) | Triton latency(ms) | TLE latency(ms) | Triton perf/vLLM | TLE perf/vLLM | TLE perf/Triton |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4096 | 8192 | 128 | 576 | 2048 | 3.763712 | 6.791088 | 3.986080 | 0.554x | 0.944x | 1.704x |
| 4096 | 32768 | 128 | 576 | 2048 | 4.342752 | 7.487360 | 4.474480 | 0.580x | 0.971x | 1.673x |
| 4096 | 65536 | 128 | 576 | 2048 | 4.480416 | 8.052416 | 4.421120 | 0.556x | 1.013x | 1.821x |
| 4096 | 98304 | 128 | 576 | 2048 | 4.562896 | 7.841824 | 5.040992 | 0.582x | 0.905x | 1.556x |
| 4096 | 131072 | 128 | 576 | 2048 | 4.614560 | 7.965472 | 4.965856 | 0.579x | 0.929x | 1.604x |
| 4096 | 8192 | 64 | 512 | 512 | 0.585792 | 0.980272 | 0.749088 | 0.598x | 0.782x | 1.309x |
| 4096 | 32768 | 64 | 512 | 512 | 0.630816 | 1.113472 | 0.796352 | 0.567x | 0.792x | 1.398x |
| 4096 | 49152 | 64 | 512 | 512 | 0.691680 | 1.136720 | 0.805280 | 0.608x | 0.859x | 1.412x |
| 4096 | 65536 | 64 | 512 | 512 | 0.716256 | 1.116336 | 0.830448 | 0.642x | 0.862x | 1.344x |
| 4096 | 8192 | 128 | 512 | 1024 | 1.928768 | 3.236096 | 2.287968 | 0.596x | 0.843x | 1.414x |
| 4096 | 32768 | 128 | 512 | 1024 | 1.976000 | 3.672880 | 2.294448 | 0.538x | 0.861x | 1.601x |
| 4096 | 49152 | 128 | 512 | 1024 | 2.052784 | 3.828816 | 2.426624 | 0.536x | 0.846x | 1.578x |
| 4096 | 65536 | 128 | 512 | 1024 | 2.093568 | 3.804096 | 2.468128 | 0.550x | 0.848x | 1.541x |
| **Avg** | - | - | - | - | **2.495385** | **4.386681** | **2.734374** | **0.575x** | **0.879x** | **1.528x** |

### Accuracy notes
The benchmark compares all returned tensors against vLLM for every row above. Observed TLE-vs-vLLM differences were:
- output max absolute diff: up to `4.883e-04`
- max_logits max absolute diff: `0.000e+00`
- lse max absolute diff: up to `1.431e-06`

### Validation
```bash
git diff --check
PYTHONPATH=/root/repos/flagtree/python:/root/repos/FlagGems-vllm/src \
  conda run -n flagtree python -m py_compile src/flaggems_vllm/ops/flashmla_sparse.py
PYTHONPATH=/root/repos/flagtree/python:/root/repos/FlagGems-vllm/src \
  TRITON_CACHE_DIR=/tmp/flaggems-inline-3way CUDA_LAUNCH_BLOCKING=1 \
  conda run -n flagtree python build/bench_flashmla_sparse_3way.py --warmup 10 --iter 30
```
