### PR TITLE
Add FlashMLA-style TLE split-kv path

### DIFF
--- a/src/flaggems_vllm/ops/flash_mla.py
+++ b/src/flaggems_vllm/ops/flash_mla.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import os
 
 import torch
 import triton
@@ -8,10 +9,521 @@ import triton.language as tl
 from flaggems_vllm.runtime import device, error, torch_device_fn
 from flaggems_vllm.utils import triton_lang_extension as ext
 from flaggems_vllm.utils.device_info import get_device_capability
+from flaggems_vllm.utils.triton_version_utils import has_triton_tle
+
+if has_triton_tle(3, 6, 0):
+    try:
+        import triton.experimental.tle.language as tle
+
+        HAS_TLE_FLASH_MLA = True
+    except ImportError:
+        tle = None
+        HAS_TLE_FLASH_MLA = False
+else:
+    tle = None
+    HAS_TLE_FLASH_MLA = False
 
 vendor_name = device.vendor_name
 device = device.name
 logger = logging.getLogger(__name__)
+
+FLASH_MLA_META_FIELDS = 8
+FLASH_MLA_BLOCK_M = 64
+FLASH_MLA_BLOCK_N = 64
+FLASH_MLA_FIXED_OVERHEAD_BLOCKS = 5
+FLASH_MLA_COMBINE_BLOCK_H = 16
+
+
+def _flash_mla_tle_variant() -> str:
+    variant = os.environ.get("FLAGGEMS_VLLM_FLASH_MLA_TLE_VARIANT", "auto").lower()
+    legacy = os.environ.get("FLAGGEMS_VLLM_FLASH_MLA_TLE")
+    if legacy is not None and legacy.lower() in {"0", "false", "off", "no"}:
+        return "triton"
+    if variant not in {"auto", "triton"}:
+        logger.warning("Unknown FLAGGEMS_VLLM_FLASH_MLA_TLE_VARIANT=%s", variant)
+        return "auto"
+    return variant
+
+
+def _can_use_tle_flash_mla(
+    q: torch.Tensor,
+    block_table: torch.Tensor,
+    blocked_k: torch.Tensor,
+    block_size: int,
+    b: int,
+    s_q: int,
+    cache_seqlens: torch.Tensor,
+    h_q: int,
+    h_kv: int,
+    d: int,
+    dv: int,
+    causal: bool,
+) -> bool:
+    if _flash_mla_tle_variant() == "triton":
+        return False
+    if not HAS_TLE_FLASH_MLA:
+        return False
+    if q.device.type != "cuda":
+        return False
+    major, _ = get_device_capability()
+    if major != 9:
+        return False
+    return (
+        causal
+        and q.dtype in (torch.bfloat16, torch.float16)
+        and blocked_k.dtype == q.dtype
+        and block_table.dtype == torch.int32
+        and cache_seqlens.dtype == torch.int32
+        and q.ndim == 4
+        and blocked_k.ndim == 4
+        and block_table.ndim == 2
+        and cache_seqlens.ndim == 1
+        and b == q.shape[0]
+        and s_q == q.shape[1]
+        and s_q == 1
+        and h_q == q.shape[2]
+        and h_kv == 1
+        and d == q.shape[3]
+        and dv == 512
+        and d in (512, 576)
+        and d >= dv
+        and h_q % 64 == 0
+        and block_size == 64
+        and blocked_k.shape[1] == block_size
+        and blocked_k.shape[2] == h_kv
+        and blocked_k.shape[3] == d
+        and cache_seqlens.shape[0] == b
+    )
+
+
+@triton.jit
+def flash_mla_sched_meta_kernel(
+    B_seq_len,
+    Sched_meta,
+    Num_splits,
+    BLOCK_B: tl.constexpr,
+    BATCH_SIZE: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    FIXED_OVERHEAD_NUM_BLOCKS: tl.constexpr,
+    NUM_SM_PARTS: tl.constexpr,
+    META_FIELDS: tl.constexpr,
+):
+    offs_b = tl.arange(0, BLOCK_B)
+    mask_b = offs_b < BATCH_SIZE
+    seqlens = tl.load(B_seq_len + offs_b, mask=mask_b, other=0)
+    num_blocks_vec = tl.cdiv(tl.maximum(seqlens, 1), BLOCK_SIZE_N)
+    total_num_blocks = tl.sum(
+        tl.where(mask_b, num_blocks_vec + FIXED_OVERHEAD_NUM_BLOCKS, 0), axis=0
+    )
+    payload = tl.cdiv(total_num_blocks, NUM_SM_PARTS) + FIXED_OVERHEAD_NUM_BLOCKS
+
+    now_req_idx = 0
+    now_block = 0
+    now_n_split_idx = 0
+    cum_num_splits = 0
+    tl.store(Num_splits, 0)
+
+    for part in tl.static_range(0, NUM_SM_PARTS):
+        begin_req_idx = now_req_idx
+        begin_block_idx = now_block
+        begin_split_idx = now_n_split_idx
+        is_first_req_splitted = now_block != 0
+        remain_payload = payload
+
+        while (now_req_idx < BATCH_SIZE) & (remain_payload > 0):
+            cur_seq_len = tl.load(B_seq_len + now_req_idx)
+            cur_num_blocks = tl.cdiv(tl.maximum(cur_seq_len, 1), BLOCK_SIZE_N)
+            now_remain_blocks = cur_num_blocks - now_block
+            if remain_payload >= now_remain_blocks + FIXED_OVERHEAD_NUM_BLOCKS:
+                cum_num_splits += now_n_split_idx + 1
+                tl.store(Num_splits + now_req_idx + 1, cum_num_splits)
+                remain_payload -= now_remain_blocks + FIXED_OVERHEAD_NUM_BLOCKS
+                now_req_idx += 1
+                now_block = 0
+                now_n_split_idx = 0
+            else:
+                if remain_payload - FIXED_OVERHEAD_NUM_BLOCKS > 0:
+                    now_block += remain_payload - FIXED_OVERHEAD_NUM_BLOCKS
+                    now_n_split_idx += 1
+                remain_payload = 0
+
+        if now_block > 0:
+            end_req_idx = now_req_idx
+            end_block_idx = now_block
+        else:
+            end_req_idx = now_req_idx - 1
+            if end_req_idx >= 0:
+                end_seq_len = tl.load(B_seq_len + end_req_idx)
+                end_block_idx = tl.where(
+                    end_seq_len == 0, 0, tl.cdiv(end_seq_len, BLOCK_SIZE_N)
+                )
+            else:
+                end_block_idx = 0
+
+        meta = Sched_meta + part * META_FIELDS
+        if begin_req_idx >= BATCH_SIZE:
+            tl.store(meta + 0, BATCH_SIZE)
+            tl.store(meta + 1, BATCH_SIZE - 1)
+            tl.store(meta + 2, 0)
+            tl.store(meta + 3, 0)
+            tl.store(meta + 4, 0)
+            tl.store(meta + 5, 0)
+            tl.store(meta + 6, 0)
+            tl.store(meta + 7, 0)
+        else:
+            end_seq_len = tl.load(B_seq_len + end_req_idx)
+            last_block_exclusive = tl.where(
+                end_seq_len == 0, 0, tl.cdiv(end_seq_len, BLOCK_SIZE_N)
+            )
+            is_last_req_splitted = (end_block_idx != last_block_exclusive) & (
+                end_seq_len != 0
+            )
+            if begin_req_idx == end_req_idx:
+                same_req_split = is_first_req_splitted | is_last_req_splitted
+                is_first_req_splitted = same_req_split
+                is_last_req_splitted = same_req_split
+
+            tl.store(meta + 0, begin_req_idx)
+            tl.store(meta + 1, end_req_idx)
+            tl.store(meta + 2, begin_block_idx)
+            tl.store(meta + 3, end_block_idx)
+            tl.store(meta + 4, begin_split_idx)
+            tl.store(meta + 5, is_first_req_splitted.to(tl.int32))
+            tl.store(meta + 6, is_last_req_splitted.to(tl.int32))
+            tl.store(meta + 7, 0)
+
+
+@triton.jit
+def flash_mla_splitkv_tle_kernel(
+    Q_ptr,
+    Kv_cache,
+    Block_table,
+    B_seq_len,
+    Sched_meta,
+    Num_splits,
+    O,
+    O_accum,
+    LSE_accum,
+    sm_scale,
+    head_num,
+    stride_q_b,
+    stride_q_h,
+    stride_kv_token,
+    stride_block_table_b,
+    stride_o_b,
+    stride_o_h,
+    stride_oaccum_split,
+    stride_oaccum_h,
+    stride_lseaccum_split,
+    stride_lseaccum_h,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    HEAD_DIM_V: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    META_FIELDS: tl.constexpr,
+):
+    m_block_idx = tl.program_id(0)
+    partition_idx = tl.program_id(1)
+
+    meta_base = Sched_meta + partition_idx * META_FIELDS
+    begin_req_idx = tl.load(meta_base + 0)
+    end_req_idx = tl.load(meta_base + 1)
+    begin_block_idx_meta = tl.load(meta_base + 2)
+    end_block_idx_meta = tl.load(meta_base + 3)
+    begin_split_idx = tl.load(meta_base + 4)
+    is_first_req_splitted = tl.load(meta_base + 5) != 0
+    is_last_req_splitted = tl.load(meta_base + 6) != 0
+
+    offs_h = m_block_idx * BLOCK_M + tl.arange(0, BLOCK_M)
+    mask_h = offs_h < head_num
+    offs_dv = tl.arange(0, HEAD_DIM_V)
+    offs_dt = tl.arange(HEAD_DIM_V, HEAD_DIM)
+
+    for batch_idx in tl.range(begin_req_idx, end_req_idx + 1):
+        seq_len = tl.load(B_seq_len + batch_idx)
+        start_block_idx = tl.where(batch_idx == begin_req_idx, begin_block_idx_meta, 0)
+        full_end_block_idx = tl.cdiv(seq_len, BLOCK_N)
+        end_block_idx = tl.where(
+            batch_idx == end_req_idx, end_block_idx_meta, full_end_block_idx
+        )
+        n_split_idx = tl.where(batch_idx == begin_req_idx, begin_split_idx, 0)
+        no_split_middle = (batch_idx != begin_req_idx) & (batch_idx != end_req_idx)
+        no_split_first = (batch_idx == begin_req_idx) & (~is_first_req_splitted)
+        no_split_last = (batch_idx == end_req_idx) & (~is_last_req_splitted)
+        is_no_split = no_split_middle | no_split_first | no_split_last
+        if begin_req_idx == end_req_idx:
+            is_no_split = ~is_first_req_splitted
+
+        q_nope = tl.load(
+            Q_ptr
+            + batch_idx * stride_q_b
+            + offs_h[:, None] * stride_q_h
+            + offs_dv[None, :],
+            mask=mask_h[:, None],
+            other=0.0,
+        )
+        q_pe = tl.load(
+            Q_ptr
+            + batch_idx * stride_q_b
+            + offs_h[:, None] * stride_q_h
+            + offs_dt[None, :],
+            mask=mask_h[:, None],
+            other=0.0,
+        )
+
+        e_max = tl.full([BLOCK_M], value=float("-inf"), dtype=tl.float32)
+        e_sum = tl.zeros([BLOCK_M], dtype=tl.float32)
+        acc = tl.zeros([BLOCK_M, HEAD_DIM_V], dtype=tl.float32)
+        offs_n = tl.arange(0, BLOCK_N)
+        block_table_base = Block_table + batch_idx * stride_block_table_b
+
+        for block_idx in tl.range(start_block_idx, end_block_idx):
+            page_id = tle.load(block_table_base + block_idx)
+            token_idx = page_id * PAGE_SIZE + offs_n
+            token_pos = block_idx * BLOCK_N + offs_n
+            valid_n = token_pos < seq_len
+            v_c = tl.load(
+                Kv_cache + token_idx[:, None] * stride_kv_token + offs_dv[None, :],
+                mask=valid_n[:, None],
+                other=0.0,
+            )
+            qk = tl.dot(q_nope, tl.trans(v_c), out_dtype=tl.float32)
+            k_pe = tl.load(
+                Kv_cache + token_idx[None, :] * stride_kv_token + offs_dt[:, None],
+                mask=valid_n[None, :],
+                other=0.0,
+            )
+            qk = tl.dot(q_pe, k_pe, qk, out_dtype=tl.float32)
+            qk *= sm_scale
+            qk = tl.where(valid_n[None, :], qk, float("-inf"))
+
+            n_e_max = tl.maximum(tl.max(qk, axis=1), e_max)
+            re_scale = tl.exp(e_max - n_e_max)
+            p = tl.exp(qk - n_e_max[:, None])
+            acc *= re_scale[:, None]
+            acc = tl.dot(p.to(v_c.dtype), v_c, acc, out_dtype=tl.float32)
+            e_sum = e_sum * re_scale + tl.sum(p, axis=1)
+            e_max = n_e_max
+
+        valid = e_sum > 0.0
+        out_vals = tl.where(valid[:, None], acc * tl.fdiv(1.0, e_sum)[:, None], 0.0)
+        lse_vals = tl.where(valid, tl.log(e_sum) + e_max, float("-inf"))
+
+        if is_no_split:
+            tl.store(
+                O
+                + batch_idx * stride_o_b
+                + offs_h[:, None] * stride_o_h
+                + offs_dv[None, :],
+                out_vals.to(O.dtype.element_ty),
+                mask=mask_h[:, None],
+            )
+        else:
+            split_idx = tl.load(Num_splits + batch_idx) + n_split_idx
+            tl.store(
+                O_accum
+                + split_idx * stride_oaccum_split
+                + offs_h[:, None] * stride_oaccum_h
+                + offs_dv[None, :],
+                out_vals,
+                mask=mask_h[:, None],
+            )
+            tl.store(
+                LSE_accum
+                + split_idx * stride_lseaccum_split
+                + offs_h * stride_lseaccum_h,
+                lse_vals,
+                mask=mask_h,
+            )
+
+
+@triton.jit
+def flash_mla_combine_kernel(
+    O_accum,
+    LSE_accum,
+    Num_splits,
+    O,
+    head_num,
+    stride_oaccum_split,
+    stride_oaccum_h,
+    stride_lseaccum_split,
+    stride_lseaccum_h,
+    stride_o_b,
+    stride_o_h,
+    BLOCK_H: tl.constexpr,
+    HEAD_DIM_V: tl.constexpr,
+    MAX_SPLITS: tl.constexpr,
+):
+    batch_idx = tl.program_id(0)
+    h_block_idx = tl.program_id(1)
+    offs_h = h_block_idx * BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = offs_h < head_num
+    offs_d = tl.arange(0, HEAD_DIM_V)
+
+    start_split = tl.load(Num_splits + batch_idx)
+    end_split = tl.load(Num_splits + batch_idx + 1)
+    my_num_splits = end_split - start_split
+    if my_num_splits != 1:
+        max_lse = tl.full([BLOCK_H], value=float("-inf"), dtype=tl.float32)
+        for s in tl.static_range(0, MAX_SPLITS):
+            active = s < my_num_splits
+            lse_s = tl.load(
+                LSE_accum
+                + (start_split + s) * stride_lseaccum_split
+                + offs_h * stride_lseaccum_h,
+                mask=active & mask_h,
+                other=float("-inf"),
+            )
+            max_lse = tl.maximum(max_lse, lse_s)
+
+        acc = tl.zeros([BLOCK_H, HEAD_DIM_V], dtype=tl.float32)
+        sum_w = tl.zeros([BLOCK_H], dtype=tl.float32)
+        for s in tl.static_range(0, MAX_SPLITS):
+            active = s < my_num_splits
+            lse_s = tl.load(
+                LSE_accum
+                + (start_split + s) * stride_lseaccum_split
+                + offs_h * stride_lseaccum_h,
+                mask=active & mask_h,
+                other=float("-inf"),
+            )
+            w = tl.exp(lse_s - max_lse)
+            sum_w += tl.where(active, w, 0.0)
+            o_s = tl.load(
+                O_accum
+                + (start_split + s) * stride_oaccum_split
+                + offs_h[:, None] * stride_oaccum_h
+                + offs_d[None, :],
+                mask=active & mask_h[:, None],
+                other=0.0,
+            )
+            acc += w[:, None] * o_s
+
+        acc = acc * tl.fdiv(1.0, sum_w)[:, None]
+        tl.store(
+            O + batch_idx * stride_o_b + offs_h[:, None] * stride_o_h + offs_d[None, :],
+            acc.to(O.dtype.element_ty),
+            mask=mask_h[:, None],
+        )
+
+
+def _try_flash_mla_tle(
+    q: torch.Tensor,
+    block_table: torch.Tensor,
+    blocked_k: torch.Tensor,
+    block_size: int,
+    b: int,
+    s_q: int,
+    cache_seqlens: torch.Tensor,
+    h_q: int,
+    h_kv: int,
+    d: int,
+    dv: int,
+    causal: bool,
+) -> torch.Tensor | None:
+    if not _can_use_tle_flash_mla(
+        q,
+        block_table,
+        blocked_k,
+        block_size,
+        b,
+        s_q,
+        cache_seqlens,
+        h_q,
+        h_kv,
+        d,
+        dv,
+        causal,
+    ):
+        return None
+
+    q_tle = q.contiguous()
+    kv_flat = blocked_k.contiguous().view(-1, d)
+    block_table_tle = block_table.contiguous()
+    cache_seqlens_tle = cache_seqlens.contiguous()
+    num_m_blocks = triton.cdiv(s_q * h_q // h_kv, FLASH_MLA_BLOCK_M)
+    num_sms = torch.cuda.get_device_properties(q.device).multi_processor_count
+    num_sm_parts = max(num_sms // h_kv // num_m_blocks, 1)
+    sched_meta = torch.empty(
+        (num_sm_parts, FLASH_MLA_META_FIELDS),
+        dtype=torch.int32,
+        device=q.device,
+    )
+    num_splits = torch.empty(b + 1, dtype=torch.int32, device=q.device)
+    flash_mla_sched_meta_kernel[(1,)](
+        cache_seqlens_tle,
+        sched_meta,
+        num_splits,
+        BLOCK_B=triton.next_power_of_2(b),
+        BATCH_SIZE=b,
+        BLOCK_SIZE_N=FLASH_MLA_BLOCK_N,
+        FIXED_OVERHEAD_NUM_BLOCKS=FLASH_MLA_FIXED_OVERHEAD_BLOCKS,
+        NUM_SM_PARTS=num_sm_parts,
+        META_FIELDS=FLASH_MLA_META_FIELDS,
+        num_warps=1,
+        num_stages=1,
+    )
+    total_num_splits = b + num_sm_parts
+    out = torch.empty((b * s_q, h_q, dv), dtype=q.dtype, device=q.device)
+    out_accum = torch.empty(
+        (total_num_splits, h_q, dv), dtype=torch.float32, device=q.device
+    )
+    lse_accum = torch.empty(
+        (total_num_splits, h_q), dtype=torch.float32, device=q.device
+    )
+
+    flash_mla_splitkv_tle_kernel[(num_m_blocks, num_sm_parts)](
+        q_tle,
+        kv_flat,
+        block_table_tle,
+        cache_seqlens_tle,
+        sched_meta,
+        num_splits,
+        out,
+        out_accum,
+        lse_accum,
+        1 / math.sqrt(d),
+        h_q,
+        q_tle.stride(0),
+        q_tle.stride(2),
+        kv_flat.stride(0),
+        block_table_tle.stride(0),
+        out.stride(0),
+        out.stride(1),
+        out_accum.stride(0),
+        out_accum.stride(1),
+        lse_accum.stride(0),
+        lse_accum.stride(1),
+        BLOCK_M=FLASH_MLA_BLOCK_M,
+        BLOCK_N=FLASH_MLA_BLOCK_N,
+        PAGE_SIZE=block_size,
+        HEAD_DIM_V=dv,
+        HEAD_DIM=d,
+        META_FIELDS=FLASH_MLA_META_FIELDS,
+        num_warps=8,
+        num_stages=3,
+    )
+
+    flash_mla_combine_kernel[(b, triton.cdiv(h_q, FLASH_MLA_COMBINE_BLOCK_H))](
+        out_accum,
+        lse_accum,
+        num_splits,
+        out,
+        h_q,
+        out_accum.stride(0),
+        out_accum.stride(1),
+        lse_accum.stride(0),
+        lse_accum.stride(1),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_H=FLASH_MLA_COMBINE_BLOCK_H,
+        HEAD_DIM_V=dv,
+        MAX_SPLITS=num_sm_parts,
+        num_warps=FLASH_MLA_COMBINE_BLOCK_H,
+        num_stages=1,
+    )
+    return out.view([b, s_q, h_q, dv])
 
 
 # @triton.autotune(
@@ -173,6 +685,23 @@ def flash_mla(
     logger.debug("GEMS FLASH MLA")
     assert causal, "causal False not supported"
     assert d > dv, "mla with rope dim should be larger than no rope dim"
+
+    tle_out = _try_flash_mla_tle(
+        q,
+        block_table,
+        blocked_k,
+        block_size,
+        b,
+        s_q,
+        cache_seqlens,
+        h_q,
+        h_kv,
+        d,
+        dv,
+        causal,
+    )
+    if tle_out is not None:
+        return tle_out
 
     batch_size, s_q, head_num, d = list(q.shape)
     q = q.view([-1, head_num, d]).contiguous()


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator 
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Performance OptimizationPerformance Optimization
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
 A clean, unified FlashMLA-style TLE split-kv path using a sched-meta partition scheme.
 The core insight is that decode workloads have variable-length KV
  caches across requests. A naive grid launch would severely
  imbalance SM utilization. Instead, we use a lightweight
  pre-scheduling pass to compute balanced workload partitions,
  followed by a unified split-kv attention kernel.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
      batch    s_kv   s_q   h_q  d_qk    vLLM(ms)  Triton(ms)     TLE(ms)  Triton/vLLM     TLE/vLLM   TLE/Triton
     1    4096     1   128   576      0.0506      0.3636      0.0622       0.139x       0.813x       5.842x
     1    8192     1   128   576      0.0650      0.7188      0.0629       0.090x       1.034x      11.431x
     1   32768     1   128   576      0.1142      2.9278      0.1285       0.039x       0.889x      22.788x
     2    4096     1   128   576      0.0584      0.3820      0.0640       0.153x       0.912x       5.968x
     2    8192     1   128   576      0.0757      0.7032      0.0851       0.108x       0.890x       8.261x
     2   32768     1   128   576      0.1875      2.8445      0.2052       0.066x       0.913x      13.859x
     4    4096     1   128   576      0.0788      0.3716      0.0917       0.212x       0.859x       4.053x
     4    8192     1   128   576      0.1104      0.7259      0.1297       0.152x       0.851x       5.597x
     4   32768     1   128   576      0.3151      2.8505      0.3700       0.111x       0.852x       7.704x
     8    4096     1   128   576      0.1125      0.3886      0.1387       0.289x       0.811x       2.802x
     8    8192     1   128   576      0.1779      0.7553      0.2148       0.236x       0.828x       3.516x
     8   32768     1   128   576      0.5831      2.8671      0.6854       0.203x       0.851x       4.183x
    16    4096     1   128   576      0.1830      0.3864      0.2316       0.474x       0.790x       1.668x
    16    8192     1   128   576      0.3156      0.7561      0.3856       0.417x       0.818x       1.961x
    16   32768     1   128   576      1.1245      2.9561      1.3321       0.380x       0.844x       2.219x
    32    4096     1   128   576      0.3319      0.3894      0.4245       0.852x       0.782x       0.917x
    32    8192     1   128   576      0.5979      0.7547      0.7296       0.792x       0.819x       1.034x
    32   32768     1   128   576      2.2199      2.9659      2.6176       0.748x       0.848x       1.133x
    64    4096     1   128   576      0.6251      0.7667      0.7509       0.815x       0.832x       1.021x
    64    8192     1   128   576      1.1617      1.4782      1.3790       0.786x       0.842x       1.072x
    64   32768     1   128   576      4.3845      5.8206      5.1404       0.753x       0.853x       1.132x
    128    4096     1   128   576      1.2092      1.4477      1.4214       0.835x       0.851x       1.019x
    128    8192     1   128   576      2.2837      2.8022      2.6732       0.815x       0.854x       1.048x