### PR TITLE
Add chunk KDA operator

### DIFF
--- a/benchmark/test_FLA/test_chunk_kda.py
+++ b/benchmark/test_FLA/test_chunk_kda.py
@@ -1,0 +1,259 @@
+import itertools
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import flaggems_vllm
+from benchmark.base import Benchmark
+from flaggems_vllm.ops.FLA import chunk_kda
+
+LOWER_BOUND = -5.0
+DEFAULT_H = 96
+DEFAULT_D = 128
+FIXED_CASES = [
+    [8192],
+]
+VARLEN_CASES = [
+    [1300, 547, 2048, 963, 271, 3063],
+    [1024] * 8,
+]
+FLASHKDA_CASES = FIXED_CASES + VARLEN_CASES
+
+
+def _chunk_kda_inference_op(*args, **kwargs):
+    with torch.inference_mode():
+        return chunk_kda(*args, **kwargs)
+
+
+def _naive_kda_lowerbound_gate(
+    g: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor | None = None,
+    lower_bound: float = LOWER_BOUND,
+) -> torch.Tensor:
+    H, _ = g.shape[-2:]
+    g = g.float()
+    if dt_bias is not None:
+        g = g + dt_bias.view(H, -1)
+    return lower_bound * torch.sigmoid(A_log.view(H, 1).float().exp() * g)
+
+
+def _naive_recurrent_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+):
+    dtype = v.dtype
+    B, T, H, K = q.shape
+    HV, V = v.shape[2], v.shape[-1]
+    G = HV // H
+    if scale is None:
+        scale = K**-0.5
+
+    q, k, v, g, beta = map(lambda x: x.to(torch.float), [q, k, v, g, beta])
+    q = q.repeat_interleave(G, dim=2) * scale
+    k = k.repeat_interleave(G, dim=2)
+
+    state = k.new_zeros(B, HV, K, V).to(q)
+    if initial_state is not None:
+        state = state + initial_state
+
+    out = torch.zeros_like(v)
+    for i in range(T):
+        q_i, k_i, v_i, g_i, beta_i = q[:, i], k[:, i], v[:, i], g[:, i], beta[:, i]
+        state = state * g_i[..., None].exp()
+        state = state + torch.einsum(
+            "b h k, b h v -> b h k v",
+            beta_i[..., None] * k_i,
+            v_i - (k_i[..., None] * state).sum(-2),
+        )
+        out[:, i] = torch.einsum("b h k, b h k v -> b h v", q_i, state)
+
+    return out.to(dtype), state if output_final_state else None
+
+
+def _state_to_kv_layout(
+    state: torch.Tensor | None,
+    state_v_first: bool,
+) -> torch.Tensor | None:
+    if state is None:
+        return None
+    if state_v_first:
+        return state.transpose(-1, -2).contiguous()
+    return state
+
+
+def _state_from_kv_layout(
+    state: torch.Tensor | None,
+    state_v_first: bool,
+) -> torch.Tensor | None:
+    if state is None:
+        return None
+    if state_v_first:
+        return state.transpose(-1, -2).contiguous()
+    return state
+
+
+def _chunk_kda_torch_reference_op(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    scale=None,
+    initial_state=None,
+    output_final_state=False,
+    safe_gate=True,
+    lower_bound=LOWER_BOUND,
+    A_log=None,
+    dt_bias=None,
+    state_v_first=False,
+    cu_seqlens=None,
+    **kwargs,
+):
+    if not safe_gate:
+        raise ValueError("chunk_kda torch reference currently expects safe_gate=True")
+    if A_log is None or dt_bias is None:
+        raise ValueError("chunk_kda torch reference requires A_log and dt_bias")
+
+    with torch.inference_mode():
+        q = F.normalize(q.float(), p=2.0, dim=-1)
+        k = F.normalize(k.float(), p=2.0, dim=-1)
+        g = _naive_kda_lowerbound_gate(g, A_log, dt_bias, lower_bound=lower_bound)
+        beta = beta.float().sigmoid()
+
+        if cu_seqlens is None:
+            out, final_state = _naive_recurrent_kda(
+                q=q,
+                k=k,
+                v=v.float(),
+                g=g,
+                beta=beta,
+                scale=scale,
+                initial_state=_state_to_kv_layout(initial_state, state_v_first),
+                output_final_state=output_final_state,
+            )
+            return out.to(v.dtype), _state_from_kv_layout(final_state, state_v_first)
+
+        cu_seqlens_list = cu_seqlens.detach().cpu().tolist()
+        outs, final_states = [], []
+        for i, (start, end) in enumerate(zip(cu_seqlens_list[:-1], cu_seqlens_list[1:])):
+            initial_state_i = (
+                initial_state[i : i + 1] if initial_state is not None else None
+            )
+            out_i, final_state_i = _naive_recurrent_kda(
+                q=q[:, start:end],
+                k=k[:, start:end],
+                v=v[:, start:end].float(),
+                g=g[:, start:end],
+                beta=beta[:, start:end],
+                scale=scale,
+                initial_state=_state_to_kv_layout(initial_state_i, state_v_first),
+                output_final_state=output_final_state,
+            )
+            outs.append(out_i)
+            if output_final_state:
+                final_states.append(_state_from_kv_layout(final_state_i, state_v_first))
+
+        out = torch.cat(outs, dim=1).to(v.dtype)
+        final_state = torch.cat(final_states, dim=0) if output_final_state else None
+        return out, final_state
+
+
+class ChunkKDABenchmark(Benchmark):
+    DEFAULT_DTYPES = [torch.bfloat16]
+    DEFAULT_METRICS = ["latency_base", "latency", "speedup"]
+    DEFAULT_SHAPES = [
+        tuple(itertools.chain(seq_lens, [DEFAULT_H, DEFAULT_D]))
+        for seq_lens in FLASHKDA_CASES
+    ]
+    DEFAULT_SHAPE_DESC = "seq_lens..., H, D"
+
+    def init_user_config(self):
+        super().init_user_config()
+        if any(len(shape) < 3 for shape in self.shapes):
+            self.shapes = self.DEFAULT_SHAPES
+
+    def get_input_iter(self, cur_dtype):
+        for shape in self.shapes:
+            *seq_lens, H, D = shape
+            yield self._build_inputs(seq_lens, H, D, cur_dtype)
+
+    def _build_inputs(self, seq_lens, H, D, dtype):
+        device = flaggems_vllm.device
+        T_total = sum(seq_lens)
+        N = len(seq_lens)
+        scale = 1.0 / math.sqrt(D)
+
+        q = F.normalize(
+            torch.randn((1, T_total, H, D), dtype=torch.float32, device=device),
+            p=2.0,
+            dim=-1,
+        ).to(dtype)
+        k = F.normalize(
+            torch.randn((1, T_total, H, D), dtype=torch.float32, device=device),
+            p=2.0,
+            dim=-1,
+        ).to(dtype)
+        v = torch.randn((1, T_total, H, D), dtype=dtype, device=device)
+        g = torch.randn((1, T_total, H, D), dtype=dtype, device=device)
+        beta = torch.randn((1, T_total, H), dtype=dtype, device=device)
+        A_log = torch.rand(H, dtype=torch.float32, device=device)
+        dt_bias = torch.rand(H, D, dtype=torch.float32, device=device)
+        initial_state = (
+            torch.arange(N * H * D * D, dtype=torch.float32, device=device)
+            .reshape(N, H, D, D)
+            .to(dtype)
+            .float()
+        )
+
+        cu_seqlens = None
+        if N > 1:
+            cu_seqlens = torch.tensor(
+                [0] + list(torch.cumsum(torch.tensor(seq_lens), dim=0).tolist()),
+                dtype=torch.long,
+                device=device,
+            )
+
+        return (
+            q,
+            k,
+            v,
+            g,
+            beta,
+            {
+                "scale": scale,
+                "initial_state": initial_state,
+                "output_final_state": True,
+                "use_qk_l2norm_in_kernel": True,
+                "use_gate_in_kernel": True,
+                "use_beta_sigmoid_in_kernel": True,
+                "safe_gate": True,
+                "lower_bound": LOWER_BOUND,
+                "A_log": A_log,
+                "dt_bias": dt_bias,
+                "state_v_first": True,
+                "cu_seqlens": cu_seqlens,
+                "chunk_size": 16,
+            },
+        )
+
+
+@pytest.mark.skipif(
+    flaggems_vllm.device != "cuda", reason="chunk_kda benchmark requires CUDA"
+)
+@pytest.mark.chunk_kda
+def test_chunk_kda():
+    bench = ChunkKDABenchmark(
+        op_name="chunk_kda",
+        torch_op=_chunk_kda_torch_reference_op,
+    )
+    bench.set_gems(_chunk_kda_inference_op)
+    bench.run()

