### PR TITLE
Simplify code style CI checks

### DIFF
--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -8,32 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  pre-commit:
-    name: pre-commit checks
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-
-    steps:
-      - name: check out repository
-        uses: actions/checkout@v6
-
-      - name: set up python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-          cache: pip
-
-      - name: install pre-commit
-        shell: bash
-        run: python -m pip install pre-commit pre-commit-hooks==4.6.0 black==24.8.0 flake8==7.1.0 isort==5.12.0
-
-      - name: run pre-commit
-        shell: bash
-        run: pre-commit run --all-files --show-diff-on-failure
-
   code-style:
     name: code style
-    needs: pre-commit
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -49,19 +25,11 @@ jobs:
 
       - name: install style tools
         shell: bash
-        run: python -m pip install black==24.8.0 flake8==7.1.0 isort==5.12.0
+        run: python -m pip install pre-commit pre-commit-hooks==4.6.0 black==24.8.0 flake8==7.1.0 isort==5.12.0
 
-      - name: check black formatting
+      - name: run pre-commit
         shell: bash
-        run: black --check .
-
-      - name: check import order
-        shell: bash
-        run: isort --check-only --profile black .
-
-      - name: run flake8
-        shell: bash
-        run: flake8 .
+        run: pre-commit run --all-files --show-diff-on-failure
 
   select-targets:
     name: select ci targets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,3 @@ build-dir = "build/{cache_tag}"
 
 [tool.black]
 line-length = 88
-
-[tool.flake8]
-max-line-length = 120
-extend-ignore = ["F405", "E731", "W503", "E203", "E704"]


### PR DESCRIPTION
### PR Category
CI/CD

### Type of Change
Refactor

### Description
Simplify the code style CI workflow by merging the duplicated pre-commit and code-style checks into a single code-style job.

The updated job still installs the same style tools and runs `pre-commit run --all-files --show-diff-on-failure`, so the effective style checks remain covered by `.pre-commit-config.yaml`. This avoids running black, isort, and flake8 twice in CI.

Also remove the duplicated `[tool.flake8]` section from `pyproject.toml` because the current flake8 setup reads `.flake8` instead.

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
N/A. This is a CI workflow cleanup and does not affect runtime performance.