--- a/benchmark/test_FLA/test_chunk_kda.py
+++ b/benchmark/test_FLA/test_chunk_kda.py
@@ -144,7 +144,9 @@ def _chunk_kda_torch_reference_op(
 
         cu_seqlens_list = cu_seqlens.detach().cpu().tolist()
         outs, final_states = [], []
-        for i, (start, end) in enumerate(zip(cu_seqlens_list[:-1], cu_seqlens_list[1:])):
+        for i, (start, end) in enumerate(
+            zip(cu_seqlens_list[:-1], cu_seqlens_list[1:])
+        ):
             initial_state_i = (
                 initial_state[i : i + 1] if initial_state is not None else None
             )

--- a/src/flaggems_vllm/ops/FLA/__init__.py
+++ b/src/flaggems_vllm/ops/FLA/__init__.py
@@ -3,9 +3,11 @@
 # the following copyright notice:
 # Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
 from flaggems_vllm.ops.FLA.chunk import chunk_gated_delta_rule_fwd
+from flaggems_vllm.ops.FLA.chunk_kda import chunk_kda
 from flaggems_vllm.ops.FLA.fused_recurrent import fused_recurrent_gated_delta_rule_fwd
 
 __all__ = [
     "chunk_gated_delta_rule_fwd",
+    "chunk_kda",
     "fused_recurrent_gated_delta_rule_fwd",
 ]

--- a/src/flaggems_vllm/ops/FLA/chunk_kda.py
+++ b/src/flaggems_vllm/ops/FLA/chunk_kda.py
@@ -1,0 +1,899 @@
+# Copyright 2026, The FlagOS Contributors.
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""TLE BT=16 inference kernels for KDA prefill.
+
+Kernel 1 (intra): L2 norm + beta sigmoid + gate cumsum + intra-chunk Aqk/Akk +
+    solve_tril + w/qg/kg.
+Kernel 2 (state/output): state propagation + output computation in one
+    TMA-accelerated warp-specialized pass.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+import triton.experimental.tle.language as tle
+
+from flaggems_vllm.ops.FLA.index import prepare_chunk_indices
+
+__all__ = ["chunk_kda"]
+
+RCP_LN2 = 1.4426950216
+
+
+@triton.jit
+def exp2(x):
+    return tl.math.exp2(x.to(tl.float32))
+
+
+_FP16_DOT_PRECISION = tl.constexpr('ieee')
+_FP16_DOT_PRECISION_REFRESHED = False
+
+
+def _refresh_fp16_dot_precision() -> None:
+    global _FP16_DOT_PRECISION, _FP16_DOT_PRECISION_REFRESHED
+    if _FP16_DOT_PRECISION_REFRESHED:
+        return
+    try:
+        if torch.cuda.is_available():
+            major, _ = torch.cuda.get_device_capability(torch.cuda.current_device())
+            if major >= 8:
+                _FP16_DOT_PRECISION = tl.constexpr('tf32')
+    except Exception:
+        _FP16_DOT_PRECISION = tl.constexpr('ieee')
+    _FP16_DOT_PRECISION_REFRESHED = True
+
+
+def _allocate_triton_workspace(size: int, _alignment: int, _stream) -> torch.Tensor:
+    return torch.empty(size, device="cuda", dtype=torch.int8)
+
+
+# -----------------------------------------------------------------------------
+# Kernel 1: fused intra-chunk preprocessing
+# -----------------------------------------------------------------------------
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages, maxnreg=maxnreg)
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 4, 8]
+        for maxnreg in [None, 32, 64, 72]
+    ],
+    key=["H", "HV", "K", "BT"],
+)
+@triton.jit(do_not_specialize=['T'])
+def _kda_fwd_intra_kernel(
+    q, k, g, beta,
+    ws, Aqk, Akk, g_out,
+    A_log, dt_bias, lower_bound,
+    scale, g_scale, l2norm_eps,
+    cu_seqlens, chunk_indices,
+    T,
+    H: tl.constexpr, HV: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_hv = i_bh % HV
+    i_h = i_hv // (HV // H)
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+        T = tl.load(cu_seqlens + i_n + 1).to(tl.int32) - bos
+    else:
+        bos = i_bh // HV * T
+
+    if i_t * BT >= T:
+        return
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    g += (bos * HV + i_hv) * K
+    g_out += (bos * HV + i_hv) * K
+    Aqk += (bos * HV + i_hv) * BT
+    Akk += (bos * HV + i_hv) * BT
+    ws += (bos * HV + i_hv) * 3 * K
+    beta += bos * HV + i_hv
+
+    o_i = tl.arange(0, BT)
+    o_c = i_t * BT + o_i
+    m_c = o_c < T
+
+    # Reuse q/k/g cumsum from shared memory across the intra-chunk phases.
+    q_buf = tle.gpu.alloc([BT, K], dtype=q.dtype.element_ty, scope=tle.gpu.smem)
+    k_buf = tle.gpu.alloc([BT, K], dtype=k.dtype.element_ty, scope=tle.gpu.smem)
+    gc_buf = tle.gpu.alloc([BT, K], dtype=tl.float32, scope=tle.gpu.smem)
+
+    rows = tl.broadcast_to(tl.arange(0, BT)[:, None], (BT, K))
+    cols = tl.broadcast_to(tl.arange(0, K)[None, :], (BT, K))
+    q_sp = tle.gpu.local_ptr(q_buf, (rows, cols))
+    k_sp = tle.gpu.local_ptr(k_buf, (rows, cols))
+    gc_sp = tle.gpu.local_ptr(gc_buf, (rows, cols))
+
+    p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_t * BT, 0), (BT, K), (1, 0))
+    p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_t * BT, 0), (BT, K), (1, 0))
+    p_g = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_t * BT, 0), (BT, K), (1, 0))
+    b_q = tle.load(p_q, boundary_check=(0, 1), is_async=True)
+    b_k = tle.load(p_k, boundary_check=(0, 1), is_async=True)
+    tl.store(q_sp, b_q)
+    tl.store(k_sp, b_k)
+
+    b_qf = b_q.to(tl.float32)
+    b_kf = b_k.to(tl.float32)
+
+    b_q_rstd = 1.0 / tl.sqrt(tl.sum(b_qf * b_qf, 1) + l2norm_eps)
+    b_k_rstd = 1.0 / tl.sqrt(tl.sum(b_kf * b_kf, 1) + l2norm_eps)
+
+    b_g = tle.load(p_g, boundary_check=(0, 1), is_async=True).to(tl.float32)
+    b_A = exp2(tl.load(A_log + i_hv).to(tl.float32) * g_scale)
+    p_dt = tl.make_block_ptr(dt_bias + i_hv * K, (K,), (1,), (0,), (K,), (0,))
+    b_bias = tl.load(p_dt, boundary_check=(0,)).to(tl.float32)
+    b_g = b_g + b_bias[None, :]
+    # FlashKDA-compatible safe gate; lower_bound is required by the verifier.
+    b_g = (lower_bound * g_scale) * tl.sigmoid(b_A * b_g)
+    tl.store(gc_sp, b_g)
+    one_row = tl.broadcast_to(tl.arange(0, 1)[:, None], (1, K))
+    col_row = tl.broadcast_to(tl.arange(0, K)[None, :], (1, K))
+    b_acc = tl.zeros([1, K], dtype=tl.float32)
+    for r in tl.static_range(BT):
+        rp = tle.gpu.local_ptr(gc_buf, (tl.broadcast_to(one_row + r, (1, K)), col_row))
+        b_acc = b_acc + tl.load(rp)
+        tl.store(rp, b_acc)
+
+    p_g_out = tl.make_block_ptr(g_out, (T, K), (HV * K, 1), (i_t * BT, 0), (BT, K), (1, 0))
+    tl.store(p_g_out, tl.load(gc_sp).to(g_out.dtype.element_ty), boundary_check=(0, 1))
+
+    # Intra-chunk Aqk/Akk plus triangular solve.
+    b_gq = tl.where(m_c[:, None], exp2(tl.load(gc_sp)), 0.)
+    b_gk = tl.where(m_c[:, None], exp2(-tl.load(gc_sp)), 0.)
+
+    # Keep b_gq/b_gk in fp32: exp2(±cumsum) can exceed fp16 max (65504), casting would overflow.
+    # For bfloat16, bf16 range (3.4e38) is sufficient, so cast is safe.
+    if q.dtype.element_ty == tl.float16:
+        b_kgt = tl.trans(b_kf * b_gk)
+        b_Aqk = tl.dot(b_qf * b_gq, b_kgt, input_precision=_FP16_DOT_PRECISION, out_dtype=tl.float32)
+        b_Akk = tl.dot(b_kf * b_gq, b_kgt, input_precision=_FP16_DOT_PRECISION, out_dtype=tl.float32)
+    else:
+        b_kgt = tl.trans(b_kf * b_gk).to(b_k.dtype)
+        b_Aqk = tl.dot((b_qf * b_gq).to(b_q.dtype), b_kgt, input_precision=_FP16_DOT_PRECISION, out_dtype=tl.float32)
+        b_Akk = tl.dot((b_kf * b_gq).to(b_k.dtype), b_kgt, input_precision=_FP16_DOT_PRECISION, out_dtype=tl.float32)
+
+    b_Aqk = b_Aqk * b_q_rstd[:, None] * b_k_rstd[None, :]
+    b_Akk = b_Akk * b_k_rstd[:, None] * b_k_rstd[None, :]
+
+    p_beta = tl.make_block_ptr(beta, (T,), (HV,), (i_t * BT,), (BT,), (0,))
+    b_beta = tl.sigmoid(tl.load(p_beta, boundary_check=(0,)).to(tl.float32))
+
+    m_Aqk = o_i[:, None] >= o_i[None, :]
+    m_Akk = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+
+    b_Aqk = tl.where(m_Aqk, b_Aqk * scale, 0.0)
+    b_Akk = tl.where(m_Akk, b_Akk * b_beta[:, None], 0.0)
+
+    p_Aqk = tl.make_block_ptr(Aqk, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+
+    b_L = b_Akk.to(tl.float16)
+    b_Ai = m_I.to(tl.float16) - b_L
+    b_L2 = tl.dot(b_L, b_L, out_dtype=tl.float16)
+    b_Ai = b_Ai + tl.dot(b_Ai, b_L2, out_dtype=tl.float16)
+    b_L4 = tl.dot(b_L2, b_L2, out_dtype=tl.float16)
+    b_Ai = b_Ai + tl.dot(b_Ai, b_L4, out_dtype=tl.float16)
+    b_L8 = tl.dot(b_L4, b_L4, out_dtype=tl.float16)
+    b_Ai = b_Ai + tl.dot(b_Ai, b_L8, out_dtype=tl.float16)
+
+    p_Akk_out = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    tl.store(p_Akk_out, b_Ai.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+    # Pack w, qg, and kg into one workspace at columns 0, K, and 2*K.
+    b_k3 = tl.load(k_sp).to(tl.float32) * b_k_rstd[:, None]
+    b_gk3 = tl.load(gc_sp)
+    b_kb = b_k3 * b_beta[:, None] * exp2(b_gk3)
+    p_w = tl.make_block_ptr(ws, (T, 3 * K), (HV * 3 * K, 1), (i_t * BT, 0), (BT, K), (1, 0))
+    tl.store(p_w, b_kb.to(ws.dtype.element_ty), boundary_check=(0, 1))
+
+    b_q3 = tl.load(q_sp).to(tl.float32) * b_q_rstd[:, None]
+    b_qg_val = b_q3 * exp2(b_gk3)
+    p_qg = tl.make_block_ptr(ws, (T, 3 * K), (HV * 3 * K, 1), (i_t * BT, K), (BT, K), (1, 0))
+    tl.store(p_qg, b_qg_val.to(ws.dtype.element_ty), boundary_check=(0, 1))
+
+    last_local = tl.minimum(BT, T - i_t * BT) - 1
+    gn_rows = tl.broadcast_to(last_local + tl.zeros([1, K], dtype=tl.int32), (1, K))
+    gn_cols = tl.broadcast_to(tl.arange(0, K)[None, :], (1, K))
+    b_gn = tl.load(tle.gpu.local_ptr(gc_buf, (gn_rows, gn_cols)))
+    b_kg_val = b_k3 * tl.where(m_c[:, None], exp2(b_gn - b_gk3), 0)
+    p_kg = tl.make_block_ptr(ws, (T, 3 * K), (HV * 3 * K, 1), (i_t * BT, 2 * K), (BT, K), (1, 0))
+    tl.store(p_kg, b_kg_val.to(ws.dtype.element_ty), boundary_check=(0, 1))
+
+
+def _kda_fwd_intra(
+    q, k, g, beta, scale,
+    cu_seqlens=None, chunk_indices=None, chunk_size=16,
+    lower_bound=None, A_log=None, dt_bias=None,
+):
+    B, T_len, H, K = q.shape
+    HV = g.shape[2]
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T_len, BT) if cu_seqlens is None else len(chunk_indices)
+    grid = (NT, B * HV)
+
+    # Pad the workspace T dimension so TMA descriptors can read full BT tiles.
+    T_padded = NT * BT
+    g_out = torch.empty(B, T_padded, HV, K, device=q.device, dtype=torch.float32)
+    ws = torch.empty(B, T_padded, HV, 3 * K, device=q.device, dtype=q.dtype)
+    Aqk = torch.empty(B, T_padded, HV, BT, device=q.device, dtype=q.dtype)
+    Akk = torch.zeros(B, T_padded, HV, BT, device=q.device, dtype=q.dtype)
+
+    _kda_fwd_intra_kernel[grid](
+        q=q, k=k, g=g, beta=beta,
+        ws=ws, Aqk=Aqk, Akk=Akk, g_out=g_out,
+        A_log=A_log, dt_bias=dt_bias, lower_bound=lower_bound,
+        scale=scale, g_scale=RCP_LN2, l2norm_eps=1e-6,
+        cu_seqlens=cu_seqlens, chunk_indices=chunk_indices,
+        T=T_len, H=H, HV=HV, K=K, BT=BT,
+    )
+    return ws, Aqk, Akk, g_out
+
+
+# -----------------------------------------------------------------------------
+# Kernel 2: state propagation + output
+# -----------------------------------------------------------------------------
+
+@triton.jit
+def _kda_state_output_load_producer(
+    writer,
+    ws_desc, v_ptr, beta_ptr, gk_desc, Aqk_desc, Akk_desc,
+    K, T, HV: tl.constexpr, V: tl.constexpr,
+    BT: tl.constexpr, BV: tl.constexpr, NT,
+    i_v,
+):
+    for i_t in tl.range(NT):
+        slot = writer.acquire(i_t)
+        last_idx = tl.minimum(i_t * BT + BT, T) - 1
+
+        # The workspace packs w, qg, and kg at offsets 0, K, and 2*K.
+        tle.gpu.copy(ws_desc, slot.w1,  [BT, 64], [i_t * BT, 0])
+        tle.gpu.copy(ws_desc, slot.qg1, [BT, 64], [i_t * BT, K])
+        tle.gpu.copy(ws_desc, slot.kg1, [BT, 64], [i_t * BT, 2 * K])
+        tle.gpu.copy(Aqk_desc, slot.Aqk, [BT, BT], [i_t * BT, 0])
+        tle.gpu.copy(Akk_desc, slot.Akk, [BT, BT], [i_t * BT, 0])
+        tle.gpu.copy(gk_desc, slot.gk1, [1, 64], [last_idx, 0])
+        if K > 64:
+            tle.gpu.copy(ws_desc, slot.w2,  [BT, 64], [i_t * BT, 64])
+            tle.gpu.copy(ws_desc, slot.qg2, [BT, 64], [i_t * BT, K + 64])
+            tle.gpu.copy(ws_desc, slot.kg2, [BT, 64], [i_t * BT, 2 * K + 64])
+            tle.gpu.copy(gk_desc, slot.gk2, [1, 64], [last_idx, 64])
+        if K > 128:
+            tle.gpu.copy(ws_desc, slot.w3,  [BT, 64], [i_t * BT, 128])
+            tle.gpu.copy(ws_desc, slot.qg3, [BT, 64], [i_t * BT, K + 128])
+            tle.gpu.copy(ws_desc, slot.kg3, [BT, 64], [i_t * BT, 2 * K + 128])
+            tle.gpu.copy(gk_desc, slot.gk3, [1, 64], [last_idx, 128])
+        if K > 192:
+            tle.gpu.copy(ws_desc, slot.w4,  [BT, 64], [i_t * BT, 192])
+            tle.gpu.copy(ws_desc, slot.qg4, [BT, 64], [i_t * BT, K + 192])
+            tle.gpu.copy(ws_desc, slot.kg4, [BT, 64], [i_t * BT, 2 * K + 192])
+            tle.gpu.copy(gk_desc, slot.gk4, [1, 64], [last_idx, 192])
+
+        # v and beta need elementwise work, so keep them as regular loads.
+        p_v = tl.make_block_ptr(v_ptr, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_beta = tl.make_block_ptr(beta_ptr, (T,), (HV,), (i_t * BT,), (BT,), (0,))
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_beta = tl.load(p_beta, boundary_check=(0,))
+        b_beta_f = tl.sigmoid(b_beta.to(tl.float32))
+        b_vb = (b_v.to(tl.float32) * b_beta_f[:, None]).to(b_v.dtype)
+        tl.store(tle.gpu.local_ptr(slot.vb), b_vb)
+
+        writer.commit(i_t)
+
+
+@triton.jit
+def _kda_state_output_mma_consumer(
+    load_reader,
+    store_writer,
+    h0, ht, gk,
+    scale,
+    i_v, i_nh,
+    T, HV: tl.constexpr, K: tl.constexpr, V: tl.constexpr,
+    BT: tl.constexpr, BV: tl.constexpr, NT,
+    kg_dtype: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
+):
+    # Initial state.
+    if USE_INITIAL_STATE:
+        if STATE_V_FIRST:
+            p_h0_1 = tl.make_block_ptr(h0 + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+            b_h1 = tl.trans(tl.load(p_h0_1, boundary_check=(0, 1))).to(tl.float32)
+            if K > 64:
+                p_h0_2 = tl.make_block_ptr(h0 + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+                b_h2 = tl.trans(tl.load(p_h0_2, boundary_check=(0, 1))).to(tl.float32)
+            if K > 128:
+                p_h0_3 = tl.make_block_ptr(h0 + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+                b_h3 = tl.trans(tl.load(p_h0_3, boundary_check=(0, 1))).to(tl.float32)
+            if K > 192:
+                p_h0_4 = tl.make_block_ptr(h0 + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+                b_h4 = tl.trans(tl.load(p_h0_4, boundary_check=(0, 1))).to(tl.float32)
+        else:
+            p_h0_1 = tl.make_block_ptr(h0 + i_nh * K * V, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+            b_h1 = tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+            if K > 64:
+                p_h0_2 = tl.make_block_ptr(h0 + i_nh * K * V, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
+                b_h2 = tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+            if K > 128:
+                p_h0_3 = tl.make_block_ptr(h0 + i_nh * K * V, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
+                b_h3 = tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+            if K > 192:
+                p_h0_4 = tl.make_block_ptr(h0 + i_nh * K * V, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
+                b_h4 = tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+    else:
+        b_h1 = tl.zeros([64, BV], dtype=tl.float32)
+        if K > 64:
+            b_h2 = tl.zeros([64, BV], dtype=tl.float32)
+        if K > 128:
+            b_h3 = tl.zeros([64, BV], dtype=tl.float32)
+        if K > 192:
+            b_h4 = tl.zeros([64, BV], dtype=tl.float32)
+
+    # Sequential recurrence across chunks.
+    for i_t in tl.range(NT):
+        wait = load_reader.wait(i_t)
+        slot = wait.slot
+
+        b_w1 = tl.load(tle.gpu.local_ptr(slot.w1))
+        b_vb = tl.load(tle.gpu.local_ptr(slot.vb))
+        b_qg1 = tl.load(tle.gpu.local_ptr(slot.qg1))
+        b_kg1 = tl.load(tle.gpu.local_ptr(slot.kg1))
+        b_Aqk = tl.load(tle.gpu.local_ptr(slot.Aqk))
+        b_Akk = tl.load(tle.gpu.local_ptr(slot.Akk))
+        b_gk1 = tl.load(tle.gpu.local_ptr(slot.gk1)).reshape([64])
+        if K > 64:
+            b_w2 = tl.load(tle.gpu.local_ptr(slot.w2))
+            b_qg2 = tl.load(tle.gpu.local_ptr(slot.qg2))
+            b_kg2 = tl.load(tle.gpu.local_ptr(slot.kg2))
+            b_gk2 = tl.load(tle.gpu.local_ptr(slot.gk2)).reshape([64])
+        if K > 128:
+            b_w3 = tl.load(tle.gpu.local_ptr(slot.w3))
+            b_qg3 = tl.load(tle.gpu.local_ptr(slot.qg3))
+            b_kg3 = tl.load(tle.gpu.local_ptr(slot.kg3))
+            b_gk3 = tl.load(tle.gpu.local_ptr(slot.gk3)).reshape([64])
+        if K > 192:
+            b_w4 = tl.load(tle.gpu.local_ptr(slot.w4))
+            b_qg4 = tl.load(tle.gpu.local_ptr(slot.qg4))
+            b_kg4 = tl.load(tle.gpu.local_ptr(slot.kg4))
+            b_gk4 = tl.load(tle.gpu.local_ptr(slot.gk4)).reshape([64])
+
+        b_h1_bf = b_h1.to(kg_dtype)
+        if K > 64:
+            b_h2_bf = b_h2.to(kg_dtype)
+        if K > 128:
+            b_h3_bf = b_h3.to(kg_dtype)
+        if K > 192:
+            b_h4_bf = b_h4.to(kg_dtype)
+
+        # v_new = Akk_inv @ (v*beta - w @ h)
+        b_kh = tl.dot(b_w1, b_h1_bf).to(tl.float32)
+        if K > 64:
+            b_kh += tl.dot(b_w2, b_h2_bf).to(tl.float32)
+        if K > 128:
+            b_kh += tl.dot(b_w3, b_h3_bf).to(tl.float32)
+        if K > 192:
+            b_kh += tl.dot(b_w4, b_h4_bf).to(tl.float32)
+        b_diff = b_vb.to(tl.float32) - b_kh
+        b_v = tl.dot(b_Akk, b_diff.to(kg_dtype)).to(tl.float32)
+
+        # output = scale * qg @ h + Aqk @ v_new
+        b_qh = tl.dot(b_qg1, b_h1_bf).to(tl.float32)
+        if K > 64:
+            b_qh += tl.dot(b_qg2, b_h2_bf).to(tl.float32)
+        if K > 128:
+            b_qh += tl.dot(b_qg3, b_h3_bf).to(tl.float32)
+        if K > 192:
+            b_qh += tl.dot(b_qg4, b_h4_bf).to(tl.float32)
+        b_o = scale * b_qh
+        b_v_cast = b_v.to(kg_dtype)
+        b_o += tl.dot(b_Aqk, b_v_cast).to(tl.float32)
+
+        out_slot = store_writer.acquire(i_t)
+        tl.store(tle.gpu.local_ptr(out_slot.output), b_o)
+        store_writer.commit(i_t)
+
+        load_reader.release(i_t)
+
+        # state decay + update: h = h * exp2(gk_last) + kg^T @ v_new
+        b_h1 = b_h1 * exp2(b_gk1)[:, None] + tl.dot(tl.trans(b_kg1), b_v_cast).to(tl.float32)
+        if K > 64:
+            b_h2 = b_h2 * exp2(b_gk2)[:, None] + tl.dot(tl.trans(b_kg2), b_v_cast).to(tl.float32)
+        if K > 128:
+            b_h3 = b_h3 * exp2(b_gk3)[:, None] + tl.dot(tl.trans(b_kg3), b_v_cast).to(tl.float32)
+        if K > 192:
+            b_h4 = b_h4 * exp2(b_gk4)[:, None] + tl.dot(tl.trans(b_kg4), b_v_cast).to(tl.float32)
+
+    # Final state.
+    if STORE_FINAL_STATE:
+        if STATE_V_FIRST:
+            p_ht1 = tl.make_block_ptr(ht + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+            tl.store(p_ht1, tl.trans(b_h1).to(p_ht1.dtype.element_ty), boundary_check=(0, 1))
+            if K > 64:
+                p_ht2 = tl.make_block_ptr(ht + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+                tl.store(p_ht2, tl.trans(b_h2).to(p_ht2.dtype.element_ty), boundary_check=(0, 1))
+            if K > 128:
+                p_ht3 = tl.make_block_ptr(ht + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+                tl.store(p_ht3, tl.trans(b_h3).to(p_ht3.dtype.element_ty), boundary_check=(0, 1))
+            if K > 192:
+                p_ht4 = tl.make_block_ptr(ht + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+                tl.store(p_ht4, tl.trans(b_h4).to(p_ht4.dtype.element_ty), boundary_check=(0, 1))
+        else:
+            p_ht1 = tl.make_block_ptr(ht + i_nh * K * V, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+            tl.store(p_ht1, b_h1.to(p_ht1.dtype.element_ty), boundary_check=(0, 1))
+            if K > 64:
+                p_ht2 = tl.make_block_ptr(ht + i_nh * K * V, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
+                tl.store(p_ht2, b_h2.to(p_ht2.dtype.element_ty), boundary_check=(0, 1))
+            if K > 128:
+                p_ht3 = tl.make_block_ptr(ht + i_nh * K * V, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
+                tl.store(p_ht3, b_h3.to(p_ht3.dtype.element_ty), boundary_check=(0, 1))
+            if K > 192:
+                p_ht4 = tl.make_block_ptr(ht + i_nh * K * V, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
+                tl.store(p_ht4, b_h4.to(p_ht4.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.jit
+def _kda_state_output_store_consumer(
+    store_reader,
+    o_ptr,
+    T, HV: tl.constexpr, V: tl.constexpr,
+    BT: tl.constexpr, BV: tl.constexpr, NT,
+    i_v,
+):
+    for i_t in tl.range(NT):
+        store_wait = store_reader.wait(i_t)
+        slot = store_wait.slot
+        b_o = tl.load(tle.gpu.local_ptr(slot.output))
+        p_o = tl.make_block_ptr(o_ptr, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+        store_reader.release(i_t)
+
+
+PIPE_STAGES = tl.constexpr(4)
+
+
+@triton.heuristics({
+    'USE_INITIAL_STATE': lambda args: args['h0'].numel() > 1,
+    'STORE_FINAL_STATE': lambda args: args['ht'].numel() > 1,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[triton.Config({'BV': BV}, num_warps=4) for BV in [32, 64, 128]],
+    key=["HV", "K", "V", "BT"],  # warp_specialize fixes num_warps=4, only BV is tuned
+)
+@triton.jit(do_not_specialize=['T'])
+def _kda_fwd_state_output_kernel(
+    kg, v, beta, gk, Aqk, Akk, o, ws,
+    h0, ht,
+    cu_seqlens,
+    scale,
+    T, HV: tl.constexpr, K: tl.constexpr, V: tl.constexpr,
+    BT: tl.constexpr, BV: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+
+    if IS_VARLEN:
+        i_n = i_nh // HV
+        i_h = i_nh % HV
+        bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        i_n = i_nh // HV
+        i_h = i_nh % HV
+        bos = i_n * T
+        NT = tl.cdiv(T, BT)
+
+    v += (bos * HV + i_h).to(tl.int64) * V
+    beta += bos * HV + i_h
+    gk += (bos * HV + i_h).to(tl.int64) * K
+    Aqk += (bos * HV + i_h).to(tl.int64) * BT
+    Akk += (bos * HV + i_h).to(tl.int64) * BT
+    o += (bos * HV + i_h).to(tl.int64) * V
+    ws_base = ws + (bos * HV + i_h).to(tl.int64) * 3 * K
+
+    # TMA descriptors.
+    ws_desc = tl.make_tensor_descriptor(
+        ws_base, shape=[T, 3 * K], strides=[HV * 3 * K, 1], block_shape=[BT, 64])
+    gk_desc = tl.make_tensor_descriptor(
+        gk, shape=[T, K], strides=[HV * K, 1], block_shape=[1, 64])
+    Aqk_desc = tl.make_tensor_descriptor(
+        Aqk, shape=[T, BT], strides=[HV * BT, 1], block_shape=[BT, BT])
+    Akk_desc = tl.make_tensor_descriptor(
+        Akk, shape=[T, BT], strides=[HV * BT, 1], block_shape=[BT, BT])
+
+    # Allocate only the K blocks needed by this specialization.
+    w1_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
+    vb_smem = tle.gpu.alloc([PIPE_STAGES, BT, BV], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
+    qg1_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
+    kg1_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
+    Aqk_smem = tle.gpu.alloc([PIPE_STAGES, BT, BT], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
+    Akk_smem = tle.gpu.alloc([PIPE_STAGES, BT, BT], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
+    gk1_smem = tle.gpu.alloc([PIPE_STAGES, 1, 64], dtype=tl.float32, scope=tle.gpu.smem)
+    if K > 64:
+        w2_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
+        qg2_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
+        kg2_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
+        gk2_smem = tle.gpu.alloc([PIPE_STAGES, 1, 64], dtype=tl.float32, scope=tle.gpu.smem)
+    if K > 128:
+        w3_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
+        qg3_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
+        kg3_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
+        gk3_smem = tle.gpu.alloc([PIPE_STAGES, 1, 64], dtype=tl.float32, scope=tle.gpu.smem)
+    if K > 192:
+        w4_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
+        qg4_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
+        kg4_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
+        gk4_smem = tle.gpu.alloc([PIPE_STAGES, 1, 64], dtype=tl.float32, scope=tle.gpu.smem)
+    out_smem = tle.gpu.alloc([PIPE_STAGES, BT, BV], dtype=tl.float32, scope=tle.gpu.smem)
+
+    # Build pipe slots that match the allocated blocks.
+    if K <= 64:
+        load_pipe = tle.pipe(
+            capacity=PIPE_STAGES, scope="cta", name="kda_load",
+            w1=w1_smem, vb=vb_smem, qg1=qg1_smem, kg1=kg1_smem,
+            Aqk=Aqk_smem, Akk=Akk_smem, gk1=gk1_smem,
+        )
+    elif K <= 128:
+        load_pipe = tle.pipe(
+            capacity=PIPE_STAGES, scope="cta", name="kda_load",
+            w1=w1_smem, w2=w2_smem, vb=vb_smem,
+            qg1=qg1_smem, qg2=qg2_smem,
+            kg1=kg1_smem, kg2=kg2_smem,
+            Aqk=Aqk_smem, Akk=Akk_smem,
+            gk1=gk1_smem, gk2=gk2_smem,
+        )
+    elif K <= 192:
+        load_pipe = tle.pipe(
+            capacity=PIPE_STAGES, scope="cta", name="kda_load",
+            w1=w1_smem, w2=w2_smem, w3=w3_smem, vb=vb_smem,
+            qg1=qg1_smem, qg2=qg2_smem, qg3=qg3_smem,
+            kg1=kg1_smem, kg2=kg2_smem, kg3=kg3_smem,
+            Aqk=Aqk_smem, Akk=Akk_smem,
+            gk1=gk1_smem, gk2=gk2_smem, gk3=gk3_smem,
+        )
+    else:
+        load_pipe = tle.pipe(
+            capacity=PIPE_STAGES, scope="cta", name="kda_load",
+            w1=w1_smem, w2=w2_smem, w3=w3_smem, w4=w4_smem, vb=vb_smem,
+            qg1=qg1_smem, qg2=qg2_smem, qg3=qg3_smem, qg4=qg4_smem,
+            kg1=kg1_smem, kg2=kg2_smem, kg3=kg3_smem, kg4=kg4_smem,
+            Aqk=Aqk_smem, Akk=Akk_smem,
+            gk1=gk1_smem, gk2=gk2_smem, gk3=gk3_smem, gk4=gk4_smem,
+        )
+    store_pipe = tle.pipe(
+        capacity=PIPE_STAGES, scope="cta", name="kda_store", output=out_smem,
+    )
+    tle.gpu.warp_specialize(
+        [
+            (
+                _kda_state_output_load_producer,
+                (load_pipe.writer(), ws_desc, v, beta, gk_desc, Aqk_desc, Akk_desc,
+                 K, T, HV, V, BT, BV, NT, i_v),
+            ),
+            (
+                _kda_state_output_mma_consumer,
+                (load_pipe.reader(), store_pipe.writer(),
+                 h0, ht, gk,
+                 scale, i_v, i_nh,
+                 T, HV, K, V, BT, BV, NT,
+                 kg.dtype.element_ty, USE_INITIAL_STATE, STORE_FINAL_STATE, STATE_V_FIRST),
+            ),
+            (
+                _kda_state_output_store_consumer,
+                (store_pipe.reader(), o, T, HV, V, BT, BV, NT, i_v),
+            ),
+        ],
+        [4, 1],
+        [240, 32],
+    )
+
+
+def _kda_fwd_state_output(
+    kg: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    Akk: torch.Tensor,
+    gk: torch.Tensor,
+    Aqk: torch.Tensor,
+    scale: float | None,
+    ws: torch.Tensor | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    state_v_first: bool = True,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 16,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    B, _, HV, K = kg.shape
+    T_actual = v.shape[1]
+    V = v.shape[-1]
+    BT = chunk_size
+
+    if K > 256:
+        raise ValueError(f"KDA K must be <= 256, got {K}")
+
+    if cu_seqlens is None:
+        N = B
+    else:
+        N = len(cu_seqlens) - 1
+
+    final_state = None
+    if output_final_state:
+        if state_v_first:
+            final_state = kg.new_zeros(N, HV, V, K, dtype=torch.float32)
+        else:
+            final_state = kg.new_zeros(N, HV, K, V, dtype=torch.float32)
+
+    o = torch.zeros(B, T_actual, HV, V, device=kg.device, dtype=v.dtype)
+
+    h0_arg = initial_state if initial_state is not None else kg.new_empty(1, dtype=torch.float32)
+    ht_arg = final_state if final_state is not None else kg.new_empty(1, dtype=torch.float32)
+
+    grid = lambda meta: (triton.cdiv(V, meta['BV']), N * HV)
+    _kda_fwd_state_output_kernel[grid](
+        kg=kg, v=v, beta=beta, gk=gk, Aqk=Aqk, Akk=Akk, o=o, ws=ws,
+        h0=h0_arg, ht=ht_arg,
+        cu_seqlens=cu_seqlens,
+        scale=scale,
+        T=T_actual, HV=HV, K=K, V=V, BT=BT,
+        STATE_V_FIRST=state_v_first,
+    )
+
+    return o, final_state
+
+
+# -----------------------------------------------------------------------------
+# Public forward entry
+# -----------------------------------------------------------------------------
+
+
+def _validate_chunk_kda_inputs(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.LongTensor | None,
+    A_log: torch.Tensor | None,
+    dt_bias: torch.Tensor | None,
+    chunk_size: int,
+    state_v_first: bool,
+    use_qk_l2norm_in_kernel: bool,
+    use_gate_in_kernel: bool,
+    use_beta_sigmoid_in_kernel: bool,
+    allow_neg_eigval: bool,
+    safe_gate: bool,
+    lower_bound: float | None,
+) -> None:
+    if torch.is_grad_enabled():
+        raise RuntimeError("chunk_kda TLE path only supports inference/no-grad mode")
+    if chunk_size != 16:
+        raise ValueError(f"chunk_kda TLE path requires chunk_size=16, got {chunk_size}")
+    supported_dtypes = (torch.bfloat16, torch.float16)
+    for name, tensor in (("q", q), ("k", k), ("v", v), ("g", g), ("beta", beta)):
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor")
+        if tensor.device != q.device:
+            raise ValueError(f"{name} must be on the same device as q")
+        if tensor.dtype not in supported_dtypes:
+            raise ValueError(
+                f"chunk_kda TLE path requires {name} dtype to be bf16 or fp16, "
+                f"got {tensor.dtype}"
+            )
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4 or g.ndim != 4:
+        raise ValueError("q, k, v, and g must be 4D tensors in [B, T, H, D] layout")
+    if beta.ndim != 3:
+        raise ValueError("beta must be a 3D tensor in [B, T, HV] layout")
+
+    B, T, H, K = q.shape
+    Bk, Tk, Hk, Kk = k.shape
+    Bv, Tv, HV, V = v.shape
+    if (Bk, Tk, Hk, Kk) != (B, T, H, K):
+        raise ValueError(f"k must have shape {tuple(q.shape)}, got {tuple(k.shape)}")
+    if (Bv, Tv) != (B, T):
+        raise ValueError("v must share B and T dimensions with q/k")
+    if g.shape != (B, T, HV, K):
+        raise ValueError(f"g must have shape {(B, T, HV, K)}, got {tuple(g.shape)}")
+    if beta.shape != (B, T, HV):
+        raise ValueError(f"beta must have shape {(B, T, HV)}, got {tuple(beta.shape)}")
+    if K not in (64, 128, 192, 256):
+        raise ValueError(f"chunk_kda TLE path requires K in {{64, 128, 192, 256}}, got {K}")
+    if V <= 0:
+        raise ValueError(f"chunk_kda TLE path requires V > 0, got {V}")
+    if HV < H or HV % H != 0:
+        raise ValueError(f"chunk_kda TLE path requires HV % H == 0, got H={H}, HV={HV}")
+
+    if not use_qk_l2norm_in_kernel:
+        raise ValueError("chunk_kda TLE path requires use_qk_l2norm_in_kernel=True")
+    if not use_gate_in_kernel:
+        raise ValueError("chunk_kda TLE path requires use_gate_in_kernel=True")
+    if not use_beta_sigmoid_in_kernel:
+        raise ValueError("chunk_kda TLE path requires use_beta_sigmoid_in_kernel=True")
+    if allow_neg_eigval:
+        raise ValueError("chunk_kda TLE path does not support allow_neg_eigval=True")
+    if not safe_gate:
+        raise ValueError("chunk_kda TLE path requires safe_gate=True")
+    if lower_bound is None:
+        raise ValueError("chunk_kda TLE path requires lower_bound")
+    if A_log is None:
+        raise ValueError("chunk_kda TLE path requires A_log")
+    if A_log.device != q.device:
+        raise ValueError("A_log must be on the same device as q")
+    if A_log.numel() != HV:
+        raise ValueError(f"A_log.numel() must be HV={HV}, got {A_log.numel()}")
+    if dt_bias is None:
+        raise ValueError("chunk_kda TLE path requires dt_bias")
+    if dt_bias.device != q.device:
+        raise ValueError("dt_bias must be on the same device as q")
+    if dt_bias.numel() != HV * K:
+        raise ValueError(f"dt_bias.numel() must be HV*K={HV * K}, got {dt_bias.numel()}")
+
+    if cu_seqlens is not None:
+        if cu_seqlens.ndim != 1:
+            raise ValueError("cu_seqlens must be a 1D tensor")
+        if cu_seqlens.dtype != torch.long:
+            raise ValueError("cu_seqlens must have dtype torch.long")
+        if cu_seqlens.device != q.device:
+            raise ValueError("cu_seqlens must be on the same device as q")
+        if B != 1:
+            raise ValueError("cu_seqlens packed varlen inputs must use B=1")
+
+    if initial_state is not None:
+        if initial_state.device != q.device:
+            raise ValueError("initial_state must be on the same device as q")
+        N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
+        expected_shape = (N, HV, V, K) if state_v_first else (N, HV, K, V)
+        if tuple(initial_state.shape) != expected_shape:
+            raise ValueError(
+                f"initial_state must have shape {expected_shape}, "
+                f"got {tuple(initial_state.shape)}"
+            )
+
+
+def chunk_kda_fwd_infer(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+    chunk_size: int = 16,
+    safe_gate: bool = False,
+    lower_bound: float | None = None,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    **kwargs,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    triton.set_allocator(_allocate_triton_workspace)
+    _refresh_fp16_dot_precision()
+
+    if scale is None:
+        scale = q.shape[-1] ** -0.5
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+
+    ws, Aqk, Akk, g_cumsum = _kda_fwd_intra(
+        q=q, k=k, g=g, beta=beta,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+        lower_bound=lower_bound,
+        A_log=A_log,
+        dt_bias=dt_bias,
+    )
+
+    K = q.shape[-1]
+    return _kda_fwd_state_output(
+        kg=ws[:, :, :, 2 * K:], v=v, beta=beta,
+        Akk=Akk, gk=g_cumsum, Aqk=Aqk,
+        ws=ws,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        state_v_first=state_v_first,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+    )
+
+
+def chunk_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = True,
+    use_gate_in_kernel: bool = True,
+    use_beta_sigmoid_in_kernel: bool = True,
+    allow_neg_eigval: bool = False,
+    safe_gate: bool = True,
+    lower_bound: float | None = None,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 16,
+    **kwargs,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Inference-only TLE implementation of chunk Kimi Delta Attention.
+
+    Inputs use seq-first layout: q/k ``[B, T, H, K]``, v/g ``[B, T, HV, *]``,
+    and beta ``[B, T, HV]``. This single-file wrapper exposes the fused TLE path
+    only, so q/k L2 norm, gate activation, and beta sigmoid are computed inside
+    the kernels.
+    """
+    A_log = kwargs.get("A_log")
+    dt_bias = kwargs.get("dt_bias")
+
+    _validate_chunk_kda_inputs(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=initial_state,
+        cu_seqlens=cu_seqlens,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        chunk_size=chunk_size,
+        state_v_first=state_v_first,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        use_gate_in_kernel=use_gate_in_kernel,
+        use_beta_sigmoid_in_kernel=use_beta_sigmoid_in_kernel,
+        allow_neg_eigval=allow_neg_eigval,
+        safe_gate=safe_gate,
+        lower_bound=lower_bound,
+    )
+
+    return chunk_kda_fwd_infer(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        state_v_first=state_v_first,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        safe_gate=safe_gate,
+        lower_bound=lower_bound,
+        A_log=A_log,
+        dt_bias=dt_bias,
+    )

--- a/src/flaggems_vllm/ops/FLA/chunk_kda.py
+++ b/src/flaggems_vllm/ops/FLA/chunk_kda.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 
 import torch
 import triton
-import triton.language as tl
 import triton.experimental.tle.language as tle
+import triton.language as tl
 
 from flaggems_vllm.ops.FLA.index import prepare_chunk_indices
 
@@ -33,7 +33,7 @@ def exp2(x):
     return tl.math.exp2(x.to(tl.float32))
 
 
-_FP16_DOT_PRECISION = tl.constexpr('ieee')
+_FP16_DOT_PRECISION = tl.constexpr("ieee")
 _FP16_DOT_PRECISION_REFRESHED = False
 
 
@@ -45,9 +45,9 @@ def _refresh_fp16_dot_precision() -> None:
         if torch.cuda.is_available():
             major, _ = torch.cuda.get_device_capability(torch.cuda.current_device())
             if major >= 8:
-                _FP16_DOT_PRECISION = tl.constexpr('tf32')
+                _FP16_DOT_PRECISION = tl.constexpr("tf32")
     except Exception:
-        _FP16_DOT_PRECISION = tl.constexpr('ieee')
+        _FP16_DOT_PRECISION = tl.constexpr("ieee")
     _FP16_DOT_PRECISION_REFRESHED = True
 
 
@@ -59,9 +59,12 @@ def _allocate_triton_workspace(size: int, _alignment: int, _stream) -> torch.Ten
 # Kernel 1: fused intra-chunk preprocessing
 # -----------------------------------------------------------------------------
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
 @triton.autotune(
     configs=[
         triton.Config({}, num_warps=num_warps, num_stages=num_stages, maxnreg=maxnreg)
@@ -71,15 +74,27 @@ def _allocate_triton_workspace(size: int, _alignment: int, _stream) -> torch.Ten
     ],
     key=["H", "HV", "K", "BT"],
 )
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=["T"])
 def _kda_fwd_intra_kernel(
-    q, k, g, beta,
-    ws, Aqk, Akk, g_out,
-    A_log, dt_bias, lower_bound,
-    scale, g_scale, l2norm_eps,
-    cu_seqlens, chunk_indices,
+    q,
+    k,
+    g,
+    beta,
+    ws,
+    Aqk,
+    Akk,
+    g_out,
+    A_log,
+    dt_bias,
+    lower_bound,
+    scale,
+    g_scale,
+    l2norm_eps,
+    cu_seqlens,
+    chunk_indices,
     T,
-    H: tl.constexpr, HV: tl.constexpr,
+    H: tl.constexpr,
+    HV: tl.constexpr,
     K: tl.constexpr,
     BT: tl.constexpr,
     IS_VARLEN: tl.constexpr,
@@ -89,7 +104,9 @@ def _kda_fwd_intra_kernel(
     i_h = i_hv // (HV // H)
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
         bos = tl.load(cu_seqlens + i_n).to(tl.int32)
         T = tl.load(cu_seqlens + i_n + 1).to(tl.int32) - bos
     else:
@@ -152,23 +169,45 @@ def _kda_fwd_intra_kernel(
         b_acc = b_acc + tl.load(rp)
         tl.store(rp, b_acc)
 
-    p_g_out = tl.make_block_ptr(g_out, (T, K), (HV * K, 1), (i_t * BT, 0), (BT, K), (1, 0))
+    p_g_out = tl.make_block_ptr(
+        g_out, (T, K), (HV * K, 1), (i_t * BT, 0), (BT, K), (1, 0)
+    )
     tl.store(p_g_out, tl.load(gc_sp).to(g_out.dtype.element_ty), boundary_check=(0, 1))
 
     # Intra-chunk Aqk/Akk plus triangular solve.
-    b_gq = tl.where(m_c[:, None], exp2(tl.load(gc_sp)), 0.)
-    b_gk = tl.where(m_c[:, None], exp2(-tl.load(gc_sp)), 0.)
+    b_gq = tl.where(m_c[:, None], exp2(tl.load(gc_sp)), 0.0)
+    b_gk = tl.where(m_c[:, None], exp2(-tl.load(gc_sp)), 0.0)
 
     # Keep b_gq/b_gk in fp32: exp2(±cumsum) can exceed fp16 max (65504), casting would overflow.
     # For bfloat16, bf16 range (3.4e38) is sufficient, so cast is safe.
     if q.dtype.element_ty == tl.float16:
         b_kgt = tl.trans(b_kf * b_gk)
-        b_Aqk = tl.dot(b_qf * b_gq, b_kgt, input_precision=_FP16_DOT_PRECISION, out_dtype=tl.float32)
-        b_Akk = tl.dot(b_kf * b_gq, b_kgt, input_precision=_FP16_DOT_PRECISION, out_dtype=tl.float32)
+        b_Aqk = tl.dot(
+            b_qf * b_gq,
+            b_kgt,
+            input_precision=_FP16_DOT_PRECISION,
+            out_dtype=tl.float32,
+        )
+        b_Akk = tl.dot(
+            b_kf * b_gq,
+            b_kgt,
+            input_precision=_FP16_DOT_PRECISION,
+            out_dtype=tl.float32,
+        )
     else:
         b_kgt = tl.trans(b_kf * b_gk).to(b_k.dtype)
-        b_Aqk = tl.dot((b_qf * b_gq).to(b_q.dtype), b_kgt, input_precision=_FP16_DOT_PRECISION, out_dtype=tl.float32)
-        b_Akk = tl.dot((b_kf * b_gq).to(b_k.dtype), b_kgt, input_precision=_FP16_DOT_PRECISION, out_dtype=tl.float32)
+        b_Aqk = tl.dot(
+            (b_qf * b_gq).to(b_q.dtype),
+            b_kgt,
+            input_precision=_FP16_DOT_PRECISION,
+            out_dtype=tl.float32,
+        )
+        b_Akk = tl.dot(
+            (b_kf * b_gq).to(b_k.dtype),
+            b_kgt,
+            input_precision=_FP16_DOT_PRECISION,
+            out_dtype=tl.float32,
+        )
 
     b_Aqk = b_Aqk * b_q_rstd[:, None] * b_k_rstd[None, :]
     b_Akk = b_Akk * b_k_rstd[:, None] * b_k_rstd[None, :]
@@ -183,7 +222,9 @@ def _kda_fwd_intra_kernel(
     b_Aqk = tl.where(m_Aqk, b_Aqk * scale, 0.0)
     b_Akk = tl.where(m_Akk, b_Akk * b_beta[:, None], 0.0)
 
-    p_Aqk = tl.make_block_ptr(Aqk, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_Aqk = tl.make_block_ptr(
+        Aqk, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+    )
     tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), boundary_check=(0, 1))
 
     b_L = b_Akk.to(tl.float16)
@@ -195,19 +236,25 @@ def _kda_fwd_intra_kernel(
     b_L8 = tl.dot(b_L4, b_L4, out_dtype=tl.float16)
     b_Ai = b_Ai + tl.dot(b_Ai, b_L8, out_dtype=tl.float16)
 
-    p_Akk_out = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_Akk_out = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+    )
     tl.store(p_Akk_out, b_Ai.to(Akk.dtype.element_ty), boundary_check=(0, 1))
 
     # Pack w, qg, and kg into one workspace at columns 0, K, and 2*K.
     b_k3 = tl.load(k_sp).to(tl.float32) * b_k_rstd[:, None]
     b_gk3 = tl.load(gc_sp)
     b_kb = b_k3 * b_beta[:, None] * exp2(b_gk3)
-    p_w = tl.make_block_ptr(ws, (T, 3 * K), (HV * 3 * K, 1), (i_t * BT, 0), (BT, K), (1, 0))
+    p_w = tl.make_block_ptr(
+        ws, (T, 3 * K), (HV * 3 * K, 1), (i_t * BT, 0), (BT, K), (1, 0)
+    )
     tl.store(p_w, b_kb.to(ws.dtype.element_ty), boundary_check=(0, 1))
 
     b_q3 = tl.load(q_sp).to(tl.float32) * b_q_rstd[:, None]
     b_qg_val = b_q3 * exp2(b_gk3)
-    p_qg = tl.make_block_ptr(ws, (T, 3 * K), (HV * 3 * K, 1), (i_t * BT, K), (BT, K), (1, 0))
+    p_qg = tl.make_block_ptr(
+        ws, (T, 3 * K), (HV * 3 * K, 1), (i_t * BT, K), (BT, K), (1, 0)
+    )
     tl.store(p_qg, b_qg_val.to(ws.dtype.element_ty), boundary_check=(0, 1))
 
     last_local = tl.minimum(BT, T - i_t * BT) - 1
@@ -215,14 +262,24 @@ def _kda_fwd_intra_kernel(
     gn_cols = tl.broadcast_to(tl.arange(0, K)[None, :], (1, K))
     b_gn = tl.load(tle.gpu.local_ptr(gc_buf, (gn_rows, gn_cols)))
     b_kg_val = b_k3 * tl.where(m_c[:, None], exp2(b_gn - b_gk3), 0)
-    p_kg = tl.make_block_ptr(ws, (T, 3 * K), (HV * 3 * K, 1), (i_t * BT, 2 * K), (BT, K), (1, 0))
+    p_kg = tl.make_block_ptr(
+        ws, (T, 3 * K), (HV * 3 * K, 1), (i_t * BT, 2 * K), (BT, K), (1, 0)
+    )
     tl.store(p_kg, b_kg_val.to(ws.dtype.element_ty), boundary_check=(0, 1))
 
 
 def _kda_fwd_intra(
-    q, k, g, beta, scale,
-    cu_seqlens=None, chunk_indices=None, chunk_size=16,
-    lower_bound=None, A_log=None, dt_bias=None,
+    q,
+    k,
+    g,
+    beta,
+    scale,
+    cu_seqlens=None,
+    chunk_indices=None,
+    chunk_size=16,
+    lower_bound=None,
+    A_log=None,
+    dt_bias=None,
 ):
     B, T_len, H, K = q.shape
     HV = g.shape[2]
@@ -241,12 +298,27 @@ def _kda_fwd_intra(
     Akk = torch.zeros(B, T_padded, HV, BT, device=q.device, dtype=q.dtype)
 
     _kda_fwd_intra_kernel[grid](
-        q=q, k=k, g=g, beta=beta,
-        ws=ws, Aqk=Aqk, Akk=Akk, g_out=g_out,
-        A_log=A_log, dt_bias=dt_bias, lower_bound=lower_bound,
-        scale=scale, g_scale=RCP_LN2, l2norm_eps=1e-6,
-        cu_seqlens=cu_seqlens, chunk_indices=chunk_indices,
-        T=T_len, H=H, HV=HV, K=K, BT=BT,
+        q=q,
+        k=k,
+        g=g,
+        beta=beta,
+        ws=ws,
+        Aqk=Aqk,
+        Akk=Akk,
+        g_out=g_out,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        lower_bound=lower_bound,
+        scale=scale,
+        g_scale=RCP_LN2,
+        l2norm_eps=1e-6,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T_len,
+        H=H,
+        HV=HV,
+        K=K,
+        BT=BT,
     )
     return ws, Aqk, Akk, g_out
 
@@ -255,12 +327,23 @@ def _kda_fwd_intra(
 # Kernel 2: state propagation + output
 # -----------------------------------------------------------------------------
 
+
 @triton.jit
 def _kda_state_output_load_producer(
     writer,
-    ws_desc, v_ptr, beta_ptr, gk_desc, Aqk_desc, Akk_desc,
-    K, T, HV: tl.constexpr, V: tl.constexpr,
-    BT: tl.constexpr, BV: tl.constexpr, NT,
+    ws_desc,
+    v_ptr,
+    beta_ptr,
+    gk_desc,
+    Aqk_desc,
+    Akk_desc,
+    K,
+    T,
+    HV: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    NT,
     i_v,
 ):
     for i_t in tl.range(NT):
@@ -268,30 +351,32 @@ def _kda_state_output_load_producer(
         last_idx = tl.minimum(i_t * BT + BT, T) - 1
 
         # The workspace packs w, qg, and kg at offsets 0, K, and 2*K.
-        tle.gpu.copy(ws_desc, slot.w1,  [BT, 64], [i_t * BT, 0])
+        tle.gpu.copy(ws_desc, slot.w1, [BT, 64], [i_t * BT, 0])
         tle.gpu.copy(ws_desc, slot.qg1, [BT, 64], [i_t * BT, K])
         tle.gpu.copy(ws_desc, slot.kg1, [BT, 64], [i_t * BT, 2 * K])
         tle.gpu.copy(Aqk_desc, slot.Aqk, [BT, BT], [i_t * BT, 0])
         tle.gpu.copy(Akk_desc, slot.Akk, [BT, BT], [i_t * BT, 0])
         tle.gpu.copy(gk_desc, slot.gk1, [1, 64], [last_idx, 0])
         if K > 64:
-            tle.gpu.copy(ws_desc, slot.w2,  [BT, 64], [i_t * BT, 64])
+            tle.gpu.copy(ws_desc, slot.w2, [BT, 64], [i_t * BT, 64])
             tle.gpu.copy(ws_desc, slot.qg2, [BT, 64], [i_t * BT, K + 64])
             tle.gpu.copy(ws_desc, slot.kg2, [BT, 64], [i_t * BT, 2 * K + 64])
             tle.gpu.copy(gk_desc, slot.gk2, [1, 64], [last_idx, 64])
         if K > 128:
-            tle.gpu.copy(ws_desc, slot.w3,  [BT, 64], [i_t * BT, 128])
+            tle.gpu.copy(ws_desc, slot.w3, [BT, 64], [i_t * BT, 128])
             tle.gpu.copy(ws_desc, slot.qg3, [BT, 64], [i_t * BT, K + 128])
             tle.gpu.copy(ws_desc, slot.kg3, [BT, 64], [i_t * BT, 2 * K + 128])
             tle.gpu.copy(gk_desc, slot.gk3, [1, 64], [last_idx, 128])
         if K > 192:
-            tle.gpu.copy(ws_desc, slot.w4,  [BT, 64], [i_t * BT, 192])
+            tle.gpu.copy(ws_desc, slot.w4, [BT, 64], [i_t * BT, 192])
             tle.gpu.copy(ws_desc, slot.qg4, [BT, 64], [i_t * BT, K + 192])
             tle.gpu.copy(ws_desc, slot.kg4, [BT, 64], [i_t * BT, 2 * K + 192])
             tle.gpu.copy(gk_desc, slot.gk4, [1, 64], [last_idx, 192])
 
         # v and beta need elementwise work, so keep them as regular loads.
-        p_v = tl.make_block_ptr(v_ptr, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_v = tl.make_block_ptr(
+            v_ptr, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
         p_beta = tl.make_block_ptr(beta_ptr, (T,), (HV,), (i_t * BT,), (BT,), (0,))
         b_v = tl.load(p_v, boundary_check=(0, 1))
         b_beta = tl.load(p_beta, boundary_check=(0,))
@@ -306,11 +391,19 @@ def _kda_state_output_load_producer(
 def _kda_state_output_mma_consumer(
     load_reader,
     store_writer,
-    h0, ht, gk,
+    h0,
+    ht,
+    gk,
     scale,
-    i_v, i_nh,
-    T, HV: tl.constexpr, K: tl.constexpr, V: tl.constexpr,
-    BT: tl.constexpr, BV: tl.constexpr, NT,
+    i_v,
+    i_nh,
+    T,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    NT,
     kg_dtype: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
     STORE_FINAL_STATE: tl.constexpr,
@@ -319,28 +412,44 @@ def _kda_state_output_mma_consumer(
     # Initial state.
     if USE_INITIAL_STATE:
         if STATE_V_FIRST:
-            p_h0_1 = tl.make_block_ptr(h0 + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+            p_h0_1 = tl.make_block_ptr(
+                h0 + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0)
+            )
             b_h1 = tl.trans(tl.load(p_h0_1, boundary_check=(0, 1))).to(tl.float32)
             if K > 64:
-                p_h0_2 = tl.make_block_ptr(h0 + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+                p_h0_2 = tl.make_block_ptr(
+                    h0 + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0)
+                )
                 b_h2 = tl.trans(tl.load(p_h0_2, boundary_check=(0, 1))).to(tl.float32)
             if K > 128:
-                p_h0_3 = tl.make_block_ptr(h0 + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+                p_h0_3 = tl.make_block_ptr(
+                    h0 + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0)
+                )
                 b_h3 = tl.trans(tl.load(p_h0_3, boundary_check=(0, 1))).to(tl.float32)
             if K > 192:
-                p_h0_4 = tl.make_block_ptr(h0 + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+                p_h0_4 = tl.make_block_ptr(
+                    h0 + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0)
+                )
                 b_h4 = tl.trans(tl.load(p_h0_4, boundary_check=(0, 1))).to(tl.float32)
         else:
-            p_h0_1 = tl.make_block_ptr(h0 + i_nh * K * V, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+            p_h0_1 = tl.make_block_ptr(
+                h0 + i_nh * K * V, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0)
+            )
             b_h1 = tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
             if K > 64:
-                p_h0_2 = tl.make_block_ptr(h0 + i_nh * K * V, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
+                p_h0_2 = tl.make_block_ptr(
+                    h0 + i_nh * K * V, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
+                )
                 b_h2 = tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
             if K > 128:
-                p_h0_3 = tl.make_block_ptr(h0 + i_nh * K * V, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
+                p_h0_3 = tl.make_block_ptr(
+                    h0 + i_nh * K * V, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
+                )
                 b_h3 = tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
             if K > 192:
-                p_h0_4 = tl.make_block_ptr(h0 + i_nh * K * V, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
+                p_h0_4 = tl.make_block_ptr(
+                    h0 + i_nh * K * V, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
+                )
                 b_h4 = tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
     else:
         b_h1 = tl.zeros([64, BV], dtype=tl.float32)
@@ -417,39 +526,77 @@ def _kda_state_output_mma_consumer(
         load_reader.release(i_t)
 
         # state decay + update: h = h * exp2(gk_last) + kg^T @ v_new
-        b_h1 = b_h1 * exp2(b_gk1)[:, None] + tl.dot(tl.trans(b_kg1), b_v_cast).to(tl.float32)
+        b_h1 = b_h1 * exp2(b_gk1)[:, None] + tl.dot(tl.trans(b_kg1), b_v_cast).to(
+            tl.float32
+        )
         if K > 64:
-            b_h2 = b_h2 * exp2(b_gk2)[:, None] + tl.dot(tl.trans(b_kg2), b_v_cast).to(tl.float32)
+            b_h2 = b_h2 * exp2(b_gk2)[:, None] + tl.dot(tl.trans(b_kg2), b_v_cast).to(
+                tl.float32
+            )
         if K > 128:
-            b_h3 = b_h3 * exp2(b_gk3)[:, None] + tl.dot(tl.trans(b_kg3), b_v_cast).to(tl.float32)
+            b_h3 = b_h3 * exp2(b_gk3)[:, None] + tl.dot(tl.trans(b_kg3), b_v_cast).to(
+                tl.float32
+            )
         if K > 192:
-            b_h4 = b_h4 * exp2(b_gk4)[:, None] + tl.dot(tl.trans(b_kg4), b_v_cast).to(tl.float32)
+            b_h4 = b_h4 * exp2(b_gk4)[:, None] + tl.dot(tl.trans(b_kg4), b_v_cast).to(
+                tl.float32
+            )
 
     # Final state.
     if STORE_FINAL_STATE:
         if STATE_V_FIRST:
-            p_ht1 = tl.make_block_ptr(ht + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
-            tl.store(p_ht1, tl.trans(b_h1).to(p_ht1.dtype.element_ty), boundary_check=(0, 1))
+            p_ht1 = tl.make_block_ptr(
+                ht + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0)
+            )
+            tl.store(
+                p_ht1, tl.trans(b_h1).to(p_ht1.dtype.element_ty), boundary_check=(0, 1)
+            )
             if K > 64:
-                p_ht2 = tl.make_block_ptr(ht + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
-                tl.store(p_ht2, tl.trans(b_h2).to(p_ht2.dtype.element_ty), boundary_check=(0, 1))
+                p_ht2 = tl.make_block_ptr(
+                    ht + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0)
+                )
+                tl.store(
+                    p_ht2,
+                    tl.trans(b_h2).to(p_ht2.dtype.element_ty),
+                    boundary_check=(0, 1),
+                )
             if K > 128:
-                p_ht3 = tl.make_block_ptr(ht + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
-                tl.store(p_ht3, tl.trans(b_h3).to(p_ht3.dtype.element_ty), boundary_check=(0, 1))
+                p_ht3 = tl.make_block_ptr(
+                    ht + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0)
+                )
+                tl.store(
+                    p_ht3,
+                    tl.trans(b_h3).to(p_ht3.dtype.element_ty),
+                    boundary_check=(0, 1),
+                )
             if K > 192:
-                p_ht4 = tl.make_block_ptr(ht + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
-                tl.store(p_ht4, tl.trans(b_h4).to(p_ht4.dtype.element_ty), boundary_check=(0, 1))
+                p_ht4 = tl.make_block_ptr(
+                    ht + i_nh * K * V, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0)
+                )
+                tl.store(
+                    p_ht4,
+                    tl.trans(b_h4).to(p_ht4.dtype.element_ty),
+                    boundary_check=(0, 1),
+                )
         else:
-            p_ht1 = tl.make_block_ptr(ht + i_nh * K * V, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+            p_ht1 = tl.make_block_ptr(
+                ht + i_nh * K * V, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0)
+            )
             tl.store(p_ht1, b_h1.to(p_ht1.dtype.element_ty), boundary_check=(0, 1))
             if K > 64:
-                p_ht2 = tl.make_block_ptr(ht + i_nh * K * V, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
+                p_ht2 = tl.make_block_ptr(
+                    ht + i_nh * K * V, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
+                )
                 tl.store(p_ht2, b_h2.to(p_ht2.dtype.element_ty), boundary_check=(0, 1))
             if K > 128:
-                p_ht3 = tl.make_block_ptr(ht + i_nh * K * V, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
+                p_ht3 = tl.make_block_ptr(
+                    ht + i_nh * K * V, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
+                )
                 tl.store(p_ht3, b_h3.to(p_ht3.dtype.element_ty), boundary_check=(0, 1))
             if K > 192:
-                p_ht4 = tl.make_block_ptr(ht + i_nh * K * V, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
+                p_ht4 = tl.make_block_ptr(
+                    ht + i_nh * K * V, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
+                )
                 tl.store(p_ht4, b_h4.to(p_ht4.dtype.element_ty), boundary_check=(0, 1))
 
 
@@ -457,15 +604,21 @@ def _kda_state_output_mma_consumer(
 def _kda_state_output_store_consumer(
     store_reader,
     o_ptr,
-    T, HV: tl.constexpr, V: tl.constexpr,
-    BT: tl.constexpr, BV: tl.constexpr, NT,
+    T,
+    HV: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    NT,
     i_v,
 ):
     for i_t in tl.range(NT):
         store_wait = store_reader.wait(i_t)
         slot = store_wait.slot
         b_o = tl.load(tle.gpu.local_ptr(slot.output))
-        p_o = tl.make_block_ptr(o_ptr, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_o = tl.make_block_ptr(
+            o_ptr, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
         tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
         store_reader.release(i_t)
 
@@ -473,23 +626,37 @@ def _kda_state_output_store_consumer(
 PIPE_STAGES = tl.constexpr(4)
 
 
-@triton.heuristics({
-    'USE_INITIAL_STATE': lambda args: args['h0'].numel() > 1,
-    'STORE_FINAL_STATE': lambda args: args['ht'].numel() > 1,
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
+@triton.heuristics(
+    {
+        "USE_INITIAL_STATE": lambda args: args["h0"].numel() > 1,
+        "STORE_FINAL_STATE": lambda args: args["ht"].numel() > 1,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
 @triton.autotune(
-    configs=[triton.Config({'BV': BV}, num_warps=4) for BV in [32, 64, 128]],
+    configs=[triton.Config({"BV": BV}, num_warps=4) for BV in [32, 64, 128]],
     key=["HV", "K", "V", "BT"],  # warp_specialize fixes num_warps=4, only BV is tuned
 )
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=["T"])
 def _kda_fwd_state_output_kernel(
-    kg, v, beta, gk, Aqk, Akk, o, ws,
-    h0, ht,
+    kg,
+    v,
+    beta,
+    gk,
+    Aqk,
+    Akk,
+    o,
+    ws,
+    h0,
+    ht,
     cu_seqlens,
     scale,
-    T, HV: tl.constexpr, K: tl.constexpr, V: tl.constexpr,
-    BT: tl.constexpr, BV: tl.constexpr,
+    T,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
     STATE_V_FIRST: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
     STORE_FINAL_STATE: tl.constexpr,
@@ -520,90 +687,209 @@ def _kda_fwd_state_output_kernel(
 
     # TMA descriptors.
     ws_desc = tl.make_tensor_descriptor(
-        ws_base, shape=[T, 3 * K], strides=[HV * 3 * K, 1], block_shape=[BT, 64])
+        ws_base, shape=[T, 3 * K], strides=[HV * 3 * K, 1], block_shape=[BT, 64]
+    )
     gk_desc = tl.make_tensor_descriptor(
-        gk, shape=[T, K], strides=[HV * K, 1], block_shape=[1, 64])
+        gk, shape=[T, K], strides=[HV * K, 1], block_shape=[1, 64]
+    )
     Aqk_desc = tl.make_tensor_descriptor(
-        Aqk, shape=[T, BT], strides=[HV * BT, 1], block_shape=[BT, BT])
+        Aqk, shape=[T, BT], strides=[HV * BT, 1], block_shape=[BT, BT]
+    )
     Akk_desc = tl.make_tensor_descriptor(
-        Akk, shape=[T, BT], strides=[HV * BT, 1], block_shape=[BT, BT])
+        Akk, shape=[T, BT], strides=[HV * BT, 1], block_shape=[BT, BT]
+    )
 
     # Allocate only the K blocks needed by this specialization.
-    w1_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
-    vb_smem = tle.gpu.alloc([PIPE_STAGES, BT, BV], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
-    qg1_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
-    kg1_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
-    Aqk_smem = tle.gpu.alloc([PIPE_STAGES, BT, BT], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
-    Akk_smem = tle.gpu.alloc([PIPE_STAGES, BT, BT], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
+    w1_smem = tle.gpu.alloc(
+        [PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem
+    )
+    vb_smem = tle.gpu.alloc(
+        [PIPE_STAGES, BT, BV], dtype=kg.dtype.element_ty, scope=tle.gpu.smem
+    )
+    qg1_smem = tle.gpu.alloc(
+        [PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem
+    )
+    kg1_smem = tle.gpu.alloc(
+        [PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem
+    )
+    Aqk_smem = tle.gpu.alloc(
+        [PIPE_STAGES, BT, BT], dtype=kg.dtype.element_ty, scope=tle.gpu.smem
+    )
+    Akk_smem = tle.gpu.alloc(
+        [PIPE_STAGES, BT, BT], dtype=kg.dtype.element_ty, scope=tle.gpu.smem
+    )
     gk1_smem = tle.gpu.alloc([PIPE_STAGES, 1, 64], dtype=tl.float32, scope=tle.gpu.smem)
     if K > 64:
-        w2_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
-        qg2_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
-        kg2_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
-        gk2_smem = tle.gpu.alloc([PIPE_STAGES, 1, 64], dtype=tl.float32, scope=tle.gpu.smem)
+        w2_smem = tle.gpu.alloc(
+            [PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem
+        )
+        qg2_smem = tle.gpu.alloc(
+            [PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem
+        )
+        kg2_smem = tle.gpu.alloc(
+            [PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem
+        )
+        gk2_smem = tle.gpu.alloc(
+            [PIPE_STAGES, 1, 64], dtype=tl.float32, scope=tle.gpu.smem
+        )
     if K > 128:
-        w3_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
-        qg3_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
-        kg3_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
-        gk3_smem = tle.gpu.alloc([PIPE_STAGES, 1, 64], dtype=tl.float32, scope=tle.gpu.smem)
+        w3_smem = tle.gpu.alloc(
+            [PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem
+        )
+        qg3_smem = tle.gpu.alloc(
+            [PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem
+        )
+        kg3_smem = tle.gpu.alloc(
+            [PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem
+        )
+        gk3_smem = tle.gpu.alloc(
+            [PIPE_STAGES, 1, 64], dtype=tl.float32, scope=tle.gpu.smem
+        )
     if K > 192:
-        w4_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
-        qg4_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
-        kg4_smem = tle.gpu.alloc([PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem)
-        gk4_smem = tle.gpu.alloc([PIPE_STAGES, 1, 64], dtype=tl.float32, scope=tle.gpu.smem)
-    out_smem = tle.gpu.alloc([PIPE_STAGES, BT, BV], dtype=tl.float32, scope=tle.gpu.smem)
+        w4_smem = tle.gpu.alloc(
+            [PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem
+        )
+        qg4_smem = tle.gpu.alloc(
+            [PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem
+        )
+        kg4_smem = tle.gpu.alloc(
+            [PIPE_STAGES, BT, 64], dtype=kg.dtype.element_ty, scope=tle.gpu.smem
+        )
+        gk4_smem = tle.gpu.alloc(
+            [PIPE_STAGES, 1, 64], dtype=tl.float32, scope=tle.gpu.smem
+        )
+    out_smem = tle.gpu.alloc(
+        [PIPE_STAGES, BT, BV], dtype=tl.float32, scope=tle.gpu.smem
+    )
 
     # Build pipe slots that match the allocated blocks.
     if K <= 64:
         load_pipe = tle.pipe(
-            capacity=PIPE_STAGES, scope="cta", name="kda_load",
-            w1=w1_smem, vb=vb_smem, qg1=qg1_smem, kg1=kg1_smem,
-            Aqk=Aqk_smem, Akk=Akk_smem, gk1=gk1_smem,
+            capacity=PIPE_STAGES,
+            scope="cta",
+            name="kda_load",
+            w1=w1_smem,
+            vb=vb_smem,
+            qg1=qg1_smem,
+            kg1=kg1_smem,
+            Aqk=Aqk_smem,
+            Akk=Akk_smem,
+            gk1=gk1_smem,
         )
     elif K <= 128:
         load_pipe = tle.pipe(
-            capacity=PIPE_STAGES, scope="cta", name="kda_load",
-            w1=w1_smem, w2=w2_smem, vb=vb_smem,
-            qg1=qg1_smem, qg2=qg2_smem,
-            kg1=kg1_smem, kg2=kg2_smem,
-            Aqk=Aqk_smem, Akk=Akk_smem,
-            gk1=gk1_smem, gk2=gk2_smem,
+            capacity=PIPE_STAGES,
+            scope="cta",
+            name="kda_load",
+            w1=w1_smem,
+            w2=w2_smem,
+            vb=vb_smem,
+            qg1=qg1_smem,
+            qg2=qg2_smem,
+            kg1=kg1_smem,
+            kg2=kg2_smem,
+            Aqk=Aqk_smem,
+            Akk=Akk_smem,
+            gk1=gk1_smem,
+            gk2=gk2_smem,
         )
     elif K <= 192:
         load_pipe = tle.pipe(
-            capacity=PIPE_STAGES, scope="cta", name="kda_load",
-            w1=w1_smem, w2=w2_smem, w3=w3_smem, vb=vb_smem,
-            qg1=qg1_smem, qg2=qg2_smem, qg3=qg3_smem,
-            kg1=kg1_smem, kg2=kg2_smem, kg3=kg3_smem,
-            Aqk=Aqk_smem, Akk=Akk_smem,
-            gk1=gk1_smem, gk2=gk2_smem, gk3=gk3_smem,
+            capacity=PIPE_STAGES,
+            scope="cta",
+            name="kda_load",
+            w1=w1_smem,
+            w2=w2_smem,
+            w3=w3_smem,
+            vb=vb_smem,
+            qg1=qg1_smem,
+            qg2=qg2_smem,
+            qg3=qg3_smem,
+            kg1=kg1_smem,
+            kg2=kg2_smem,
+            kg3=kg3_smem,
+            Aqk=Aqk_smem,
+            Akk=Akk_smem,
+            gk1=gk1_smem,
+            gk2=gk2_smem,
+            gk3=gk3_smem,
         )
     else:
         load_pipe = tle.pipe(
-            capacity=PIPE_STAGES, scope="cta", name="kda_load",
-            w1=w1_smem, w2=w2_smem, w3=w3_smem, w4=w4_smem, vb=vb_smem,
-            qg1=qg1_smem, qg2=qg2_smem, qg3=qg3_smem, qg4=qg4_smem,
-            kg1=kg1_smem, kg2=kg2_smem, kg3=kg3_smem, kg4=kg4_smem,
-            Aqk=Aqk_smem, Akk=Akk_smem,
-            gk1=gk1_smem, gk2=gk2_smem, gk3=gk3_smem, gk4=gk4_smem,
+            capacity=PIPE_STAGES,
+            scope="cta",
+            name="kda_load",
+            w1=w1_smem,
+            w2=w2_smem,
+            w3=w3_smem,
+            w4=w4_smem,
+            vb=vb_smem,
+            qg1=qg1_smem,
+            qg2=qg2_smem,
+            qg3=qg3_smem,
+            qg4=qg4_smem,
+            kg1=kg1_smem,
+            kg2=kg2_smem,
+            kg3=kg3_smem,
+            kg4=kg4_smem,
+            Aqk=Aqk_smem,
+            Akk=Akk_smem,
+            gk1=gk1_smem,
+            gk2=gk2_smem,
+            gk3=gk3_smem,
+            gk4=gk4_smem,
         )
     store_pipe = tle.pipe(
-        capacity=PIPE_STAGES, scope="cta", name="kda_store", output=out_smem,
+        capacity=PIPE_STAGES,
+        scope="cta",
+        name="kda_store",
+        output=out_smem,
     )
     tle.gpu.warp_specialize(
         [
             (
                 _kda_state_output_load_producer,
-                (load_pipe.writer(), ws_desc, v, beta, gk_desc, Aqk_desc, Akk_desc,
-                 K, T, HV, V, BT, BV, NT, i_v),
+                (
+                    load_pipe.writer(),
+                    ws_desc,
+                    v,
+                    beta,
+                    gk_desc,
+                    Aqk_desc,
+                    Akk_desc,
+                    K,
+                    T,
+                    HV,
+                    V,
+                    BT,
+                    BV,
+                    NT,
+                    i_v,
+                ),
             ),
             (
                 _kda_state_output_mma_consumer,
-                (load_pipe.reader(), store_pipe.writer(),
-                 h0, ht, gk,
-                 scale, i_v, i_nh,
-                 T, HV, K, V, BT, BV, NT,
-                 kg.dtype.element_ty, USE_INITIAL_STATE, STORE_FINAL_STATE, STATE_V_FIRST),
+                (
+                    load_pipe.reader(),
+                    store_pipe.writer(),
+                    h0,
+                    ht,
+                    gk,
+                    scale,
+                    i_v,
+                    i_nh,
+                    T,
+                    HV,
+                    K,
+                    V,
+                    BT,
+                    BV,
+                    NT,
+                    kg.dtype.element_ty,
+                    USE_INITIAL_STATE,
+                    STORE_FINAL_STATE,
+                    STATE_V_FIRST,
+                ),
             ),
             (
                 _kda_state_output_store_consumer,
@@ -652,16 +938,34 @@ def _kda_fwd_state_output(
 
     o = torch.zeros(B, T_actual, HV, V, device=kg.device, dtype=v.dtype)
 
-    h0_arg = initial_state if initial_state is not None else kg.new_empty(1, dtype=torch.float32)
-    ht_arg = final_state if final_state is not None else kg.new_empty(1, dtype=torch.float32)
+    h0_arg = (
+        initial_state
+        if initial_state is not None
+        else kg.new_empty(1, dtype=torch.float32)
+    )
+    ht_arg = (
+        final_state if final_state is not None else kg.new_empty(1, dtype=torch.float32)
+    )
 
-    grid = lambda meta: (triton.cdiv(V, meta['BV']), N * HV)
+    grid = lambda meta: (triton.cdiv(V, meta["BV"]), N * HV)
     _kda_fwd_state_output_kernel[grid](
-        kg=kg, v=v, beta=beta, gk=gk, Aqk=Aqk, Akk=Akk, o=o, ws=ws,
-        h0=h0_arg, ht=ht_arg,
+        kg=kg,
+        v=v,
+        beta=beta,
+        gk=gk,
+        Aqk=Aqk,
+        Akk=Akk,
+        o=o,
+        ws=ws,
+        h0=h0_arg,
+        ht=ht_arg,
         cu_seqlens=cu_seqlens,
         scale=scale,
-        T=T_actual, HV=HV, K=K, V=V, BT=BT,
+        T=T_actual,
+        HV=HV,
+        K=K,
+        V=V,
+        BT=BT,
         STATE_V_FIRST=state_v_first,
     )
 
@@ -724,7 +1028,9 @@ def _validate_chunk_kda_inputs(
     if beta.shape != (B, T, HV):
         raise ValueError(f"beta must have shape {(B, T, HV)}, got {tuple(beta.shape)}")
     if K not in (64, 128, 192, 256):
-        raise ValueError(f"chunk_kda TLE path requires K in {{64, 128, 192, 256}}, got {K}")
+        raise ValueError(
+            f"chunk_kda TLE path requires K in {{64, 128, 192, 256}}, got {K}"
+        )
     if V <= 0:
         raise ValueError(f"chunk_kda TLE path requires V > 0, got {V}")
     if HV < H or HV % H != 0:
@@ -753,7 +1059,9 @@ def _validate_chunk_kda_inputs(
     if dt_bias.device != q.device:
         raise ValueError("dt_bias must be on the same device as q")
     if dt_bias.numel() != HV * K:
-        raise ValueError(f"dt_bias.numel() must be HV*K={HV * K}, got {dt_bias.numel()}")
+        raise ValueError(
+            f"dt_bias.numel() must be HV*K={HV * K}, got {dt_bias.numel()}"
+        )
 
     if cu_seqlens is not None:
         if cu_seqlens.ndim != 1:
@@ -806,7 +1114,10 @@ def chunk_kda_fwd_infer(
         chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
 
     ws, Aqk, Akk, g_cumsum = _kda_fwd_intra(
-        q=q, k=k, g=g, beta=beta,
+        q=q,
+        k=k,
+        g=g,
+        beta=beta,
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
@@ -818,8 +1129,12 @@ def chunk_kda_fwd_infer(
 
     K = q.shape[-1]
     return _kda_fwd_state_output(
-        kg=ws[:, :, :, 2 * K:], v=v, beta=beta,
-        Akk=Akk, gk=g_cumsum, Aqk=Aqk,
+        kg=ws[:, :, :, 2 * K :],
+        v=v,
+        beta=beta,
+        Akk=Akk,
+        gk=g_cumsum,
+        Aqk=Aqk,
         ws=ws,
         scale=scale,
         initial_state=initial_state,

--- a/tests/test_FLA/test_chunk_kda.py
+++ b/tests/test_FLA/test_chunk_kda.py
@@ -130,10 +130,10 @@ def _reference_chunk_kda(
 
     cu_seqlens_list = cu_seqlens.detach().cpu().tolist()
     outs, final_states = [], []
-    for i, (start, end) in enumerate(
-        zip(cu_seqlens_list[:-1], cu_seqlens_list[1:])
-    ):
-        initial_state_i = initial_state[i : i + 1] if initial_state is not None else None
+    for i, (start, end) in enumerate(zip(cu_seqlens_list[:-1], cu_seqlens_list[1:])):
+        initial_state_i = (
+            initial_state[i : i + 1] if initial_state is not None else None
+        )
         out_i, final_state_i = _naive_recurrent_kda(
             q=q[:, start:end],
             k=k[:, start:end],
@@ -231,8 +231,7 @@ def _assert_close(
     abs_err = _abs_err(expected, actual)
     err_ratio = _err_ratio(expected, actual)
     msg = (
-        f"{name} diff: {abs_err:.6f} ratio: {err_ratio:.6f} "
-        f"(limit {ASSERT_RATIO})"
+        f"{name} diff: {abs_err:.6f} ratio: {err_ratio:.6f} " f"(limit {ASSERT_RATIO})"
     )
     if abs_err <= 1e-6:
         return

--- a/tests/test_FLA/test_chunk_kda.py
+++ b/tests/test_FLA/test_chunk_kda.py
@@ -1,0 +1,372 @@
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import flaggems_vllm
+from flaggems_vllm.ops.FLA import chunk_kda
+
+LOWER_BOUND = -5.0
+ASSERT_RATIO = 0.005
+
+
+def _cuda_available() -> bool:
+    return torch.cuda.is_available() and flaggems_vllm.device == "cuda"
+
+
+pytestmark = [
+    pytest.mark.chunk_kda,
+    pytest.mark.skipif(not _cuda_available(), reason="chunk_kda tests require CUDA"),
+]
+
+
+def _naive_kda_lowerbound_gate(
+    g: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor | None,
+    lower_bound: float,
+) -> torch.Tensor:
+    H, _ = g.shape[-2:]
+    g = g.float()
+    if dt_bias is not None:
+        g = g + dt_bias.view(H, -1)
+    return lower_bound * torch.sigmoid(A_log.view(H, 1).float().exp() * g)
+
+
+def _naive_recurrent_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float | None,
+    initial_state: torch.Tensor | None,
+    output_final_state: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    dtype = v.dtype
+    B, T, H, K = q.shape
+    HV, V = v.shape[2], v.shape[-1]
+    G = HV // H
+    if scale is None:
+        scale = K**-0.5
+
+    q, k, v, g, beta = map(lambda x: x.to(torch.float), [q, k, v, g, beta])
+    q = q.repeat_interleave(G, dim=2) * scale
+    k = k.repeat_interleave(G, dim=2)
+
+    state = k.new_zeros(B, HV, K, V).to(q)
+    if initial_state is not None:
+        state = state + initial_state
+
+    out = torch.zeros_like(v)
+    for i in range(T):
+        q_i, k_i, v_i, g_i, beta_i = q[:, i], k[:, i], v[:, i], g[:, i], beta[:, i]
+        state = state * g_i[..., None].exp()
+        state = state + torch.einsum(
+            "b h k, b h v -> b h k v",
+            beta_i[..., None] * k_i,
+            v_i - (k_i[..., None] * state).sum(-2),
+        )
+        out[:, i] = torch.einsum("b h k, b h k v -> b h v", q_i, state)
+
+    return out.to(dtype), state if output_final_state else None
+
+
+def _state_to_kv_layout(
+    state: torch.Tensor | None,
+    state_v_first: bool,
+) -> torch.Tensor | None:
+    if state is None:
+        return None
+    if state_v_first:
+        return state.transpose(-1, -2).contiguous()
+    return state
+
+
+def _state_from_kv_layout(
+    state: torch.Tensor | None,
+    state_v_first: bool,
+) -> torch.Tensor | None:
+    if state is None:
+        return None
+    if state_v_first:
+        return state.transpose(-1, -2).contiguous()
+    return state
+
+
+def _reference_chunk_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    scale: float,
+    initial_state: torch.Tensor | None,
+    output_final_state: bool,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_v_first: bool,
+    cu_seqlens: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    q = F.normalize(q.float(), p=2.0, dim=-1, eps=1e-6)
+    k = F.normalize(k.float(), p=2.0, dim=-1, eps=1e-6)
+    g = _naive_kda_lowerbound_gate(g, A_log, dt_bias, LOWER_BOUND)
+    beta = beta.float().sigmoid()
+
+    if cu_seqlens is None:
+        out, final_state = _naive_recurrent_kda(
+            q=q,
+            k=k,
+            v=v.float(),
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=_state_to_kv_layout(initial_state, state_v_first),
+            output_final_state=output_final_state,
+        )
+        return out.to(v.dtype), _state_from_kv_layout(final_state, state_v_first)
+
+    cu_seqlens_list = cu_seqlens.detach().cpu().tolist()
+    outs, final_states = [], []
+    for i, (start, end) in enumerate(
+        zip(cu_seqlens_list[:-1], cu_seqlens_list[1:])
+    ):
+        initial_state_i = initial_state[i : i + 1] if initial_state is not None else None
+        out_i, final_state_i = _naive_recurrent_kda(
+            q=q[:, start:end],
+            k=k[:, start:end],
+            v=v[:, start:end].float(),
+            g=g[:, start:end],
+            beta=beta[:, start:end],
+            scale=scale,
+            initial_state=_state_to_kv_layout(initial_state_i, state_v_first),
+            output_final_state=output_final_state,
+        )
+        outs.append(out_i)
+        if output_final_state:
+            final_states.append(_state_from_kv_layout(final_state_i, state_v_first))
+
+    out = torch.cat(outs, dim=1).to(v.dtype)
+    final_state = torch.cat(final_states, dim=0) if output_final_state else None
+    return out, final_state
+
+
+def _make_inputs(
+    *,
+    seq_lens: list[int],
+    H: int,
+    HV: int,
+    D: int,
+    scale: float,
+    dtype: torch.dtype,
+    state_v_first: bool,
+    normal_inputs: bool,
+    use_initial_state: bool,
+    output_final_state: bool,
+) -> tuple[tuple[torch.Tensor, ...], dict]:
+    device = flaggems_vllm.device
+    T = sum(seq_lens)
+    N = len(seq_lens)
+
+    rand = torch.randn if normal_inputs else torch.rand
+    q = rand(1, T, H, D, device=device, dtype=dtype)
+    k = rand(1, T, H, D, device=device, dtype=dtype)
+    v = rand(1, T, HV, D, device=device, dtype=dtype)
+    g = torch.randn(1, T, HV, D, device=device, dtype=dtype)
+    beta = torch.randn(1, T, HV, device=device, dtype=dtype)
+    A_log = torch.log(
+        torch.empty(HV, device=device, dtype=torch.float32).uniform_(1, 16)
+    )
+    dt_bias = torch.randn(HV * D, device=device, dtype=torch.float32)
+
+    initial_state = None
+    if use_initial_state:
+        initial_state = torch.randn(N, HV, D, D, device=device, dtype=torch.float32)
+
+    cu_seqlens = None
+    if N > 1:
+        cu_seqlens = torch.tensor(
+            [0] + torch.tensor(seq_lens).cumsum(0).tolist(),
+            device=device,
+            dtype=torch.long,
+        )
+
+    kwargs = {
+        "scale": scale,
+        "initial_state": initial_state,
+        "output_final_state": output_final_state,
+        "use_qk_l2norm_in_kernel": True,
+        "use_gate_in_kernel": True,
+        "use_beta_sigmoid_in_kernel": True,
+        "safe_gate": True,
+        "lower_bound": LOWER_BOUND,
+        "A_log": A_log,
+        "dt_bias": dt_bias,
+        "state_v_first": state_v_first,
+        "cu_seqlens": cu_seqlens,
+        "chunk_size": 16,
+    }
+    return (q, k, v, g, beta), kwargs
+
+
+def _abs_err(expected: torch.Tensor, actual: torch.Tensor) -> float:
+    return (expected.detach() - actual.detach()).flatten().abs().max().item()
+
+
+def _err_ratio(expected: torch.Tensor, actual: torch.Tensor) -> float:
+    err = (expected.detach() - actual.detach()).flatten().square().mean().sqrt().item()
+    base = expected.detach().flatten().square().mean().sqrt().item()
+    return err / (base + 1e-8)
+
+
+def _assert_close(
+    name: str,
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+) -> None:
+    actual = actual.float()
+    expected = expected.float()
+    abs_err = _abs_err(expected, actual)
+    err_ratio = _err_ratio(expected, actual)
+    msg = (
+        f"{name} diff: {abs_err:.6f} ratio: {err_ratio:.6f} "
+        f"(limit {ASSERT_RATIO})"
+    )
+    if abs_err <= 1e-6:
+        return
+    assert not torch.isnan(expected).any(), f"{name}: NaN detected in reference"
+    assert not torch.isnan(actual).any(), f"{name}: NaN detected in actual"
+    assert err_ratio < ASSERT_RATIO, msg
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(
+            {
+                "seq_lens": [32],
+                "H": 2,
+                "HV": 2,
+                "D": 64,
+                "scale": 0.1,
+                "dtype": torch.bfloat16,
+                "state_v_first": True,
+                "normal_inputs": False,
+                "use_initial_state": True,
+                "output_final_state": True,
+            },
+            id="dense",
+        ),
+        pytest.param(
+            {
+                "seq_lens": [32],
+                "H": 2,
+                "HV": 4,
+                "D": 64,
+                "scale": 0.1,
+                "dtype": torch.bfloat16,
+                "state_v_first": True,
+                "normal_inputs": False,
+                "use_initial_state": True,
+                "output_final_state": True,
+            },
+            id="dense_gqa",
+        ),
+        pytest.param(
+            {
+                "seq_lens": [13, 19, 16],
+                "H": 2,
+                "HV": 2,
+                "D": 64,
+                "scale": 0.1,
+                "dtype": torch.bfloat16,
+                "state_v_first": True,
+                "normal_inputs": True,
+                "use_initial_state": True,
+                "output_final_state": True,
+            },
+            id="varlen",
+        ),
+        pytest.param(
+            {
+                "seq_lens": [16],
+                "H": 2,
+                "HV": 2,
+                "D": 64,
+                "scale": 1 / math.sqrt(64),
+                "dtype": torch.bfloat16,
+                "state_v_first": True,
+                "normal_inputs": False,
+                "use_initial_state": False,
+                "output_final_state": False,
+            },
+            id="no_initial_state",
+        ),
+        pytest.param(
+            {
+                "seq_lens": [24],
+                "H": 2,
+                "HV": 2,
+                "D": 64,
+                "scale": 0.1,
+                "dtype": torch.bfloat16,
+                "state_v_first": False,
+                "normal_inputs": False,
+                "use_initial_state": True,
+                "output_final_state": True,
+            },
+            id="state_kv_layout",
+        ),
+        pytest.param(
+            {
+                "seq_lens": [32],
+                "H": 2,
+                "HV": 2,
+                "D": 64,
+                "scale": 0.1,
+                "dtype": torch.float16,
+                "state_v_first": True,
+                "normal_inputs": False,
+                "use_initial_state": True,
+                "output_final_state": True,
+            },
+            id="fp16_dense",
+        ),
+    ],
+)
+@torch.inference_mode()
+def test_chunk_kda_matches_torch_reference(case):
+    torch.manual_seed(42)
+    args, kwargs = _make_inputs(
+        seq_lens=case["seq_lens"],
+        H=case["H"],
+        HV=case["HV"],
+        D=case["D"],
+        scale=case["scale"],
+        dtype=case["dtype"],
+        state_v_first=case["state_v_first"],
+        normal_inputs=case["normal_inputs"],
+        use_initial_state=case["use_initial_state"],
+        output_final_state=case["output_final_state"],
+    )
+
+    actual, actual_final = chunk_kda(*args, **kwargs)
+    expected, expected_final = _reference_chunk_kda(
+        *args,
+        scale=kwargs["scale"],
+        initial_state=kwargs["initial_state"],
+        output_final_state=kwargs["output_final_state"],
+        A_log=kwargs["A_log"],
+        dt_bias=kwargs["dt_bias"],
+        state_v_first=kwargs["state_v_first"],
+        cu_seqlens=kwargs["cu_seqlens"],
+    )
+
+    _assert_close("o", actual, expected)
+    if case["output_final_state"]:
+        _assert_close("ht", actual_final, expected_final)
+    else:
+        assert actual_final is None
+        assert expected_final is None


### PR DESCRIPTION
**Fixed: `[8192, 96, 128]`**

| 方法 | mean | min | max | TLE 加速比 |
|---|---:|---:|---:|---:|
| flash_kda bf16 state | 1.4953 | 1.4885 | 1.5341 | 1.12x |
| flash_kda no state | 1.5104 | 1.5045 | 1.5281 | 1.13x |
| flash_kda fp32 state | 1.5131 | 1.5066 | 1.8940 | 1.14x |
| chunk_kda Triton | 3.5008 | 3.4790 | 3.9519 | 2.63x |
| chunk_kda TLE | 1.3328 | 1.3261 | 1.6372 | 1.00x |
| chunk_gated_delta_rule | 1.8911 | 1.8785 | 2.0311 | 1.42x |

**Varlen: `[1300, 547, 2048, 963, 271, 3063]`**

| 方法 | mean | min | max | TLE 加速比 |
|---|---:|---:|---:|---:|
| flash_kda bf16 state | 1.5313 | 1.4577 | 1.6114 | 1.18x |
| flash_kda no state | 1.5118 | 1.4485 | 1.6390 | 1.17x |
| flash_kda fp32 state | 1.5631 | 1.5008 | 1.6853 | 1.21x |
| chunk_kda Triton | 3.5256 | 3.5073 | 3.7198 | 2.73x |
| chunk_kda TLE | 1.2934 | 1.2875 | 1.4289 | 1.00x |
| chunk_gated_delta_rule | 1.8861 | 1.8770 | 2.0448 | 1.46x |

**Varlen: `[1024] * 8`**

| 方法 | mean | min | max | TLE 加速比 |
|---|---:|---:|---:|---:|
| flash_kda bf16 state | 1.3654 | 1.3556 | 1.4588 | 1.08x |
| flash_kda no state | 1.3358 | 1.3259 | 1.4078 | 1.06x |
| flash_kda fp32 state | 1.3822 | 1.3739 | 1.4600 | 1.09x |
| chunk_kda Triton | 3.4913 | 3.4789 | 3.7434 | 2.76x |
| chunk_kda TLE | 1.2631 | 1.2503 | 1.4449 | 1.00x |
| chunk_gated_delta_rule | 1.8729 | 1.8645 | 2.0084 | 1.48x |

**结论**

| 对比对象 | TLE 加速范围 |
|---|---:|
| vs flash_kda CUDA | 1.06x - 1.21x |
| vs chunk_kda Triton | 2.63x - 2.76x |
| vs chunk_gated_delta_rule | 1.42x - 1.48x |



原始数据：
╰─(tle) ⠠⠵ /root/workspace/bench_fwd.sh fla-3
shape=[8192,96,128] warmup=30 iters=200 repeats=5
  flash_kda (bf16 state) : mean=1.4953 ms, min=1.4885 ms, max=1.5341 ms
  flash_kda (no state)   : mean=1.5104 ms, min=1.5045 ms, max=1.5281 ms
  flash_kda (fp32 state) : mean=1.5131 ms, min=1.5066 ms, max=1.8940 ms
  chunk_kda : mean=3.5008 ms, min=3.4790 ms, max=3.9519 ms
  chunk_kda (tle)       : mean=1.3328 ms, min=1.3261 ms, max=1.6372 ms
  chunk_gated_delta_rule : mean=1.8911 ms, min=1.8785 ms, max=2.0311 ms
varlen shape=[8192,96,128] seq_lens=[1300, 547, 2048, 963, 271, 3063] warmup=30 iters=200 repeats=5
  flash_kda (bf16 state) : mean=1.5313 ms, min=1.4577 ms, max=1.6114 ms
  flash_kda (no state)   : mean=1.5118 ms, min=1.4485 ms, max=1.6390 ms
  flash_kda (fp32 state) : mean=1.5631 ms, min=1.5008 ms, max=1.6853 ms
  chunk_kda : mean=3.5256 ms, min=3.5073 ms, max=3.7198 ms
  chunk_kda (tle)       : mean=1.2934 ms, min=1.2875 ms, max=1.4289 ms
  chunk_gated_delta_rule : mean=1.8861 ms, min=1.8770 ms, max=2.0448 ms
varlen shape=[8192,96,128] seq_lens=[1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024] warmup=30 iters=200 repeats=5
  flash_kda (bf16 state) : mean=1.3654 ms, min=1.3556 ms, max=1.4588 ms
  flash_kda (no state)   : mean=1.3358 ms, min=1.3259 ms, max=1.4078 ms
  flash_kda (fp32 state) : mean=1.3822 ms, min=1.3739 ms, max=1.4600 ms
  chunk_kda : mean=3.4913 ms, min=3.4789 ms, max=3.7434 ms
  chunk_kda (tle)       : mean=1.2631 ms, min=1.2503 ms, max=1.4449 ms
  chunk_gated_delta_rule : mean=1.8729 ms, min=1.8645 ms, max=2.0084 ms

flaggem性能测试命令
```bash
CUDA_VISIBLE_DEVICES=2 PYTHONPATH=/root/workspace/FlagGems-vllm/src \
pytest -s benchmark/test_FLA/test_chunk_kda.py --warmup 30 --iter 200
```

flaggem正确性测试命令：
```bash
CUDA_VISIBLE_DEVICES=2 PYTHONPATH=/root/workspace/FlagGems-vllm/src \
pytest -s tests/test_FLA/test_chunk_kda.py
```