### PR TITLE
Add chunk gla operator

### DIFF
--- a/benchmark/test_FLA/test_chunk_gla_perf.py
+++ b/benchmark/test_FLA/test_chunk_gla_perf.py
@@ -1,0 +1,260 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn.functional as F
+import triton
+
+import flaggems_vllm
+from benchmark.conftest import Config
+from flaggems_vllm.ops.FLA.chunk_gla import chunk_gla as gems_chunk_gla
+
+# Try importing fla chunk_gla from installed package only.
+_HAS_FLA_CHUNK = False
+_fla_chunk_gla = None
+
+try:
+    from fla.ops.gla import chunk_gla as _fla_chunk_gla
+
+    _HAS_FLA_CHUNK = True
+except Exception:
+    _HAS_FLA_CHUNK = False
+
+
+def _torch_naive_recurrent_gla(
+    q,
+    k,
+    v,
+    g,
+    scale=None,
+    initial_state=None,
+    output_final_state=False,
+    state_v_first=False,
+    cu_seqlens=None,
+    cu_seqlens_cpu=None,
+):
+    del cu_seqlens_cpu
+
+    if state_v_first:
+        raise ValueError("state_v_first=True is not supported in torch naive baseline")
+    if cu_seqlens is not None:
+        raise ValueError("cu_seqlens is not supported in torch naive baseline")
+
+    dtype = q.dtype
+    qf = q.float()
+    kf = k.float()
+    vf = v.float()
+    gf = g.float()
+
+    B, T, H, K = qf.shape
+    V = vf.shape[-1]
+    if scale is None:
+        scale = K**-0.5
+
+    if initial_state is None:
+        h = torch.zeros((B, H, K, V), device=q.device, dtype=torch.float32)
+    else:
+        h = initial_state.float().clone()
+
+    out = torch.zeros((B, T, H, V), device=q.device, dtype=torch.float32)
+    for t in range(T):
+        qt = qf[:, t] * float(scale)
+        kt = kf[:, t]
+        vt = vf[:, t]
+        gt = gf[:, t].exp()
+        h = h * gt[..., None] + kt[..., None] * vt[..., None, :]
+        out[:, t] = (qt[..., None] * h).sum(-2)
+
+    final_state = h if output_final_state else None
+    return out.to(dtype), final_state
+
+
+def _fla_chunk_wrapper(
+    q,
+    k,
+    v,
+    g,
+    scale=None,
+    initial_state=None,
+    output_final_state=False,
+    state_v_first=False,
+    cu_seqlens=None,
+    cu_seqlens_cpu=None,
+):
+    del cu_seqlens_cpu
+    if not _HAS_FLA_CHUNK:
+        raise RuntimeError("fla chunk_gla is unavailable")
+    return _fla_chunk_gla(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        state_v_first=state_v_first,
+        cu_seqlens=cu_seqlens,
+    )
+
+
+def _load_test_reference_impl():
+    repo_root = Path(__file__).resolve().parents[2]
+    test_file = repo_root / "benchmark" / "test_FLA" / "test_chunk_gla_perf.py"
+    spec = importlib.util.spec_from_file_location("_chunk_gla_test_ref", str(test_file))
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Failed to load benchmark/test_FLA/test_chunk_gla_perf.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _check_torch_reference_consistency():
+    module = _load_test_reference_impl()
+    if hasattr(module, "_HAS_FLA_NAIVE"):
+        module._HAS_FLA_NAIVE = False
+    if not hasattr(module, "_reference_chunk_gla"):
+        print("[consistency] skip: _reference_chunk_gla not found")
+        return
+    dtype = torch.bfloat16
+    device = flaggems_vllm.device
+    B, T, H, D = 1, 16, 2, 32
+
+    torch.manual_seed(0)
+    q = torch.randn(B, T, H, D, device=device, dtype=dtype)
+    k = torch.randn(B, T, H, D, device=device, dtype=dtype)
+    v = torch.randn(B, T, H, D, device=device, dtype=dtype)
+    g = F.logsigmoid(torch.randn(B, T, H, D, device=device, dtype=dtype))
+    h0 = torch.randn(B, H, D, D, device=device, dtype=torch.float32)
+    scale = D**-0.5
+
+    out_a, ht_a = _torch_naive_recurrent_gla(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        scale=scale,
+        initial_state=h0,
+        output_final_state=True,
+    )
+    out_b, ht_b = module._reference_chunk_gla(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        scale=scale,
+        initial_state=h0,
+        output_final_state=True,
+        state_v_first=False,
+        cu_seqlens=None,
+    )
+
+    torch.testing.assert_close(out_a, out_b, atol=1e-6, rtol=1e-6)
+    torch.testing.assert_close(ht_a, ht_b, atol=1e-6, rtol=1e-6)
+    print(
+        "[consistency] torch naive == tests/test_FLA/test_chunk_gla.py reference: PASS"
+    )
+
+
+def _bench_ms(fn):
+    if Config.mode.value == "kernel":
+        return triton.testing.do_bench(
+            fn,
+            warmup=Config.warm_up,
+            rep=Config.repetition,
+            return_mode="median",
+        )
+
+    for _ in range(Config.warm_up):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(Config.repetition):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / Config.repetition
+
+
+def _build_inputs(B, T, H, D, dtype):
+    device = flaggems_vllm.device
+    q = torch.randn(B, T, H, D, device=device, dtype=dtype)
+    k = torch.randn(B, T, H, D, device=device, dtype=dtype)
+    v = torch.randn(B, T, H, D, device=device, dtype=dtype)
+    g = F.logsigmoid(torch.randn(B, T, H, D, device=device, dtype=dtype))
+    kwargs = {
+        "scale": D**-0.5,
+        "initial_state": None,
+        "output_final_state": False,
+        "state_v_first": False,
+        "cu_seqlens": None,
+        "cu_seqlens_cpu": None,
+    }
+    return q, k, v, g, kwargs
+
+
+@pytest.mark.skipif(
+    flaggems_vllm.device != "cuda", reason="benchmark requires CUDA device"
+)
+@pytest.mark.chunk_gla
+def test_perf_chunk_gla():
+    _check_torch_reference_consistency()
+
+    shapes = [
+        # small / correctness-friendly
+        (2, 512, 8, 64),
+        (4, 1024, 8, 64),
+        # small batch + medium / long context
+        (1, 2048, 8, 64),
+        (1, 4096, 16, 64),
+    ]
+    dtypes = [
+        torch.float32,
+        torch.float16,
+        torch.bfloat16,
+    ]
+
+    print("\n[chunk_gla 3-way benchmark]")
+    print(f"mode={Config.mode.value} warmup={Config.warm_up} iter={Config.repetition}")
+    if _HAS_FLA_CHUNK:
+        print("provider: torch_naive vs fla_chunk vs flaggems_chunk")
+        print(
+            f"{'B':>3} {'T':>6} {'H':>4} {'D':>4} {'dtype':>8} "
+            f"{'torch(ms)':>12} {'fla(ms)':>10} {'gems(ms)':>10} "
+            f"{'gems/torch':>11} {'gems/fla':>10}"
+        )
+    else:
+        print("provider: torch_naive vs flaggems_chunk (fla_chunk unavailable)")
+        print(
+            f"{'B':>3} {'T':>6} {'H':>4} {'D':>4} {'dtype':>8} "
+            f"{'torch(ms)':>12} {'gems(ms)':>10} {'gems/torch':>11}"
+        )
+
+    for dtype in dtypes:
+        print("精度：", dtype)
+        for B, T, H, D in shapes:
+            q, k, v, g, kwargs = _build_inputs(B, T, H, D, dtype)
+
+            ms_torch = _bench_ms(
+                lambda: _torch_naive_recurrent_gla(q, k, v, g, **kwargs)
+            )
+            ms_fla = None
+            if _HAS_FLA_CHUNK:
+                ms_fla = _bench_ms(lambda: _fla_chunk_wrapper(q, k, v, g, **kwargs))
+            ms_gems = _bench_ms(lambda: gems_chunk_gla(q, k, v, g, **kwargs))
+
+            speedup_vs_torch = ms_torch / ms_gems if ms_gems > 0 else float("inf")
+            if _HAS_FLA_CHUNK and ms_fla is not None:
+                speedup_vs_fla = ms_fla / ms_gems if ms_gems > 0 else float("inf")
+                print(
+                    f"{B:>3} {T:>6} {H:>4} {D:>4} {str(dtype).split('.')[-1]:>8} "
+                    f"{ms_torch:>12.3f} {ms_fla:>10.3f} {ms_gems:>10.3f} "
+                    f"{speedup_vs_torch:>11.2f}x {speedup_vs_fla:>10.2f}x"
+                )
+            else:
+                print(
+                    f"{B:>3} {T:>6} {H:>4} {D:>4} {str(dtype).split('.')[-1]:>8} "
+                    f"{ms_torch:>12.3f} {ms_gems:>10.3f} {speedup_vs_torch:>11.2f}x"
+                )

--- a/src/flaggems_vllm/ops/FLA/chunk_gla.py
+++ b/src/flaggems_vllm/ops/FLA/chunk_gla.py
@@ -10,15 +10,19 @@ import triton
 import triton.language as tl
 
 from flaggems_vllm.ops.FLA.chunk_h import chunk_bwd_dh, chunk_fwd_h
-from flaggems_vllm.ops.FLA.cumsum import chunk_local_cumsum
+from flaggems_vllm.ops.FLA.cumsum_gla import chunk_local_cumsum
 from flaggems_vllm.ops.FLA.index import prepare_chunk_indices
-from flaggems_vllm.ops.FLA.triton_ops_helper import exp
 from flaggems_vllm.ops.FLA.utils import check_shared_mem, input_guard
 
 RCP_LN2 = 1.4426950216
 
 BK_LIST = [32, 64] if check_shared_mem() else [16, 32]
 BV_LIST = [64, 128] if check_shared_mem("ampere") else [16, 32]
+
+
+@triton.jit
+def exp2(x):
+    return tl.math.exp2(x.to(tl.float32))
 
 
 @triton.heuristics(
@@ -29,7 +33,7 @@ BV_LIST = [64, 128] if check_shared_mem("ampere") else [16, 32]
 @triton.autotune(
     configs=[
         triton.Config(
-            {'BK': BK},
+            {"BK": BK},
             num_warps=num_warps,
             num_stages=num_stages,
         )
@@ -37,7 +41,7 @@ BV_LIST = [64, 128] if check_shared_mem("ampere") else [16, 32]
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BC'],
+    key=["BC"],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_fwd_A_kernel_intra_sub_inter(
@@ -120,11 +124,11 @@ def chunk_gla_fwd_A_kernel_intra_sub_inter(
         # [BC, BK]
         b_q = tl.load(p_q, boundary_check=(0, 1))
         b_g = tl.load(p_g, boundary_check=(0, 1))
-        b_qg = b_q * exp(b_g - b_gn[None, :]) * scale
+        b_qg = b_q * exp2(b_g - b_gn[None, :]) * scale
         # [BK, BC]
         b_k = tl.load(p_k, boundary_check=(0, 1))
         b_gk = tl.load(p_gk, boundary_check=(0, 1))
-        b_kg = b_k * exp(b_gn[:, None] - b_gk)
+        b_kg = b_k * exp2(b_gn[:, None] - b_gk)
         # [BC, BC] using tf32 to improve precision here.
         b_A += tl.dot(b_qg, b_kg)
 
@@ -154,7 +158,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_inter(
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3]
     ],
-    key=['BK', 'BT'],
+    key=["BK", "BT"],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_fwd_A_kernel_intra_sub_intra(
@@ -213,17 +217,17 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra(
         A, (T, BT), (H * BT, 1), (i_t * BT + i_i * BC, i_j * BC), (BC, BC), (1, 0)
     )
 
-    b_q = tl.load(p_q, boundary_check=(0, 1)).to(tl.float32)
-    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_g = tl.load(p_g, boundary_check=(0, 1))
     b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
     b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
 
+    # Use tile dot to avoid a large [BC, BC, BK] temporary that can hurt occupancy.
     g_max = tl.max(b_g, axis=0)
     g_min = tl.min(b_g, axis=0)
     g_mid = 0.5 * (g_max + g_min)
-    b_qg = b_q * exp(b_g - g_mid[None, :])
-    b_kg = b_k * exp(-(b_gk - g_mid[None, :]))
-
+    b_qg = b_q * exp2(b_g - g_mid[None, :])
+    b_kg = b_k * exp2(-b_gk + g_mid[None, :])
     b_A = tl.dot(b_qg, tl.trans(b_kg)) * scale
     b_A = tl.where(m_s, b_A, 0.0)
     tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
@@ -235,11 +239,8 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra(
     }
 )
 @triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=num_warps)
-        for num_warps in [1, 2, 4, 8]
-    ],
-    key=['BC', 'BK'],
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4, 8]],
+    key=["BC", "BK"],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
@@ -281,8 +282,6 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
         return
 
     m_s = tl.arange(0, BC)[:, None] >= tl.arange(0, BC)[None, :]
-    o_k = i_k * BK + tl.arange(0, BK)
-    m_k = o_k < K
 
     q += (bos * H + i_h) * K
     k += (bos * H + i_h) * K
@@ -305,16 +304,16 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
         A, (T, BC), (H * BC, 1), (i_t * BT + i_i * BC, 0), (BC, BC), (1, 0)
     )
 
-    p_gn = g + (i_t * BT + i_i * BC) * H * K + o_k
-    b_gn = tl.load(p_gn, mask=m_k, other=0)
-
     b_q = tl.load(p_q, boundary_check=(0, 1))
     b_g = tl.load(p_g, boundary_check=(0, 1))
     b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
     b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
 
-    b_qg = b_q * exp(b_g - b_gn[None, :])
-    b_kg = b_k * exp(b_gn[None, :] - b_gk)
+    g_max = tl.max(b_g, axis=0)
+    g_min = tl.min(b_g, axis=0)
+    g_mid = 0.5 * (g_max + g_min)
+    b_qg = b_q * exp2(b_g - g_mid[None, :])
+    b_kg = b_k * exp2(-b_gk + g_mid[None, :])
     b_A = tl.dot(b_qg, tl.trans(b_kg)) * scale
     b_A = tl.where(m_s, b_A, 0.0)
     tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
@@ -332,7 +331,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
         triton.Config({}, num_warps=4),
         triton.Config({}, num_warps=8),
     ],
-    key=['BC'],
+    key=["BC"],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
@@ -396,7 +395,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
 @triton.autotune(
     configs=[
         triton.Config(
-            {'BK': BK, 'BV': BV},
+            {"BK": BK, "BV": BV},
             num_warps=num_warps,
             num_stages=num_stages,
         )
@@ -405,7 +404,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'HV', 'STATE_V_FIRST'],
+    key=["BT", "HV", "STATE_V_FIRST"],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_fwd_kernel_o(
@@ -478,7 +477,7 @@ def chunk_gla_fwd_kernel_o(
         # [BT, BK]
         b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
         # [BT, BK]
-        b_qg = (b_q * exp(b_g)).to(b_q.dtype)
+        b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
         b_h = tl.load(p_h, boundary_check=(0, 1))
         if i_k >= 0:
             if STATE_V_FIRST:
@@ -517,7 +516,7 @@ def chunk_gla_fwd_kernel_o(
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BK', 'NC', 'BT'],
+    key=["BK", "NC", "BT"],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_bwd_kernel_intra(
@@ -601,12 +600,12 @@ def chunk_gla_bwd_kernel_intra(
             # [BC, BK]
             b_k = tl.load(p_k, boundary_check=(0, 1))
             b_gk = tl.load(p_gk, boundary_check=(0, 1))
-            b_kg = b_k * exp(b_gn[None, :] - b_gk)
+            b_kg = b_k * exp2(b_gn[None, :] - b_gk)
             # [BC, BC]
             b_dA = tl.load(p_dA, boundary_check=(0, 1))
 
             b_dq += tl.dot(b_dA, b_kg)
-        b_dq *= exp(b_g - b_gn[None, :])
+        b_dq *= exp2(b_g - b_gn[None, :])
     o_i = tl.arange(0, BC)
     m_dA = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
     o_dA = (
@@ -637,7 +636,7 @@ def chunk_gla_bwd_kernel_intra(
         # [BC, BK]
         # (SY 09/17) important to not use bf16 here to have a good precision.
         b_dq += tl.where(
-            m_i, b_dA[:, None] * b_kj[None, :] * exp(b_g - b_gkj[None, :]), 0.0
+            m_i, b_dA[:, None] * b_kj[None, :] * exp2(b_g - b_gkj[None, :]), 0.0
         )
         p_kj += H * K
         p_gkj += H * K
@@ -684,13 +683,13 @@ def chunk_gla_bwd_kernel_intra(
             # [BC, BK]
             b_q = tl.load(p_q, boundary_check=(0, 1))
             b_gq = tl.load(p_gq, boundary_check=(0, 1))
-            b_qg = b_q * tl.where(m_j[:, None], exp(b_gq - b_gn[None, :]), 0)
+            b_qg = b_q * tl.where(m_j[:, None], exp2(b_gq - b_gn[None, :]), 0)
             # [BC, BC]
             b_dA = tl.load(p_dA, boundary_check=(0, 1))
             # [BC, BK]
             # (SY 09/17) important to not use bf16 here to have a good precision.
             b_dk += tl.dot(b_dA, b_qg)
-        b_dk *= exp(b_gn[None, :] - b_g)
+        b_dk *= exp2(b_gn[None, :] - b_g)
     o_dA = (
         bos * H * BT
         + (i_t * BT + i_i * BC) * H * BT
@@ -717,7 +716,7 @@ def chunk_gla_bwd_kernel_intra(
         # [BC, BK]
         m_i = o_i[:, None] <= j
         b_dk += tl.where(
-            m_i, b_dA[:, None] * b_qj[None, :] * exp(b_gqj[None, :] - b_g), 0.0
+            m_i, b_dA[:, None] * b_qj[None, :] * exp2(b_gqj[None, :] - b_g), 0.0
         )
         p_qj += H * K
         p_gqj += H * K
@@ -739,7 +738,7 @@ def chunk_gla_bwd_kernel_intra(
         for num_warps in [1, 2, 4]
         for num_stages in [2, 3, 4]
     ],
-    key=['BV', 'BT'],
+    key=["BV", "BT"],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_bwd_kernel_dA(
@@ -808,7 +807,7 @@ def chunk_gla_bwd_kernel_dA(
 @triton.autotune(
     configs=[
         triton.Config(
-            {'BK': BK, 'BV': BV},
+            {"BK": BK, "BV": BV},
             num_warps=num_warps,
             num_stages=num_stages,
         )
@@ -817,7 +816,7 @@ def chunk_gla_bwd_kernel_dA(
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'STATE_V_FIRST'],
+    key=["BT", "STATE_V_FIRST"],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_bwd_kernel_dv(
@@ -927,7 +926,7 @@ def chunk_gla_bwd_kernel_dv(
         b_gk = tl.load(p_gk, boundary_check=(0, 1))
         b_dh = tl.load(p_dh, boundary_check=(0, 1))
 
-        b_gn = exp(tl.load(p_gn, mask=m_k, other=0)[None, :] - b_gk)
+        b_gn = exp2(tl.load(p_gn, mask=m_k, other=0)[None, :] - b_gk)
         b_k = (b_k * b_gn).to(b_k.dtype)
         # [BT, BV]
         # (SY 09/17) it is ok to have bf16 interchunk gradient contribution here
@@ -944,7 +943,7 @@ def chunk_gla_bwd_kernel_dv(
 @triton.autotune(
     configs=[
         triton.Config(
-            {'BK': BK, 'BV': BV},
+            {"BK": BK, "BV": BV},
             num_warps=num_warps,
             num_stages=num_stages,
         )
@@ -953,7 +952,7 @@ def chunk_gla_bwd_kernel_dv(
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'STATE_V_FIRST'],
+    key=["BT", "STATE_V_FIRST"],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_bwd_kernel_inter(
@@ -1059,10 +1058,10 @@ def chunk_gla_bwd_kernel_inter(
         b_dq += tl.dot(b_do, b_h.to(b_do.dtype))
         b_dk += tl.dot(b_v, b_dh.to(b_v.dtype))
 
-    b_dgk *= exp(b_gn)
+    b_dgk *= exp2(b_gn)
     b_dq *= scale
-    b_dq = b_dq * exp(b_gk)
-    b_dk = b_dk * exp(b_gn[None, :] - b_gk)
+    b_dq = b_dq * exp2(b_gk)
+    b_dk = b_dk * exp2(b_gn[None, :] - b_gk)
     p_q = tl.make_block_ptr(
         q, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
     )

--- a/src/flaggems_vllm/ops/FLA/chunk_gla.py
+++ b/src/flaggems_vllm/ops/FLA/chunk_gla.py
@@ -117,11 +117,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra(
     if i_t * BT + i_i * BC >= T:
         return
 
-    o_i = tl.arange(0, BC)
-    o_k = tl.arange(0, BK)
-    o_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) * H*BT + i_j * BC
-    m_k = o_k < K
-    m_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
+    m_s = tl.arange(0, BC)[:, None] >= tl.arange(0, BC)[None, :]
 
     q += (bos * H + i_h) * K
     k += (bos * H + i_h) * K
@@ -130,23 +126,24 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra(
 
     p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT + i_i * BC, 0), (BC, BK), (1, 0))
     p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_i * BC, 0), (BC, BK), (1, 0))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_g = tl.load(p_g, boundary_check=(0, 1))
+    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT + i_j * BC, 0), (BC, BK), (1, 0))
+    p_gk = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_j * BC, 0), (BC, BK), (1, 0))
+    p_A = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * BT + i_i * BC, i_j * BC), (BC, BC), (1, 0))
 
-    p_k = k + (i_t * BT + i_j * BC) * H*K + o_k
-    p_gk = g + (i_t * BT + i_j * BC) * H*K + o_k
+    b_q = tl.load(p_q, boundary_check=(0, 1)).to(tl.float32)
+    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+    b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
+    b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
 
-    for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
-        b_k = tl.load(p_k, mask=m_k, other=0).to(tl.float32)
-        b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
-        b_A = tl.sum(b_q * b_k[None, :] * exp(b_g - b_gk[None, :]), 1) * scale
-        tl.store(A + o_A + j, b_A, mask=m_A)
-        p_k += H*K
-        p_gk += H*K
-
-    tl.debug_barrier()
-    b_A = tl.zeros([BC, BC], dtype=tl.float32)
-    tl.store(A + o_A[:, None] + o_i, b_A, mask=m_A[:, None] & (o_i[:, None] < o_i))
+    g_max = tl.max(b_g, axis=0)
+    g_min = tl.min(b_g, axis=0)
+    g_mid = 0.5 * (g_max + g_min)
+    b_qg = b_q * exp(b_g - g_mid[None, :])
+    b_kg = b_k * exp(-(b_gk - g_mid[None, :]))
+   
+    b_A = tl.dot(b_qg, tl.trans(b_kg)) * scale
+    b_A = tl.where(m_s, b_A, 0.)
+    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
 
 
 @triton.heuristics({
@@ -187,11 +184,9 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
     if i_t * BT + i_i * BC >= T:
         return
 
-    o_i = tl.arange(0, BC)
+    m_s = tl.arange(0, BC)[:, None] >= tl.arange(0, BC)[None, :]
     o_k = i_k * BK + tl.arange(0, BK)
-    o_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) * H*BC
     m_k = o_k < K
-    m_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
 
     q += (bos * H + i_h) * K
     k += (bos * H + i_h) * K
@@ -200,22 +195,23 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
 
     p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
     p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
+    p_gk = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
+    p_A = tl.make_block_ptr(A, (T, BC), (H*BC, 1), (i_t * BT + i_i * BC, 0), (BC, BC), (1, 0))
+
+    p_gn = g + (i_t * BT + i_i * BC) * H*K + o_k
+    b_gn = tl.load(p_gn, mask=m_k, other=0)
+
     b_q = tl.load(p_q, boundary_check=(0, 1))
     b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
+    b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
 
-    p_k = k + (i_t * BT + i_j * BC) * H*K + o_k
-    p_gk = g + (i_t * BT + i_j * BC) * H*K + o_k
-    for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
-        b_k = tl.load(p_k, mask=m_k, other=0).to(tl.float32)
-        b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
-        b_A = tl.sum(b_q * b_k[None, :] * exp(b_g - b_gk[None, :]), 1) * scale
-        tl.store(A + o_A + j, b_A, mask=m_A)
-        p_k += H*K
-        p_gk += H*K
-
-    tl.debug_barrier()
-    b_A = tl.zeros([BC, BC], dtype=tl.float32)
-    tl.store(A + o_A[:, None] + o_i, b_A, mask=m_A[:, None] & (o_i[:, None] < o_i))
+    b_qg = b_q * exp(b_g - b_gn[None, :])
+    b_kg = b_k * exp(b_gn[None, :] - b_gk)
+    b_A = tl.dot(b_qg, tl.trans(b_kg)) * scale
+    b_A = tl.where(m_s, b_A, 0.)
+    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
 
 
 @triton.heuristics({

--- a/src/flaggems_vllm/ops/FLA/chunk_gla.py
+++ b/src/flaggems_vllm/ops/FLA/chunk_gla.py
@@ -8,22 +8,25 @@
 import torch
 import triton
 import triton.language as tl
-from flaggems_vllm.ops.FLA.index import prepare_chunk_indices
+
 from flaggems_vllm.ops.FLA.chunk_h import chunk_bwd_dh, chunk_fwd_h
 from flaggems_vllm.ops.FLA.cumsum import chunk_local_cumsum
+from flaggems_vllm.ops.FLA.index import prepare_chunk_indices
 from flaggems_vllm.ops.FLA.triton_ops_helper import exp
 from flaggems_vllm.ops.FLA.utils import check_shared_mem, input_guard
 
 RCP_LN2 = 1.4426950216
 
 BK_LIST = [32, 64] if check_shared_mem() else [16, 32]
-BV_LIST = [64, 128] if check_shared_mem('ampere') else [16, 32]
+BV_LIST = [64, 128] if check_shared_mem("ampere") else [16, 32]
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
-@triton.jit(do_not_specialize=['T'])
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T"])
 def chunk_gla_fwd_A_kernel_intra_sub_inter(
     q,
     k,
@@ -45,8 +48,12 @@ def chunk_gla_fwd_A_kernel_intra_sub_inter(
     i_b, i_h = i_bh // H, i_bh % H
     i_i, i_j = i_c // NC, i_c % NC
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -61,11 +68,39 @@ def chunk_gla_fwd_A_kernel_intra_sub_inter(
         o_k = i_k * BK + tl.arange(0, BK)
         m_k = o_k < K
 
-        p_q = tl.make_block_ptr(q + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-        p_g = tl.make_block_ptr(g + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-        p_k = tl.make_block_ptr(k + (bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT + i_j * BC), (BK, BC), (0, 1))
-        p_gk = tl.make_block_ptr(g + (bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT + i_j * BC), (BK, BC), (0, 1))
-        p_gn = g + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
+        p_q = tl.make_block_ptr(
+            q + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT + i_i * BC, i_k * BK),
+            (BC, BK),
+            (1, 0),
+        )
+        p_g = tl.make_block_ptr(
+            g + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT + i_i * BC, i_k * BK),
+            (BC, BK),
+            (1, 0),
+        )
+        p_k = tl.make_block_ptr(
+            k + (bos * H + i_h) * K,
+            (K, T),
+            (1, H * K),
+            (i_k * BK, i_t * BT + i_j * BC),
+            (BK, BC),
+            (0, 1),
+        )
+        p_gk = tl.make_block_ptr(
+            g + (bos * H + i_h) * K,
+            (K, T),
+            (1, H * K),
+            (i_k * BK, i_t * BT + i_j * BC),
+            (BK, BC),
+            (0, 1),
+        )
+        p_gn = g + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
 
         # [BK,]
         b_gn = tl.load(p_gn, mask=m_k, other=0)
@@ -80,14 +115,23 @@ def chunk_gla_fwd_A_kernel_intra_sub_inter(
         # [BC, BC] using tf32 to improve precision here.
         b_A += tl.dot(b_qg, b_kg)
 
-    p_A = tl.make_block_ptr(A + (bos*H + i_h)*BT, (T, BT), (H*BT, 1), (i_t * BT + i_i * BC, i_j * BC), (BC, BC), (1, 0))
+    p_A = tl.make_block_ptr(
+        A + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT + i_i * BC, i_j * BC),
+        (BC, BC),
+        (1, 0),
+    )
     tl.store(p_A, b_A.to(A.dtype.element_ty), boundary_check=(0, 1))
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
-@triton.jit(do_not_specialize=['T'])
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T"])
 def chunk_gla_fwd_A_kernel_intra_sub_intra(
     q,
     k,
@@ -108,8 +152,12 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra(
     i_b, i_h = i_bh // H, i_bh % H
     i_j = i_i
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -124,11 +172,21 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra(
     g += (bos * H + i_h) * K
     A += (bos * H + i_h) * BT
 
-    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT + i_i * BC, 0), (BC, BK), (1, 0))
-    p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_i * BC, 0), (BC, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT + i_j * BC, 0), (BC, BK), (1, 0))
-    p_gk = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_j * BC, 0), (BC, BK), (1, 0))
-    p_A = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * BT + i_i * BC, i_j * BC), (BC, BC), (1, 0))
+    p_q = tl.make_block_ptr(
+        q, (T, K), (H * K, 1), (i_t * BT + i_i * BC, 0), (BC, BK), (1, 0)
+    )
+    p_g = tl.make_block_ptr(
+        g, (T, K), (H * K, 1), (i_t * BT + i_i * BC, 0), (BC, BK), (1, 0)
+    )
+    p_k = tl.make_block_ptr(
+        k, (T, K), (H * K, 1), (i_t * BT + i_j * BC, 0), (BC, BK), (1, 0)
+    )
+    p_gk = tl.make_block_ptr(
+        g, (T, K), (H * K, 1), (i_t * BT + i_j * BC, 0), (BC, BK), (1, 0)
+    )
+    p_A = tl.make_block_ptr(
+        A, (T, BT), (H * BT, 1), (i_t * BT + i_i * BC, i_j * BC), (BC, BC), (1, 0)
+    )
 
     b_q = tl.load(p_q, boundary_check=(0, 1)).to(tl.float32)
     b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
@@ -140,16 +198,18 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra(
     g_mid = 0.5 * (g_max + g_min)
     b_qg = b_q * exp(b_g - g_mid[None, :])
     b_kg = b_k * exp(-(b_gk - g_mid[None, :]))
-   
+
     b_A = tl.dot(b_qg, tl.trans(b_kg)) * scale
-    b_A = tl.where(m_s, b_A, 0.)
+    b_A = tl.where(m_s, b_A, 0.0)
     tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
-@triton.jit(do_not_specialize=['T'])
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T"])
 def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
     q,
     k,
@@ -173,8 +233,12 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
     i_t, i_i = i_tc // NC, i_tc % NC
     i_j = i_i
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
         all = T
         T = eos - bos
     else:
@@ -193,13 +257,23 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
     g += (bos * H + i_h) * K
     A += ((i_k * all + bos) * H + i_h) * BC
 
-    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-    p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-    p_gk = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-    p_A = tl.make_block_ptr(A, (T, BC), (H*BC, 1), (i_t * BT + i_i * BC, 0), (BC, BC), (1, 0))
+    p_q = tl.make_block_ptr(
+        q, (T, K), (H * K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0)
+    )
+    p_g = tl.make_block_ptr(
+        g, (T, K), (H * K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0)
+    )
+    p_k = tl.make_block_ptr(
+        k, (T, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0)
+    )
+    p_gk = tl.make_block_ptr(
+        g, (T, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0)
+    )
+    p_A = tl.make_block_ptr(
+        A, (T, BC), (H * BC, 1), (i_t * BT + i_i * BC, 0), (BC, BC), (1, 0)
+    )
 
-    p_gn = g + (i_t * BT + i_i * BC) * H*K + o_k
+    p_gn = g + (i_t * BT + i_i * BC) * H * K + o_k
     b_gn = tl.load(p_gn, mask=m_k, other=0)
 
     b_q = tl.load(p_q, boundary_check=(0, 1))
@@ -210,14 +284,16 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
     b_qg = b_q * exp(b_g - b_gn[None, :])
     b_kg = b_k * exp(b_gn[None, :] - b_gk)
     b_A = tl.dot(b_qg, tl.trans(b_kg)) * scale
-    b_A = tl.where(m_s, b_A, 0.)
+    b_A = tl.where(m_s, b_A, 0.0)
     tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
-@triton.jit(do_not_specialize=['T'])
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T"])
 def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
     A,
     A2,
@@ -234,8 +310,12 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
     i_t, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
         all = T
         T = eos - bos
     else:
@@ -247,16 +327,32 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
 
     b_A = tl.zeros([BC, BC], dtype=tl.float32)
     for i_k in range(0, NK):
-        p_A = tl.make_block_ptr(A + (i_k*all+bos)*H*BC+i_h*BC, (T, BC), (H*BC, 1), (i_t*BT + i_c*BC, 0), (BC, BC), (1, 0))
+        p_A = tl.make_block_ptr(
+            A + (i_k * all + bos) * H * BC + i_h * BC,
+            (T, BC),
+            (H * BC, 1),
+            (i_t * BT + i_c * BC, 0),
+            (BC, BC),
+            (1, 0),
+        )
         b_A += tl.load(p_A, boundary_check=(0, 1))
-    p_A2 = tl.make_block_ptr(A2 + (bos*H+i_h)*BT, (T, BT), (H*BT, 1), (i_t * BT + i_c * BC, i_c * BC), (BC, BC), (1, 0))
+    p_A2 = tl.make_block_ptr(
+        A2 + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT + i_c * BC, i_c * BC),
+        (BC, BC),
+        (1, 0),
+    )
     tl.store(p_A2, b_A.to(A2.dtype.element_ty), boundary_check=(0, 1))
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
-@triton.jit(do_not_specialize=['T'])
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T"])
 def chunk_gla_fwd_kernel_o(
     q,
     v,
@@ -283,8 +379,12 @@ def chunk_gla_fwd_kernel_o(
     i_h = i_hv // (HV // H)
     if IS_VARLEN:
         i_tg = i_t.to(tl.int64)
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int64)
         T = eos - bos
         NT = tl.cdiv(T, BT)
     else:
@@ -303,12 +403,20 @@ def chunk_gla_fwd_kernel_o(
 
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
     for i_k in range(tl.cdiv(K, BK)):
-        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_g = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_q = tl.make_block_ptr(
+            q, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+        )
+        p_g = tl.make_block_ptr(
+            g, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+        )
         if STATE_V_FIRST:
-            p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            p_h = tl.make_block_ptr(
+                h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
+            )
         else:
-            p_h = tl.make_block_ptr(h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            p_h = tl.make_block_ptr(
+                h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
+            )
 
         # [BT, BK]
         b_q = tl.load(p_q, boundary_check=(0, 1))
@@ -323,22 +431,28 @@ def chunk_gla_fwd_kernel_o(
             else:
                 b_o += tl.dot(b_qg, b_h.to(b_qg.dtype))
     b_o *= scale
-    p_v = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_o = tl.make_block_ptr(o, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_A = tl.make_block_ptr(A, (T, BT), (HV*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_v = tl.make_block_ptr(
+        v, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+    )
+    p_o = tl.make_block_ptr(
+        o, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+    )
+    p_A = tl.make_block_ptr(A, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
     # [BT, BV]
     b_v = tl.load(p_v, boundary_check=(0, 1))
     # [BT, BT]
     b_A = tl.load(p_A, boundary_check=(0, 1))
-    b_A = tl.where(m_s, b_A, 0.).to(b_v.dtype)
+    b_A = tl.where(m_s, b_A, 0.0).to(b_v.dtype)
     b_o += tl.dot(b_A, b_v)
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
-@triton.jit(do_not_specialize=['T'])
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T"])
 def chunk_gla_bwd_kernel_intra(
     q,
     k,
@@ -361,8 +475,12 @@ def chunk_gla_bwd_kernel_intra(
     i_b, i_h = i_bh // H, i_bh % H
     i_k, i_i = i_kc // NC, i_kc % NC
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
     T = eos - bos
@@ -372,19 +490,47 @@ def chunk_gla_bwd_kernel_intra(
     o_k = i_k * BK + tl.arange(0, BK)
     m_k = o_k < K
 
-    p_g = tl.make_block_ptr(g + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+    p_g = tl.make_block_ptr(
+        g + (bos * H + i_h) * K,
+        (T, K),
+        (H * K, 1),
+        (i_t * BT + i_i * BC, i_k * BK),
+        (BC, BK),
+        (1, 0),
+    )
     # [BC, BK]
     b_g = tl.load(p_g, boundary_check=(0, 1))
 
     b_dq = tl.zeros([BC, BK], dtype=tl.float32)
     if i_i > 0:
-        p_gn = g + (bos + i_t * BT + i_i * BC) * H*K + i_h*K + o_k
+        p_gn = g + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
         # [BK,]
         b_gn = tl.load(p_gn, mask=m_k, other=0)
         for i_j in range(0, i_i):
-            p_k = tl.make_block_ptr(k+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k * BK), (BC, BK), (1, 0))
-            p_gk = tl.make_block_ptr(g+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k * BK), (BC, BK), (1, 0))
-            p_dA = tl.make_block_ptr(dA+(bos*H+i_h)*BT, (T, BT), (H*BT, 1), (i_t*BT+i_i*BC, i_j * BC), (BC, BC), (1, 0))
+            p_k = tl.make_block_ptr(
+                k + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT + i_j * BC, i_k * BK),
+                (BC, BK),
+                (1, 0),
+            )
+            p_gk = tl.make_block_ptr(
+                g + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT + i_j * BC, i_k * BK),
+                (BC, BK),
+                (1, 0),
+            )
+            p_dA = tl.make_block_ptr(
+                dA + (bos * H + i_h) * BT,
+                (T, BT),
+                (H * BT, 1),
+                (i_t * BT + i_i * BC, i_j * BC),
+                (BC, BC),
+                (1, 0),
+            )
             # [BC, BK]
             b_k = tl.load(p_k, boundary_check=(0, 1))
             b_gk = tl.load(p_gk, boundary_check=(0, 1))
@@ -396,10 +542,22 @@ def chunk_gla_bwd_kernel_intra(
         b_dq *= exp(b_g - b_gn[None, :])
     o_i = tl.arange(0, BC)
     m_dA = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
-    o_dA = bos*H*BT + (i_t * BT + i_i * BC + tl.arange(0, BC)) * H*BT + i_h * BT + i_i * BC
-    p_kj = k + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
-    p_gkj = g + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
-    p_dq = tl.make_block_ptr(dq + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+    o_dA = (
+        bos * H * BT
+        + (i_t * BT + i_i * BC + tl.arange(0, BC)) * H * BT
+        + i_h * BT
+        + i_i * BC
+    )
+    p_kj = k + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+    p_gkj = g + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+    p_dq = tl.make_block_ptr(
+        dq + (bos * H + i_h) * K,
+        (T, K),
+        (H * K, 1),
+        (i_t * BT + i_i * BC, i_k * BK),
+        (BC, BK),
+        (1, 0),
+    )
 
     for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
         # [BC,]
@@ -411,9 +569,11 @@ def chunk_gla_bwd_kernel_intra(
         m_i = o_i[:, None] >= j
         # [BC, BK]
         # (SY 09/17) important to not use bf16 here to have a good precision.
-        b_dq += tl.where(m_i, b_dA[:, None] * b_kj[None, :] * exp(b_g - b_gkj[None, :]), 0.)
-        p_kj += H*K
-        p_gkj += H*K
+        b_dq += tl.where(
+            m_i, b_dA[:, None] * b_kj[None, :] * exp(b_g - b_gkj[None, :]), 0.0
+        )
+        p_kj += H * K
+        p_gkj += H * K
     tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
 
     tl.debug_barrier()
@@ -422,14 +582,35 @@ def chunk_gla_bwd_kernel_intra(
 
     NC = min(NC, tl.cdiv(T - i_t * BT, BC))
     if i_i < NC - 1:
-        p_gn = g + (bos + min(i_t * BT + i_i * BC + BC, T) - 1) * H*K + i_h * K + o_k
+        p_gn = g + (bos + min(i_t * BT + i_i * BC + BC, T) - 1) * H * K + i_h * K + o_k
 
         # [BK,]
         b_gn = tl.load(p_gn, mask=m_k, other=0)
         for i_j in range(i_i + 1, NC):
-            p_q = tl.make_block_ptr(q + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k*BK), (BC, BK), (1, 0))
-            p_gq = tl.make_block_ptr(g + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k*BK), (BC, BK), (1, 0))
-            p_dA = tl.make_block_ptr(dA + (bos*H+i_h)*BT, (BT, T), (1, H*BT), (i_i*BC, i_t*BT + i_j*BC), (BC, BC), (0, 1))
+            p_q = tl.make_block_ptr(
+                q + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT + i_j * BC, i_k * BK),
+                (BC, BK),
+                (1, 0),
+            )
+            p_gq = tl.make_block_ptr(
+                g + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT + i_j * BC, i_k * BK),
+                (BC, BK),
+                (1, 0),
+            )
+            p_dA = tl.make_block_ptr(
+                dA + (bos * H + i_h) * BT,
+                (BT, T),
+                (1, H * BT),
+                (i_i * BC, i_t * BT + i_j * BC),
+                (BC, BC),
+                (0, 1),
+            )
 
             o_j = i_t * BT + i_j * BC + o_i
             m_j = o_j < T
@@ -443,28 +624,45 @@ def chunk_gla_bwd_kernel_intra(
             # (SY 09/17) important to not use bf16 here to have a good precision.
             b_dk += tl.dot(b_dA, b_qg)
         b_dk *= exp(b_gn[None, :] - b_g)
-    o_dA = bos*H*BT + (i_t * BT + i_i * BC) * H*BT + i_h * BT + i_i * BC + tl.arange(0, BC)
-    p_qj = q + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
-    p_gqj = g + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
-    p_dk = tl.make_block_ptr(dk + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+    o_dA = (
+        bos * H * BT
+        + (i_t * BT + i_i * BC) * H * BT
+        + i_h * BT
+        + i_i * BC
+        + tl.arange(0, BC)
+    )
+    p_qj = q + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+    p_gqj = g + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+    p_dk = tl.make_block_ptr(
+        dk + (bos * H + i_h) * K,
+        (T, K),
+        (H * K, 1),
+        (i_t * BT + i_i * BC, i_k * BK),
+        (BC, BK),
+        (1, 0),
+    )
     for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
         # [BC,]
-        b_dA = tl.load(dA + o_dA + j * H*BT)
+        b_dA = tl.load(dA + o_dA + j * H * BT)
         # [BK,]
         b_qj = tl.load(p_qj, mask=m_k, other=0).to(tl.float32)
         b_gqj = tl.load(p_gqj, mask=m_k, other=0).to(tl.float32)
         # [BC, BK]
         m_i = o_i[:, None] <= j
-        b_dk += tl.where(m_i, b_dA[:, None] * b_qj[None, :] * exp(b_gqj[None, :] - b_g), 0.)
-        p_qj += H*K
-        p_gqj += H*K
+        b_dk += tl.where(
+            m_i, b_dA[:, None] * b_qj[None, :] * exp(b_gqj[None, :] - b_g), 0.0
+        )
+        p_qj += H * K
+        p_gqj += H * K
     tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
-@triton.jit(do_not_specialize=['T'])
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T"])
 def chunk_gla_bwd_kernel_dA(
     v,
     do,
@@ -482,31 +680,53 @@ def chunk_gla_bwd_kernel_dA(
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
     T = eos - bos
 
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
     for i_v in range(tl.cdiv(V, BV)):
-        p_do = tl.make_block_ptr(do + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (V, T), (1, H*V), (i_v * BV, i_t * BT), (BV, BT), (0, 1))
+        p_do = tl.make_block_ptr(
+            do + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        p_v = tl.make_block_ptr(
+            v + (bos * H + i_h) * V,
+            (V, T),
+            (1, H * V),
+            (i_v * BV, i_t * BT),
+            (BV, BT),
+            (0, 1),
+        )
         b_v = tl.load(p_v, boundary_check=(0, 1))
         b_do = tl.load(p_do, boundary_check=(0, 1))
 
         b_dA += tl.dot(b_do, b_v)
 
-    p_dA = tl.make_block_ptr(dA + (bos * H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_dA = tl.make_block_ptr(
+        dA + (bos * H + i_h) * BT, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+    )
     m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
-    b_dA = tl.where(m_s, b_dA * scale, 0.)
+    b_dA = tl.where(m_s, b_dA * scale, 0.0)
     tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
-@triton.jit(do_not_specialize=['T'])
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T"])
 def chunk_gla_bwd_kernel_dv(
     k,
     g,
@@ -530,8 +750,12 @@ def chunk_gla_bwd_kernel_dv(
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
     else:
@@ -539,13 +763,29 @@ def chunk_gla_bwd_kernel_dv(
         i_tg = i_b * NT + i_t
         bos, eos = i_b * T, i_b * T + T
 
-    p_A = tl.make_block_ptr(A + (bos * H + i_h) * BT, (BT, T), (1, H*BT), (0, i_t * BT), (BT, BT), (0, 1))
-    p_do = tl.make_block_ptr(do + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_dv = tl.make_block_ptr(dv + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+    p_A = tl.make_block_ptr(
+        A + (bos * H + i_h) * BT, (BT, T), (1, H * BT), (0, i_t * BT), (BT, BT), (0, 1)
+    )
+    p_do = tl.make_block_ptr(
+        do + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_t * BT, i_v * BV),
+        (BT, BV),
+        (1, 0),
+    )
+    p_dv = tl.make_block_ptr(
+        dv + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_t * BT, i_v * BV),
+        (BT, BV),
+        (1, 0),
+    )
     b_A = tl.load(p_A, boundary_check=(0, 1))
     b_do = tl.load(p_do, boundary_check=(0, 1))
 
-    b_A = tl.where(tl.arange(0, BT)[:, None] <= tl.arange(0, BT)[None, :], b_A, 0.)
+    b_A = tl.where(tl.arange(0, BT)[:, None] <= tl.arange(0, BT)[None, :], b_A, 0.0)
     # (SY 09/17) important to disallow tf32 here to maintain a good precision.
     b_dv = tl.dot(b_A, b_do.to(b_A.dtype), allow_tf32=False)
 
@@ -553,14 +793,42 @@ def chunk_gla_bwd_kernel_dv(
         o_k = i_k * BK + tl.arange(0, BK)
         m_k = o_k < K
 
-        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_gk = tl.make_block_ptr(g + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_gn = g + (bos + min(i_t * BT + BT, T) - 1)*H*K + i_h * K + o_k
+        p_k = tl.make_block_ptr(
+            k + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_gk = tl.make_block_ptr(
+            g + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_gn = g + (bos + min(i_t * BT + BT, T) - 1) * H * K + i_h * K + o_k
         if STATE_V_FIRST:
             # dh stored as [V, K]; read a logical [BK, BV] tile via on-the-fly transpose
-            p_dh = tl.make_block_ptr(dh + (i_tg * H + i_h) * K*V, (K, V), (1, K), (i_k * BK, i_v * BV), (BK, BV), (0, 1))
+            p_dh = tl.make_block_ptr(
+                dh + (i_tg * H + i_h) * K * V,
+                (K, V),
+                (1, K),
+                (i_k * BK, i_v * BV),
+                (BK, BV),
+                (0, 1),
+            )
         else:
-            p_dh = tl.make_block_ptr(dh + (i_tg * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            p_dh = tl.make_block_ptr(
+                dh + (i_tg * H + i_h) * K * V,
+                (K, V),
+                (V, 1),
+                (i_k * BK, i_v * BV),
+                (BK, BV),
+                (1, 0),
+            )
 
         b_k = tl.load(p_k, boundary_check=(0, 1))
         b_gk = tl.load(p_gk, boundary_check=(0, 1))
@@ -575,10 +843,12 @@ def chunk_gla_bwd_kernel_dv(
     tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
-@triton.jit(do_not_specialize=['T'])
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T"])
 def chunk_gla_bwd_kernel_inter(
     q,
     k,
@@ -609,8 +879,12 @@ def chunk_gla_bwd_kernel_inter(
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
     else:
@@ -624,33 +898,47 @@ def chunk_gla_bwd_kernel_inter(
     k += (bos * H + i_h) * K
     v += (bos * H + i_h) * V
     g += (bos * H + i_h) * K
-    h += (i_tg * H + i_h) * K*V
+    h += (i_tg * H + i_h) * K * V
     do += (bos * H + i_h) * V
-    dh += (i_tg * H + i_h) * K*V
+    dh += (i_tg * H + i_h) * K * V
     dq += (bos * H + i_h) * K
     dk += (bos * H + i_h) * K
     dq2 += (bos * H + i_h) * K
     dk2 += (bos * H + i_h) * K
     dg += (bos * H + i_h) * K
 
-    p_gk = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+    p_gk = tl.make_block_ptr(
+        g, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
     b_gk = tl.load(p_gk, boundary_check=(0, 1))
-    p_gn = g + (min(T, i_t * BT + BT) - 1) * H*K + o_k
+    p_gn = g + (min(T, i_t * BT + BT) - 1) * H * K + o_k
     b_gn = tl.load(p_gn, mask=m_k, other=0)
     b_dq = tl.zeros([BT, BK], dtype=tl.float32)
     b_dk = tl.zeros([BT, BK], dtype=tl.float32)
     b_dgk = tl.zeros([BK], dtype=tl.float32)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_v = tl.make_block_ptr(
+            v, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
+        p_do = tl.make_block_ptr(
+            do, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
         if STATE_V_FIRST:
             # h / dh stored as [V, K] -- the [BV, BK] tile is now a contiguous read
-            p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-            p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            p_h = tl.make_block_ptr(
+                h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
+            )
+            p_dh = tl.make_block_ptr(
+                dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
+            )
         else:
-            p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-            p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+            p_h = tl.make_block_ptr(
+                h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1)
+            )
+            p_dh = tl.make_block_ptr(
+                dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1)
+            )
         # [BT, BV]
         b_v = tl.load(p_v, boundary_check=(0, 1))
         b_do = tl.load(p_do, boundary_check=(0, 1))
@@ -668,10 +956,18 @@ def chunk_gla_bwd_kernel_inter(
     b_dq *= scale
     b_dq = b_dq * exp(b_gk)
     b_dk = b_dk * exp(b_gn[None, :] - b_gk)
-    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dq = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+    p_q = tl.make_block_ptr(
+        q, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
+    p_k = tl.make_block_ptr(
+        k, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
+    p_dq = tl.make_block_ptr(
+        dq, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
+    p_dk = tl.make_block_ptr(
+        dk, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
     b_q = tl.load(p_q, boundary_check=(0, 1))
     b_k = tl.load(p_k, boundary_check=(0, 1))
     b_dgk += tl.sum(b_dk * b_k, axis=0)
@@ -679,13 +975,21 @@ def chunk_gla_bwd_kernel_inter(
     b_dk += tl.load(p_dk, boundary_check=(0, 1))
     b_dg = b_q * b_dq - b_k * b_dk
     # tl.debug_barrier()
-    b_dg = b_dg - tl.cumsum(b_dg, axis=0) + tl.sum(b_dg, axis=0)[None, :] + b_dgk[None, :]
+    b_dg = (
+        b_dg - tl.cumsum(b_dg, axis=0) + tl.sum(b_dg, axis=0)[None, :] + b_dgk[None, :]
+    )
     # Buggy due to strange triton compiler issue.
     # m_s = tl.where(tl.arange(0, BT)[:, None] <= tl.arange(0, BT)[None, :], 1., 0.)
     # b_dg = tl.dot(m_s, b_dg, allow_tf32=False) + b_dgk[None, :]
-    p_dq = tl.make_block_ptr(dq2, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk2, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dg = tl.make_block_ptr(dg, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+    p_dq = tl.make_block_ptr(
+        dq2, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
+    p_dk = tl.make_block_ptr(
+        dk2, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
+    p_dg = tl.make_block_ptr(
+        dg, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
     tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
     tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
     tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
@@ -808,7 +1112,10 @@ def chunk_gla_fwd_o_gk(
 
     # Please ensure zeros, since vllm will use padding v
     o = torch.zeros_like(v)
-    def grid(meta): return (triton.cdiv(V, meta['BV']), NT, B * HV)
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), NT, B * HV)
+
     chunk_gla_fwd_kernel_o[grid](
         q=q,
         v=v,
@@ -883,7 +1190,10 @@ def chunk_gla_bwd_dv(
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
     dv = torch.empty_like(do)
-    def grid(meta): return (triton.cdiv(V, meta['BV']), NT, B * H)
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), NT, B * H)
+
     chunk_gla_bwd_kernel_dv[grid](
         k=k,
         g=g,
@@ -972,7 +1282,10 @@ def chunk_gla_bwd_dqkg(
     dg = torch.empty_like(g)
     dq2 = torch.empty_like(dq)
     dk2 = torch.empty_like(dk)
-    def grid(meta): return (triton.cdiv(K, meta['BK']), NT, B * H)
+
+    def grid(meta):
+        return (triton.cdiv(K, meta["BK"]), NT, B * H)
+
     chunk_gla_bwd_kernel_inter[grid](
         q=q,
         k=k,
@@ -1335,7 +1648,10 @@ def chunk_gla(
     if initial_state is not None:
         assert initial_state.dtype == torch.float32, "initial_state must be in float32."
     assert q.shape == k.shape == g.shape, "q, k, g must have the same shape."
-    assert v.shape == (*q.shape[:3], v.shape[-1]), "v must be of shape (batch size, seq len, num of head, head dim)."
+    assert v.shape == (
+        *q.shape[:3],
+        v.shape[-1],
+    ), "v must be of shape (batch size, seq len, num of head, head dim)."
     o, final_state = ChunkGLAFunction.apply(
         q,
         k,

--- a/src/flaggems_vllm/ops/FLA/chunk_gla.py
+++ b/src/flaggems_vllm/ops/FLA/chunk_gla.py
@@ -1,0 +1,1355 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import torch
+import triton
+import triton.language as tl
+from flaggems_vllm.ops.FLA.index import prepare_chunk_indices
+from flaggems_vllm.ops.FLA.chunk_h import chunk_bwd_dh, chunk_fwd_h
+from flaggems_vllm.ops.FLA.cumsum import chunk_local_cumsum
+from flaggems_vllm.ops.FLA.triton_ops_helper import exp
+from flaggems_vllm.ops.FLA.utils import check_shared_mem, input_guard
+
+RCP_LN2 = 1.4426950216
+
+BK_LIST = [32, 64] if check_shared_mem() else [16, 32]
+BV_LIST = [64, 128] if check_shared_mem('ampere') else [16, 32]
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def chunk_gla_fwd_A_kernel_intra_sub_inter(
+    q,
+    k,
+    g,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    NC: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    i_i, i_j = i_c // NC, i_c % NC
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT + i_i * BC >= T:
+        return
+    if i_i <= i_j:
+        return
+
+    b_A = tl.zeros([BC, BC], dtype=tl.float32)
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+
+        p_q = tl.make_block_ptr(q + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+        p_g = tl.make_block_ptr(g + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+        p_k = tl.make_block_ptr(k + (bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT + i_j * BC), (BK, BC), (0, 1))
+        p_gk = tl.make_block_ptr(g + (bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT + i_j * BC), (BK, BC), (0, 1))
+        p_gn = g + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
+
+        # [BK,]
+        b_gn = tl.load(p_gn, mask=m_k, other=0)
+        # [BC, BK]
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_g = tl.load(p_g, boundary_check=(0, 1))
+        b_qg = b_q * exp(b_g - b_gn[None, :]) * scale
+        # [BK, BC]
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_gk = tl.load(p_gk, boundary_check=(0, 1))
+        b_kg = b_k * exp(b_gn[:, None] - b_gk)
+        # [BC, BC] using tf32 to improve precision here.
+        b_A += tl.dot(b_qg, b_kg)
+
+    p_A = tl.make_block_ptr(A + (bos*H + i_h)*BT, (T, BT), (H*BT, 1), (i_t * BT + i_i * BC, i_j * BC), (BC, BC), (1, 0))
+    tl.store(p_A, b_A.to(A.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def chunk_gla_fwd_A_kernel_intra_sub_intra(
+    q,
+    k,
+    g,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    i_j = i_i
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT + i_i * BC >= T:
+        return
+
+    o_i = tl.arange(0, BC)
+    o_k = tl.arange(0, BK)
+    o_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) * H*BT + i_j * BC
+    m_k = o_k < K
+    m_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    g += (bos * H + i_h) * K
+    A += (bos * H + i_h) * BT
+
+    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT + i_i * BC, 0), (BC, BK), (1, 0))
+    p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_i * BC, 0), (BC, BK), (1, 0))
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_g = tl.load(p_g, boundary_check=(0, 1))
+
+    p_k = k + (i_t * BT + i_j * BC) * H*K + o_k
+    p_gk = g + (i_t * BT + i_j * BC) * H*K + o_k
+
+    for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
+        b_k = tl.load(p_k, mask=m_k, other=0).to(tl.float32)
+        b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
+        b_A = tl.sum(b_q * b_k[None, :] * exp(b_g - b_gk[None, :]), 1) * scale
+        tl.store(A + o_A + j, b_A, mask=m_A)
+        p_k += H*K
+        p_gk += H*K
+
+    tl.debug_barrier()
+    b_A = tl.zeros([BC, BC], dtype=tl.float32)
+    tl.store(A + o_A[:, None] + o_i, b_A, mask=m_A[:, None] & (o_i[:, None] < o_i))
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
+    q,
+    k,
+    g,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    NC: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_k, i_tc, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    i_t, i_i = i_tc // NC, i_tc % NC
+    i_j = i_i
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        all = T
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+        all = B * T
+
+    if i_t * BT + i_i * BC >= T:
+        return
+
+    o_i = tl.arange(0, BC)
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) * H*BC
+    m_k = o_k < K
+    m_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    g += (bos * H + i_h) * K
+    A += ((i_k * all + bos) * H + i_h) * BC
+
+    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+    p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_g = tl.load(p_g, boundary_check=(0, 1))
+
+    p_k = k + (i_t * BT + i_j * BC) * H*K + o_k
+    p_gk = g + (i_t * BT + i_j * BC) * H*K + o_k
+    for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
+        b_k = tl.load(p_k, mask=m_k, other=0).to(tl.float32)
+        b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
+        b_A = tl.sum(b_q * b_k[None, :] * exp(b_g - b_gk[None, :]), 1) * scale
+        tl.store(A + o_A + j, b_A, mask=m_A)
+        p_k += H*K
+        p_gk += H*K
+
+    tl.debug_barrier()
+    b_A = tl.zeros([BC, BC], dtype=tl.float32)
+    tl.store(A + o_A[:, None] + o_i, b_A, mask=m_A[:, None] & (o_i[:, None] < o_i))
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
+    A,
+    A2,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    NK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        all = T
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+        all = B * T
+
+    if i_t * BT + i_c * BC >= T:
+        return
+
+    b_A = tl.zeros([BC, BC], dtype=tl.float32)
+    for i_k in range(0, NK):
+        p_A = tl.make_block_ptr(A + (i_k*all+bos)*H*BC+i_h*BC, (T, BC), (H*BC, 1), (i_t*BT + i_c*BC, 0), (BC, BC), (1, 0))
+        b_A += tl.load(p_A, boundary_check=(0, 1))
+    p_A2 = tl.make_block_ptr(A2 + (bos*H+i_h)*BT, (T, BT), (H*BT, 1), (i_t * BT + i_c * BC, i_c * BC), (BC, BC), (1, 0))
+    tl.store(p_A2, b_A.to(A2.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def chunk_gla_fwd_kernel_o(
+    q,
+    v,
+    g,
+    h,
+    o,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
+    if IS_VARLEN:
+        i_tg = i_t.to(tl.int64)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = (i_b * NT + i_t).to(tl.int64)
+        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
+
+    m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
+
+    q += (bos * H + i_h) * K
+    g += (bos * HV + i_hv) * K
+    v += (bos * HV + i_hv) * V
+    o += (bos * HV + i_hv) * V
+    h += (i_tg * HV + i_hv).to(tl.int64) * K * V
+    A += (bos * HV + i_hv) * BT
+
+    b_o = tl.zeros([BT, BV], dtype=tl.float32)
+    for i_k in range(tl.cdiv(K, BK)):
+        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_g = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        if STATE_V_FIRST:
+            p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+        else:
+            p_h = tl.make_block_ptr(h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+
+        # [BT, BK]
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        # [BT, BK]
+        b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+        # [BT, BK]
+        b_qg = (b_q * exp(b_g)).to(b_q.dtype)
+        b_h = tl.load(p_h, boundary_check=(0, 1))
+        if i_k >= 0:
+            if STATE_V_FIRST:
+                b_o += tl.dot(b_qg, tl.trans(b_h).to(b_qg.dtype))
+            else:
+                b_o += tl.dot(b_qg, b_h.to(b_qg.dtype))
+    b_o *= scale
+    p_v = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+    p_o = tl.make_block_ptr(o, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+    p_A = tl.make_block_ptr(A, (T, BT), (HV*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    # [BT, BV]
+    b_v = tl.load(p_v, boundary_check=(0, 1))
+    # [BT, BT]
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_A = tl.where(m_s, b_A, 0.).to(b_v.dtype)
+    b_o += tl.dot(b_A, b_v)
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def chunk_gla_bwd_kernel_intra(
+    q,
+    k,
+    g,
+    dA,
+    dq,
+    dk,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    NC: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_kc, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    i_k, i_i = i_kc // NC, i_kc % NC
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+    else:
+        bos, eos = i_b * T, i_b * T + T
+    T = eos - bos
+    if i_t * BT + i_i * BC >= T:
+        return
+
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_k = o_k < K
+
+    p_g = tl.make_block_ptr(g + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+    # [BC, BK]
+    b_g = tl.load(p_g, boundary_check=(0, 1))
+
+    b_dq = tl.zeros([BC, BK], dtype=tl.float32)
+    if i_i > 0:
+        p_gn = g + (bos + i_t * BT + i_i * BC) * H*K + i_h*K + o_k
+        # [BK,]
+        b_gn = tl.load(p_gn, mask=m_k, other=0)
+        for i_j in range(0, i_i):
+            p_k = tl.make_block_ptr(k+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k * BK), (BC, BK), (1, 0))
+            p_gk = tl.make_block_ptr(g+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k * BK), (BC, BK), (1, 0))
+            p_dA = tl.make_block_ptr(dA+(bos*H+i_h)*BT, (T, BT), (H*BT, 1), (i_t*BT+i_i*BC, i_j * BC), (BC, BC), (1, 0))
+            # [BC, BK]
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            b_kg = b_k * exp(b_gn[None, :] - b_gk)
+            # [BC, BC]
+            b_dA = tl.load(p_dA, boundary_check=(0, 1))
+
+            b_dq += tl.dot(b_dA, b_kg)
+        b_dq *= exp(b_g - b_gn[None, :])
+    o_i = tl.arange(0, BC)
+    m_dA = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
+    o_dA = bos*H*BT + (i_t * BT + i_i * BC + tl.arange(0, BC)) * H*BT + i_h * BT + i_i * BC
+    p_kj = k + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
+    p_gkj = g + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
+    p_dq = tl.make_block_ptr(dq + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+
+    for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
+        # [BC,]
+        b_dA = tl.load(dA + o_dA + j, mask=m_dA, other=0)
+        # [BK,]
+        b_kj = tl.load(p_kj, mask=m_k, other=0).to(tl.float32)
+        b_gkj = tl.load(p_gkj, mask=m_k, other=0).to(tl.float32)
+        # [BC, BK]
+        m_i = o_i[:, None] >= j
+        # [BC, BK]
+        # (SY 09/17) important to not use bf16 here to have a good precision.
+        b_dq += tl.where(m_i, b_dA[:, None] * b_kj[None, :] * exp(b_g - b_gkj[None, :]), 0.)
+        p_kj += H*K
+        p_gkj += H*K
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+
+    tl.debug_barrier()
+    # [BC, BK]
+    b_dk = tl.zeros([BC, BK], dtype=tl.float32)
+
+    NC = min(NC, tl.cdiv(T - i_t * BT, BC))
+    if i_i < NC - 1:
+        p_gn = g + (bos + min(i_t * BT + i_i * BC + BC, T) - 1) * H*K + i_h * K + o_k
+
+        # [BK,]
+        b_gn = tl.load(p_gn, mask=m_k, other=0)
+        for i_j in range(i_i + 1, NC):
+            p_q = tl.make_block_ptr(q + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k*BK), (BC, BK), (1, 0))
+            p_gq = tl.make_block_ptr(g + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k*BK), (BC, BK), (1, 0))
+            p_dA = tl.make_block_ptr(dA + (bos*H+i_h)*BT, (BT, T), (1, H*BT), (i_i*BC, i_t*BT + i_j*BC), (BC, BC), (0, 1))
+
+            o_j = i_t * BT + i_j * BC + o_i
+            m_j = o_j < T
+            # [BC, BK]
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_gq = tl.load(p_gq, boundary_check=(0, 1))
+            b_qg = b_q * tl.where(m_j[:, None], exp(b_gq - b_gn[None, :]), 0)
+            # [BC, BC]
+            b_dA = tl.load(p_dA, boundary_check=(0, 1))
+            # [BC, BK]
+            # (SY 09/17) important to not use bf16 here to have a good precision.
+            b_dk += tl.dot(b_dA, b_qg)
+        b_dk *= exp(b_gn[None, :] - b_g)
+    o_dA = bos*H*BT + (i_t * BT + i_i * BC) * H*BT + i_h * BT + i_i * BC + tl.arange(0, BC)
+    p_qj = q + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
+    p_gqj = g + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
+    p_dk = tl.make_block_ptr(dk + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+    for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
+        # [BC,]
+        b_dA = tl.load(dA + o_dA + j * H*BT)
+        # [BK,]
+        b_qj = tl.load(p_qj, mask=m_k, other=0).to(tl.float32)
+        b_gqj = tl.load(p_gqj, mask=m_k, other=0).to(tl.float32)
+        # [BC, BK]
+        m_i = o_i[:, None] <= j
+        b_dk += tl.where(m_i, b_dA[:, None] * b_qj[None, :] * exp(b_gqj[None, :] - b_g), 0.)
+        p_qj += H*K
+        p_gqj += H*K
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def chunk_gla_bwd_kernel_dA(
+    v,
+    do,
+    dA,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+    else:
+        bos, eos = i_b * T, i_b * T + T
+    T = eos - bos
+
+    b_dA = tl.zeros([BT, BT], dtype=tl.float32)
+    for i_v in range(tl.cdiv(V, BV)):
+        p_do = tl.make_block_ptr(do + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (V, T), (1, H*V), (i_v * BV, i_t * BT), (BV, BT), (0, 1))
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_do = tl.load(p_do, boundary_check=(0, 1))
+
+        b_dA += tl.dot(b_do, b_v)
+
+    p_dA = tl.make_block_ptr(dA + (bos * H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
+    b_dA = tl.where(m_s, b_dA * scale, 0.)
+    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def chunk_gla_bwd_kernel_dv(
+    k,
+    g,
+    A,
+    do,
+    dh,
+    dv,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
+):
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_tg = i_t
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = i_b * NT + i_t
+        bos, eos = i_b * T, i_b * T + T
+
+    p_A = tl.make_block_ptr(A + (bos * H + i_h) * BT, (BT, T), (1, H*BT), (0, i_t * BT), (BT, BT), (0, 1))
+    p_do = tl.make_block_ptr(do + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+    p_dv = tl.make_block_ptr(dv + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_do = tl.load(p_do, boundary_check=(0, 1))
+
+    b_A = tl.where(tl.arange(0, BT)[:, None] <= tl.arange(0, BT)[None, :], b_A, 0.)
+    # (SY 09/17) important to disallow tf32 here to maintain a good precision.
+    b_dv = tl.dot(b_A, b_do.to(b_A.dtype), allow_tf32=False)
+
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+
+        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_gk = tl.make_block_ptr(g + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_gn = g + (bos + min(i_t * BT + BT, T) - 1)*H*K + i_h * K + o_k
+        if STATE_V_FIRST:
+            # dh stored as [V, K]; read a logical [BK, BV] tile via on-the-fly transpose
+            p_dh = tl.make_block_ptr(dh + (i_tg * H + i_h) * K*V, (K, V), (1, K), (i_k * BK, i_v * BV), (BK, BV), (0, 1))
+        else:
+            p_dh = tl.make_block_ptr(dh + (i_tg * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_gk = tl.load(p_gk, boundary_check=(0, 1))
+        b_dh = tl.load(p_dh, boundary_check=(0, 1))
+
+        b_gn = exp(tl.load(p_gn, mask=m_k, other=0)[None, :] - b_gk)
+        b_k = (b_k * b_gn).to(b_k.dtype)
+        # [BT, BV]
+        # (SY 09/17) it is ok to have bf16 interchunk gradient contribution here
+        b_dv += tl.dot(b_k, b_dh.to(b_k.dtype))
+
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def chunk_gla_bwd_kernel_inter(
+    q,
+    k,
+    v,
+    g,
+    h,
+    do,
+    dh,
+    dq,
+    dk,
+    dq2,
+    dk2,
+    dg,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
+):
+    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_tg = i_t
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = i_b * NT + i_t
+        bos, eos = i_b * T, i_b * T + T
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_k = o_k < K
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    v += (bos * H + i_h) * V
+    g += (bos * H + i_h) * K
+    h += (i_tg * H + i_h) * K*V
+    do += (bos * H + i_h) * V
+    dh += (i_tg * H + i_h) * K*V
+    dq += (bos * H + i_h) * K
+    dk += (bos * H + i_h) * K
+    dq2 += (bos * H + i_h) * K
+    dk2 += (bos * H + i_h) * K
+    dg += (bos * H + i_h) * K
+
+    p_gk = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+    b_gk = tl.load(p_gk, boundary_check=(0, 1))
+    p_gn = g + (min(T, i_t * BT + BT) - 1) * H*K + o_k
+    b_gn = tl.load(p_gn, mask=m_k, other=0)
+    b_dq = tl.zeros([BT, BK], dtype=tl.float32)
+    b_dk = tl.zeros([BT, BK], dtype=tl.float32)
+    b_dgk = tl.zeros([BK], dtype=tl.float32)
+
+    for i_v in range(tl.cdiv(V, BV)):
+        p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        if STATE_V_FIRST:
+            # h / dh stored as [V, K] -- the [BV, BK] tile is now a contiguous read
+            p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+        else:
+            p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+            p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+        # [BT, BV]
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_do = tl.load(p_do, boundary_check=(0, 1))
+        # [BV, BK]
+        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_dh = tl.load(p_dh, boundary_check=(0, 1))
+
+        # [BK]
+        b_dgk += tl.sum(b_h * b_dh, axis=0)
+        # [BT, BK]
+        b_dq += tl.dot(b_do, b_h.to(b_do.dtype))
+        b_dk += tl.dot(b_v, b_dh.to(b_v.dtype))
+
+    b_dgk *= exp(b_gn)
+    b_dq *= scale
+    b_dq = b_dq * exp(b_gk)
+    b_dk = b_dk * exp(b_gn[None, :] - b_gk)
+    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+    p_dq = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+    p_dk = tl.make_block_ptr(dk, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_dgk += tl.sum(b_dk * b_k, axis=0)
+    b_dq += tl.load(p_dq, boundary_check=(0, 1))
+    b_dk += tl.load(p_dk, boundary_check=(0, 1))
+    b_dg = b_q * b_dq - b_k * b_dk
+    # tl.debug_barrier()
+    b_dg = b_dg - tl.cumsum(b_dg, axis=0) + tl.sum(b_dg, axis=0)[None, :] + b_dgk[None, :]
+    # Buggy due to strange triton compiler issue.
+    # m_s = tl.where(tl.arange(0, BT)[:, None] <= tl.arange(0, BT)[None, :], 1., 0.)
+    # b_dg = tl.dot(m_s, b_dg, allow_tf32=False) + b_dgk[None, :]
+    p_dq = tl.make_block_ptr(dq2, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+    p_dk = tl.make_block_ptr(dk2, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+    p_dg = tl.make_block_ptr(dg, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_gla_fwd_intra_gk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    g: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K = k.shape
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    BC = min(16, BT)
+    NC = triton.cdiv(BT, BC)
+
+    A = q.new_empty(B, T, H, BT, dtype=torch.float)
+    grid = (NT, NC * NC, B * H)
+    chunk_gla_fwd_A_kernel_intra_sub_inter[grid](
+        q=q,
+        k=k,
+        g=g,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        K=K,
+        BT=BT,
+        BC=BC,
+        NC=NC,
+    )
+
+    grid = (NT, NC, B * H)
+    # load the entire [BC, K] blocks into SRAM at once
+    if K <= 256:
+        BK = max(triton.next_power_of_2(K), 16)
+        chunk_gla_fwd_A_kernel_intra_sub_intra[grid](
+            q=q,
+            k=k,
+            g=g,
+            A=A,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            scale=scale,
+            T=T,
+            H=H,
+            K=K,
+            BT=BT,
+            BC=BC,
+            BK=BK,
+        )
+    # split then merge
+    else:
+        BK = min(128, triton.next_power_of_2(K))
+        NK = triton.cdiv(K, BK)
+        A_intra = q.new_empty(NK, B, T, H, BC, dtype=torch.float)
+
+        grid = (NK, NT * NC, B * H)
+        chunk_gla_fwd_A_kernel_intra_sub_intra_split[grid](
+            q=q,
+            k=k,
+            g=g,
+            A=A_intra,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            scale=scale,
+            T=T,
+            B=B,
+            H=H,
+            K=K,
+            BT=BT,
+            BC=BC,
+            BK=BK,
+            NC=NC,
+        )
+
+        grid = (NT, NC, B * H)
+        chunk_gla_fwd_A_kernel_intra_sub_intra_merge[grid](
+            A=A_intra,
+            A2=A,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            T=T,
+            B=B,
+            H=H,
+            BT=BT,
+            BC=BC,
+            NK=NK,
+        )
+    return A
+
+
+def chunk_gla_fwd_o_gk(
+    q: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    A: torch.Tensor,
+    h: torch.Tensor,
+    scale: float,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K, HV, V = *q.shape, v.shape[2], v.shape[-1]
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    # Please ensure zeros, since vllm will use padding v
+    o = torch.zeros_like(v)
+    def grid(meta): return (triton.cdiv(V, meta['BV']), NT, B * HV)
+    chunk_gla_fwd_kernel_o[grid](
+        q=q,
+        v=v,
+        g=g,
+        h=h,
+        o=o,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BT=BT,
+        STATE_V_FIRST=state_v_first,
+    )
+    return o
+
+
+def chunk_gla_bwd_dA(
+    v: torch.Tensor,
+    do: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, V = v.shape
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    BV = min(64, triton.next_power_of_2(V))
+
+    dA = v.new_empty(B, T, H, BT, dtype=torch.float)
+    grid = (NT, B * H)
+    chunk_gla_bwd_kernel_dA[grid](
+        v=v,
+        do=do,
+        dA=dA,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        V=V,
+        BT=BT,
+        BV=BV,
+    )
+    return dA
+
+
+def chunk_gla_bwd_dv(
+    k: torch.Tensor,
+    g: torch.Tensor,
+    A: torch.Tensor,
+    do: torch.Tensor,
+    dh: torch.Tensor,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K, V = *k.shape, do.shape[-1]
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    dv = torch.empty_like(do)
+    def grid(meta): return (triton.cdiv(V, meta['BV']), NT, B * H)
+    chunk_gla_bwd_kernel_dv[grid](
+        k=k,
+        g=g,
+        A=A,
+        do=do,
+        dh=dh,
+        dv=dv,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        STATE_V_FIRST=state_v_first,
+    )
+    return dv
+
+
+def chunk_gla_bwd_dqk_intra(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    g: torch.Tensor,
+    dA: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K = q.shape
+    BT = chunk_size
+    BC = min(16, BT)
+    BK = min(64, triton.next_power_of_2(K))
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NC = triton.cdiv(BT, BC)
+    NK = triton.cdiv(K, BK)
+
+    dq = torch.empty_like(q, dtype=torch.float)
+    dk = torch.empty_like(k, dtype=torch.float)
+    grid = (NK * NC, NT, B * H)
+    chunk_gla_bwd_kernel_intra[grid](
+        q=q,
+        k=k,
+        g=g,
+        dA=dA,
+        dq=dq,
+        dk=dk,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        K=K,
+        BT=BT,
+        BC=BC,
+        BK=BK,
+        NC=NC,
+    )
+    return dq, dk
+
+
+def chunk_gla_bwd_dqkg(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    h: torch.Tensor,
+    g: torch.Tensor,
+    do: torch.Tensor,
+    dh: torch.Tensor,
+    dq: torch.Tensor,
+    dk: torch.Tensor,
+    scale: float | None = None,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    dg = torch.empty_like(g)
+    dq2 = torch.empty_like(dq)
+    dk2 = torch.empty_like(dk)
+    def grid(meta): return (triton.cdiv(K, meta['BK']), NT, B * H)
+    chunk_gla_bwd_kernel_inter[grid](
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        h=h,
+        do=do,
+        dh=dh,
+        dq=dq,
+        dk=dk,
+        dq2=dq2,
+        dk2=dk2,
+        dg=dg,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        STATE_V_FIRST=state_v_first,
+    )
+    return dq2, dk2, dg
+
+
+def chunk_gla_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    g_cumsum: torch.Tensor | None,
+    scale: float,
+    initial_state: torch.Tensor,
+    output_final_state: bool,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if g_cumsum is None:
+        g_cumsum = chunk_local_cumsum(
+            g,
+            chunk_size,
+            scale=RCP_LN2,
+            cu_seqlens=cu_seqlens,
+        )
+
+    h, ht = chunk_fwd_h(
+        k=k,
+        v=v,
+        g=None,
+        gk=g_cumsum,
+        gv=None,
+        h0=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        states_in_fp32=False,
+        state_v_first=state_v_first,
+    )
+
+    # the intra A is kept in fp32
+    # the computation has very marginal effect on the entire throughput
+    A = chunk_gla_fwd_intra_gk(
+        q=q,
+        k=k,
+        g=g_cumsum,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+    )
+    o = chunk_gla_fwd_o_gk(
+        q=q,
+        v=v,
+        g=g_cumsum,
+        A=A,
+        h=h,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+        state_v_first=state_v_first,
+    )
+    return g_cumsum, A, h, ht, o
+
+
+def chunk_gla_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    g_cumsum: torch.Tensor | None,
+    scale: float,
+    initial_state: torch.Tensor,
+    h: torch.Tensor,
+    A: torch.Tensor,
+    do: torch.Tensor,
+    dht: torch.Tensor,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    if g_cumsum is None:
+        g_cumsum = chunk_local_cumsum(
+            g,
+            chunk_size,
+            scale=RCP_LN2,
+            cu_seqlens=cu_seqlens,
+        )
+
+    if h is None:
+        h, _ = chunk_fwd_h(
+            k=k,
+            v=v,
+            g=None,
+            gk=g_cumsum,
+            gv=None,
+            h0=initial_state,
+            output_final_state=False,
+            cu_seqlens=cu_seqlens,
+            chunk_size=chunk_size,
+            states_in_fp32=True,
+            state_v_first=state_v_first,
+        )
+    dh, dh0 = chunk_bwd_dh(
+        q=q,
+        k=k,
+        v=v,
+        g=None,
+        gk=g_cumsum,
+        gv=None,
+        do=do,
+        h0=initial_state,
+        dht=dht,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        states_in_fp32=True,
+        state_v_first=state_v_first,
+    )
+
+    dv = chunk_gla_bwd_dv(
+        k=k,
+        g=g_cumsum,
+        A=A,
+        do=do,
+        dh=dh,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+        state_v_first=state_v_first,
+    )
+
+    # dq dk in fp32
+    dA = chunk_gla_bwd_dA(
+        v=v,
+        do=do,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+    )
+    dq, dk = chunk_gla_bwd_dqk_intra(
+        q=q,
+        k=k,
+        g=g_cumsum,
+        dA=dA,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+    )
+    dq, dk, dg = chunk_gla_bwd_dqkg(
+        q=q,
+        k=k,
+        v=v,
+        h=h,
+        g=g_cumsum,
+        do=do,
+        dh=dh,
+        dq=dq,
+        dk=dk,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+        state_v_first=state_v_first,
+    )
+    return dq, dk, dv, dg, dh0
+
+
+class ChunkGLAFunction(torch.autograd.Function):
+
+    @staticmethod
+    @input_guard
+    def forward(
+        ctx,
+        q,
+        k,
+        v,
+        g,
+        scale,
+        initial_state,
+        output_final_state,
+        state_v_first,
+        cu_seqlens,
+        cu_seqlens_cpu,
+    ):
+        chunk_size = min(64, max(16, triton.next_power_of_2(q.shape[1])))
+        if cu_seqlens is not None:
+            chunk_indices = prepare_chunk_indices(
+                cu_seqlens,
+                chunk_size,
+                cu_seqlens_cpu=cu_seqlens_cpu,
+            )
+        else:
+            chunk_indices = None
+
+        g_cumsum, A, _, ht, o = chunk_gla_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            g_cumsum=None,
+            scale=scale,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens,
+            chunk_size=chunk_size,
+            chunk_indices=chunk_indices,
+            state_v_first=state_v_first,
+        )
+        # recompute g_cumsum in bwd pass
+        if g.dtype != torch.float:
+            g_cumsum = None
+        else:
+            g = None
+        ctx.save_for_backward(q, k, v, g, g_cumsum, initial_state, A, chunk_indices)
+        ctx.chunk_size = chunk_size
+        ctx.scale = scale
+        ctx.cu_seqlens = cu_seqlens
+        ctx.state_v_first = state_v_first
+        return o, ht
+
+    @staticmethod
+    @input_guard
+    def backward(ctx, do, dht):
+        q, k, v, g, g_cumsum, initial_state, A, chunk_indices = ctx.saved_tensors
+        chunk_size, scale, cu_seqlens = ctx.chunk_size, ctx.scale, ctx.cu_seqlens
+        dq, dk, dv, dg, dh0 = chunk_gla_bwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            g_cumsum=g_cumsum,
+            scale=scale,
+            h=None,
+            A=A,
+            initial_state=initial_state,
+            do=do,
+            dht=dht,
+            cu_seqlens=cu_seqlens,
+            chunk_size=chunk_size,
+            chunk_indices=chunk_indices,
+            state_v_first=ctx.state_v_first,
+        )
+        return dq.to(q), dk.to(k), dv.to(v), dg, None, dh0, None, None, None, None
+
+
+@torch.compiler.disable
+def chunk_gla(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    scale: int | None = None,
+    initial_state: torch.Tensor = None,
+    output_final_state: bool = False,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    cu_seqlens_cpu: torch.LongTensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    r"""
+    Args:
+        q (torch.Tensor):
+            queries of shape `[B, T, H, K]`.
+        k (torch.Tensor):
+            keys of shape `[B, T, H, K]`.
+        v (torch.Tensor):
+            values of shape `[B, T, H, V]`.
+        g (torch.Tensor):
+            Forget gates of shape `[B, T, H, K]`.
+        scale (Optional[float]):
+            Scale factor for the attention scores.
+            If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
+        initial_state (Optional[torch.Tensor]):
+            Initial state of shape `[N, H, K, V]` (or `[N, H, V, K]` if `state_v_first=True`)
+            for `N` input sequences.
+            For equal-length input sequences, `N` equals the batch size `B`.
+            Default: `None`.
+        output_final_state (Optional[bool]):
+            Whether to output the final state of shape `[N, H, K, V]`
+            (or `[N, H, V, K]` if `state_v_first=True`). Default: `False`.
+        state_v_first (Optional[bool]):
+            Store the recurrent state in V-first `[V, K]` layout instead of the default `[K, V]`. Default: `False`.
+        cu_seqlens (torch.LongTensor):
+            Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
+            consistent with the FlashAttention API.
+
+    Returns:
+        o (torch.Tensor):
+            Outputs of shape `[B, T, H, V]`.
+        final_state (torch.Tensor):
+            Final state of shape `[N, H, K, V]` (or `[N, H, V, K]` if `state_v_first=True`)
+            if `output_final_state=True` else `None`.
+
+    Examples::
+        >>> import torch
+        >>> import torch.nn.functional as F
+        >>> from einops import rearrange
+        >>> from fla.ops.gla import chunk_gla
+        # inputs with equal lengths
+        >>> B, T, H, K, V = 4, 2048, 4, 512, 512
+        >>> q = torch.randn(B, T, H, K, device='cuda')
+        >>> k = torch.randn(B, T, H, K, device='cuda')
+        >>> v = torch.randn(B, T, H, V, device='cuda')
+        >>> g = F.logsigmoid(torch.randn(B, T, H, K, device='cuda'))
+        >>> h0 = torch.randn(B, H, K, V, device='cuda')
+        >>> o, ht = chunk_gla(
+            q, k, v, g,
+            initial_state=h0,
+            output_final_state=True
+        )
+        # for variable-length inputs, the batch size `B` is expected to be 1 and `cu_seqlens` is required
+        >>> q, k, v, g = map(lambda x: rearrange(x, 'b t h d -> 1 (b t) h d'), (q, k, v, g))
+        # for a batch with 4 sequences, `cu_seqlens` with 5 start/end positions are expected
+        >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
+        >>> o, ht = chunk_gla(
+            q, k, v, g,
+            initial_state=h0,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens
+        )
+    """
+    if cu_seqlens is not None:
+        if q.shape[0] != 1:
+            raise ValueError(
+                f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
+                f"Please flatten variable-length inputs before processing.",
+            )
+        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
+            raise ValueError(
+                f"The number of initial states is expected to be equal to the number of input sequences, "
+                f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}.",
+            )
+    if scale is None:
+        scale = q.shape[-1] ** -0.5
+    if initial_state is not None:
+        assert initial_state.dtype == torch.float32, "initial_state must be in float32."
+    assert q.shape == k.shape == g.shape, "q, k, g must have the same shape."
+    assert v.shape == (*q.shape[:3], v.shape[-1]), "v must be of shape (batch size, seq len, num of head, head dim)."
+    o, final_state = ChunkGLAFunction.apply(
+        q,
+        k,
+        v,
+        g,
+        scale,
+        initial_state,
+        output_final_state,
+        state_v_first,
+        cu_seqlens,
+        cu_seqlens_cpu,
+    )
+    return o, final_state

--- a/src/flaggems_vllm/ops/FLA/chunk_gla.py
+++ b/src/flaggems_vllm/ops/FLA/chunk_gla.py
@@ -26,6 +26,19 @@ BV_LIST = [64, 128] if check_shared_mem("ampere") else [16, 32]
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
 )
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {'BK': BK},
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        for BK in [32, 64]
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=['BC'],
+)
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_fwd_A_kernel_intra_sub_inter(
     q,
@@ -131,6 +144,18 @@ def chunk_gla_fwd_A_kernel_intra_sub_inter(
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
 )
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {},
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3]
+    ],
+    key=['BK', 'BT'],
+)
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_fwd_A_kernel_intra_sub_intra(
     q,
@@ -208,6 +233,13 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra(
     {
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps)
+        for num_warps in [1, 2, 4, 8]
+    ],
+    key=['BC', 'BK'],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
@@ -293,6 +325,15 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
 )
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=1),
+        triton.Config({}, num_warps=2),
+        triton.Config({}, num_warps=4),
+        triton.Config({}, num_warps=8),
+    ],
+    key=['BC'],
+)
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
     A,
@@ -351,6 +392,20 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
     {
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
+)
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {'BK': BK, 'BV': BV},
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        for BK in [32, 64]
+        for BV in [64, 128]
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=['BT', 'HV', 'STATE_V_FIRST'],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_fwd_kernel_o(
@@ -451,6 +506,18 @@ def chunk_gla_fwd_kernel_o(
     {
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
+)
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {},
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=['BK', 'NC', 'BT'],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_bwd_kernel_intra(
@@ -662,6 +729,18 @@ def chunk_gla_bwd_kernel_intra(
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
 )
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {},
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        for num_warps in [1, 2, 4]
+        for num_stages in [2, 3, 4]
+    ],
+    key=['BV', 'BT'],
+)
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_bwd_kernel_dA(
     v,
@@ -725,6 +804,20 @@ def chunk_gla_bwd_kernel_dA(
     {
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
+)
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {'BK': BK, 'BV': BV},
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        for BK in BK_LIST
+        for BV in BV_LIST
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=['BT', 'STATE_V_FIRST'],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_bwd_kernel_dv(
@@ -847,6 +940,20 @@ def chunk_gla_bwd_kernel_dv(
     {
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
+)
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {'BK': BK, 'BV': BV},
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        for BK in BK_LIST
+        for BV in BV_LIST
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=['BT', 'STATE_V_FIRST'],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_bwd_kernel_inter(

--- a/src/flaggems_vllm/ops/FLA/chunk_h.py
+++ b/src/flaggems_vllm/ops/FLA/chunk_h.py
@@ -10,29 +10,30 @@ import triton
 import triton.language as tl
 
 from flaggems_vllm.ops.FLA.index import prepare_chunk_offsets
-
-from flaggems_vllm.ops.FLA.triton_ops_helper import exp 
+from flaggems_vllm.ops.FLA.triton_ops_helper import exp
 from flaggems_vllm.ops.FLA.utils import check_shared_mem
 
 BKV_LIST = [32, 64] if check_shared_mem() else [16, 32]
 
 
-@triton.heuristics({
-    'USE_INITIAL_STATE': lambda args: args['h0'] is not None,
-    'STORE_FINAL_STATE': lambda args: args['ht'] is not None,
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
+@triton.heuristics(
+    {
+        "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+        "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
 @triton.autotune(
     configs=[
-        triton.Config({'BK': BK, 'BV': BV}, num_warps=num_warps, num_stages=num_stages)
+        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
         for BK in BKV_LIST
         for BV in BKV_LIST
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'USE_G', 'USE_GK', 'USE_GV', 'STATE_V_FIRST'],
+    key=["BT", "USE_G", "USE_GK", "USE_GV", "STATE_V_FIRST"],
 )
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=["T"])
 def chunk_fwd_kernel_h(
     k,
     v,
@@ -65,7 +66,9 @@ def chunk_fwd_kernel_h(
     i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_n, i_h = i_nh // H, i_nh % H
     if IS_VARLEN:
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
         T = eos - bos
         NT, NS = tl.cdiv(T, BT), tl.cdiv(T, BS)
         boh = tl.load(split_offsets + i_n).to(tl.int32)
@@ -84,25 +87,61 @@ def chunk_fwd_kernel_h(
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_INITIAL_STATE:
         if STATE_V_FIRST:
-            p_h0 = tl.make_block_ptr(h0 + i_nh * K*V, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            p_h0 = tl.make_block_ptr(
+                h0 + i_nh * K * V,
+                (V, K),
+                (K, 1),
+                (i_v * BV, i_k * BK),
+                (BV, BK),
+                (1, 0),
+            )
             b_h = tl.trans(tl.load(p_h0, boundary_check=(0, 1))).to(tl.float32)
         else:
-            p_h0 = tl.make_block_ptr(h0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            p_h0 = tl.make_block_ptr(
+                h0 + i_nh * K * V,
+                (K, V),
+                (V, 1),
+                (i_k * BK, i_v * BV),
+                (BK, BV),
+                (1, 0),
+            )
             b_h = tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
 
     for i_t in range(NT):
         i_s = i_t // NTS
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_k = tl.make_block_ptr(
+            k + (bos * H + i_h) * K,
+            (K, T),
+            (1, H * K),
+            (i_k * BK, i_t * BT),
+            (BK, BT),
+            (0, 1),
+        )
+        p_v = tl.make_block_ptr(
+            v + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
 
-        o_h = ((boh + i_s) * H + i_h).to(tl.int64) * K*V
+        o_h = ((boh + i_s) * H + i_h).to(tl.int64) * K * V
         if STATE_V_FIRST:
-            p_h = tl.make_block_ptr(h + o_h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            p_h = tl.make_block_ptr(
+                h + o_h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
+            )
         else:
-            p_h = tl.make_block_ptr(h + o_h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            p_h = tl.make_block_ptr(
+                h + o_h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
+            )
 
         if i_t % NTS == 0:
-            tl.store(p_h, (tl.trans(b_h) if STATE_V_FIRST else b_h).to(p_h.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(
+                p_h,
+                (tl.trans(b_h) if STATE_V_FIRST else b_h).to(p_h.dtype.element_ty),
+                boundary_check=(0, 1),
+            )
         # [BK, BT]
         b_k = tl.load(p_k, boundary_check=(0, 1))
         # [BT, BV]
@@ -112,8 +151,8 @@ def chunk_fwd_kernel_h(
         # scalar decay
         if USE_G:
             b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
-            p_g = g + bos*H + (i_t * BT + tl.arange(0, BT)) * H + i_h
-            b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.)
+            p_g = g + bos * H + (i_t * BT + tl.arange(0, BT)) * H + i_h
+            b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.0)
             b_h *= exp(b_g_last)
             b_v = (b_v * exp(b_g_last - b_g)[:, None]).to(b_v.dtype)
 
@@ -124,20 +163,42 @@ def chunk_fwd_kernel_h(
 
         # vector decay, h = Diag(gk) @ h
         if USE_GK:
-            p_gk = tl.make_block_ptr(gk + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-            p_gk_last = gk + (bos + last_idx) * H*K + i_h * K + i_k * BK + tl.arange(0, BK)
+            p_gk = tl.make_block_ptr(
+                gk + (bos * H + i_h) * K,
+                (K, T),
+                (1, H * K),
+                (i_k * BK, i_t * BT),
+                (BK, BT),
+                (0, 1),
+            )
+            p_gk_last = (
+                gk + (bos + last_idx) * H * K + i_h * K + i_k * BK + tl.arange(0, BK)
+            )
 
-            b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.)
+            b_gk_last = tl.load(
+                p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.0
+            )
             b_gk = tl.load(p_gk, boundary_check=(0, 1))
             b_h *= exp(b_gk_last)[:, None]
             b_k = (b_k * exp(b_gk_last[:, None] - b_gk)).to(b_k.dtype)
 
         # vector decay, h = h @ Diag(gv)
         if USE_GV:
-            p_gv = tl.make_block_ptr(gv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-            p_gv_last = gv + (bos + last_idx) * H*V + i_h * V + i_v * BV + tl.arange(0, BV)
+            p_gv = tl.make_block_ptr(
+                gv + (bos * H + i_h) * V,
+                (T, V),
+                (H * V, 1),
+                (i_t * BT, i_v * BV),
+                (BT, BV),
+                (1, 0),
+            )
+            p_gv_last = (
+                gv + (bos + last_idx) * H * V + i_h * V + i_v * BV + tl.arange(0, BV)
+            )
 
-            b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.)
+            b_gv_last = tl.load(
+                p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.0
+            )
             b_gv = tl.load(p_gv, boundary_check=(0, 1))
             b_h *= exp(b_gv_last)[None, :]
             b_v = (b_v * exp(b_gv_last[None, :] - b_gv)).to(b_v.dtype)
@@ -146,29 +207,47 @@ def chunk_fwd_kernel_h(
 
     if STORE_FINAL_STATE:
         if STATE_V_FIRST:
-            p_ht = tl.make_block_ptr(ht + i_nh * K*V, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-            tl.store(p_ht, tl.trans(b_h).to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = tl.make_block_ptr(
+                ht + i_nh * K * V,
+                (V, K),
+                (K, 1),
+                (i_v * BV, i_k * BK),
+                (BV, BK),
+                (1, 0),
+            )
+            tl.store(
+                p_ht, tl.trans(b_h).to(p_ht.dtype.element_ty), boundary_check=(0, 1)
+            )
         else:
-            p_ht = tl.make_block_ptr(ht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            p_ht = tl.make_block_ptr(
+                ht + i_nh * K * V,
+                (K, V),
+                (V, 1),
+                (i_k * BK, i_v * BV),
+                (BK, BV),
+                (1, 0),
+            )
             tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
 
 
-@triton.heuristics({
-    'STORE_INITIAL_STATE_GRADIENT': lambda args: args['dh0'] is not None,
-    'USE_FINAL_STATE_GRADIENT': lambda args: args['dht'] is not None,
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
+@triton.heuristics(
+    {
+        "STORE_INITIAL_STATE_GRADIENT": lambda args: args["dh0"] is not None,
+        "USE_FINAL_STATE_GRADIENT": lambda args: args["dht"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
 @triton.autotune(
     configs=[
-        triton.Config({'BK': BK, 'BV': BV}, num_warps=num_warps, num_stages=num_stages)
+        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
         for BK in BKV_LIST
         for BV in BKV_LIST
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'USE_G', 'USE_GK', 'USE_GV', 'STATE_V_FIRST'],
+    key=["BT", "USE_G", "USE_GK", "USE_GV", "STATE_V_FIRST"],
 )
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=["T"])
 def chunk_bwd_kernel_dh(
     q,
     g,
@@ -205,7 +284,9 @@ def chunk_bwd_kernel_dh(
     i_n, i_hq = i_nh // HQ, i_nh % HQ
     i_h = i_hq // NG
     if IS_VARLEN:
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
         NS = tl.cdiv(T, BS)
@@ -224,26 +305,62 @@ def chunk_bwd_kernel_dh(
     b_dh = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_FINAL_STATE_GRADIENT:
         if STATE_V_FIRST:
-            p_dht = tl.make_block_ptr(dht + i_nh * K*V, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            p_dht = tl.make_block_ptr(
+                dht + i_nh * K * V,
+                (V, K),
+                (K, 1),
+                (i_v * BV, i_k * BK),
+                (BV, BK),
+                (1, 0),
+            )
             b_dh += tl.trans(tl.load(p_dht, boundary_check=(0, 1))).to(tl.float32)
         else:
-            p_dht = tl.make_block_ptr(dht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            p_dht = tl.make_block_ptr(
+                dht + i_nh * K * V,
+                (K, V),
+                (V, 1),
+                (i_k * BK, i_v * BV),
+                (BK, BV),
+                (1, 0),
+            )
             b_dh += tl.load(p_dht, boundary_check=(0, 1)).to(tl.float32)
 
     for i_t in range(NT - 1, -1, -1):
         i_s = i_t // (BS // BT)
-        o_dh = ((boh + i_s) * H + i_h).to(tl.int64) * K*V
+        o_dh = ((boh + i_s) * H + i_h).to(tl.int64) * K * V
         if STATE_V_FIRST:
-            p_dh = tl.make_block_ptr(dh + o_dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            p_dh = tl.make_block_ptr(
+                dh + o_dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
+            )
         else:
-            p_dh = tl.make_block_ptr(dh + o_dh, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            p_dh = tl.make_block_ptr(
+                dh + o_dh, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
+            )
 
         if i_t % (BS // BT) == 0:
-            tl.store(p_dh, (tl.trans(b_dh) if STATE_V_FIRST else b_dh).to(p_dh.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(
+                p_dh,
+                (tl.trans(b_dh) if STATE_V_FIRST else b_dh).to(p_dh.dtype.element_ty),
+                boundary_check=(0, 1),
+            )
         last_idx = min(i_t * BT + BT, T) - 1
         # [BK, BT]
-        p_q = tl.make_block_ptr(q + (bos*HQ + i_hq) * K, (K, T), (1, HQ*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_do = tl.make_block_ptr(do + (bos*HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_q = tl.make_block_ptr(
+            q + (bos * HQ + i_hq) * K,
+            (K, T),
+            (1, HQ * K),
+            (i_k * BK, i_t * BT),
+            (BK, BT),
+            (0, 1),
+        )
+        p_do = tl.make_block_ptr(
+            do + (bos * HQ + i_hq) * V,
+            (T, V),
+            (HQ * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
         b_q = tl.load(p_q, boundary_check=(0, 1))
         b_q = (b_q * scale).to(b_q.dtype)
         # [BT, BV]
@@ -252,7 +369,7 @@ def chunk_bwd_kernel_dh(
         if USE_G:
             p_g = g + (bos + i_t * BT + tl.arange(0, BT)) * H + i_h
             b_g_last = tl.load(g + (bos + last_idx) * H + i_h)
-            b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.)
+            b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.0)
             b_q = (b_q * exp(b_g)[None, :]).to(b_q.dtype)
             b_dh *= exp(b_g_last)
 
@@ -262,31 +379,69 @@ def chunk_bwd_kernel_dh(
             b_dh *= exp(b_g_last)
 
         if USE_GK:
-            p_gk = tl.make_block_ptr(gk + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-            p_gk_last = gk + (bos + last_idx) * H*K + i_h * K + i_k * BK + tl.arange(0, BK)
+            p_gk = tl.make_block_ptr(
+                gk + (bos * H + i_h) * K,
+                (K, T),
+                (1, H * K),
+                (i_k * BK, i_t * BT),
+                (BK, BT),
+                (0, 1),
+            )
+            p_gk_last = (
+                gk + (bos + last_idx) * H * K + i_h * K + i_k * BK + tl.arange(0, BK)
+            )
 
             b_gk = tl.load(p_gk, boundary_check=(0, 1))
-            b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.)
+            b_gk_last = tl.load(
+                p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.0
+            )
             b_q = (b_q * exp(b_gk)).to(b_q.dtype)
             b_dh *= exp(b_gk_last)[:, None]
 
         if USE_GV:
-            p_gv = tl.make_block_ptr(gv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-            p_gv_last = gv + (bos + last_idx) * H*V + i_h * V + i_v * BV + tl.arange(0, BV)
+            p_gv = tl.make_block_ptr(
+                gv + (bos * H + i_h) * V,
+                (T, V),
+                (H * V, 1),
+                (i_t * BT, i_v * BV),
+                (BT, BV),
+                (1, 0),
+            )
+            p_gv_last = (
+                gv + (bos + last_idx) * H * V + i_h * V + i_v * BV + tl.arange(0, BV)
+            )
 
             b_gv = tl.load(p_gv, boundary_check=(0, 1))
-            b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.)
-            b_do = (b_do * exp(b_gv))
+            b_gv_last = tl.load(
+                p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.0
+            )
+            b_do = b_do * exp(b_gv)
             b_dh *= exp(b_gv_last)[None, :]
 
         b_dh += tl.dot(b_q, b_do.to(b_q.dtype))
 
     if STORE_INITIAL_STATE_GRADIENT:
         if STATE_V_FIRST:
-            p_dh0 = tl.make_block_ptr(dh0 + i_nh * K*V, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-            tl.store(p_dh0, tl.trans(b_dh).to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+            p_dh0 = tl.make_block_ptr(
+                dh0 + i_nh * K * V,
+                (V, K),
+                (K, 1),
+                (i_v * BV, i_k * BK),
+                (BV, BK),
+                (1, 0),
+            )
+            tl.store(
+                p_dh0, tl.trans(b_dh).to(p_dh0.dtype.element_ty), boundary_check=(0, 1)
+            )
         else:
-            p_dh0 = tl.make_block_ptr(dh0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            p_dh0 = tl.make_block_ptr(
+                dh0 + i_nh * K * V,
+                (K, V),
+                (V, 1),
+                (i_k * BK, i_v * BV),
+                (BK, BV),
+                (1, 0),
+            )
             tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
 
 
@@ -308,7 +463,9 @@ def chunk_fwd_h(
     B, T, H, K, V = *k.shape, v.shape[-1]
     BT = chunk_size
     BS = BT if split_size is None else split_size
-    assert BS % BT == 0, f"The `split_size` (got {BS}) must be a multiple of `chunk_size` {BT}"
+    assert (
+        BS % BT == 0
+    ), f"The `split_size` (got {BS}) must be a multiple of `chunk_size` {BT}"
     # N: the actual number of sequences in the batch with either equal or variable lengths
     if cu_seqlens is None:
         N, NS, split_offsets = B, triton.cdiv(T, BS), None
@@ -318,9 +475,18 @@ def chunk_fwd_h(
 
     # `state_v_first` stores the states in V-first `[V, K]` layout instead of `[K, V]`
     state_shape = (V, K) if state_v_first else (K, V)
-    h = k.new_empty(B, NS, H, *state_shape, dtype=k.dtype if not states_in_fp32 else torch.float)
-    ht = k.new_empty(N, H, *state_shape, dtype=torch.float) if output_final_state else None
-    def grid(meta): return (triton.cdiv(K, meta['BK']), triton.cdiv(V, meta['BV']), N * H)
+    h = k.new_empty(
+        B, NS, H, *state_shape, dtype=k.dtype if not states_in_fp32 else torch.float
+    )
+    ht = (
+        k.new_empty(N, H, *state_shape, dtype=torch.float)
+        if output_final_state
+        else None
+    )
+
+    def grid(meta):
+        return (triton.cdiv(K, meta["BK"]), triton.cdiv(V, meta["BV"]), N * H)
+
     chunk_fwd_kernel_h[grid](
         k=k,
         v=v,
@@ -370,7 +536,9 @@ def chunk_bwd_dh(
     HQ = q.shape[2]
     BT = chunk_size
     BS = BT if split_size is None else split_size
-    assert BS % BT == 0, f"The `split_size` (got {BS}) must be a multiple of `chunk_size` {BT}"
+    assert (
+        BS % BT == 0
+    ), f"The `split_size` (got {BS}) must be a multiple of `chunk_size` {BT}"
     # N: the actual number of sequences in the batch with either equal or variable lengths
     # NG: number of groups in GQA
     if cu_seqlens is None:
@@ -382,10 +550,14 @@ def chunk_bwd_dh(
 
     # `state_v_first` stores the states in V-first `[V, K]` layout instead of `[K, V]`
     state_shape = (V, K) if state_v_first else (K, V)
-    dh = k.new_empty(B, NS, HQ, *state_shape, dtype=k.dtype if not states_in_fp32 else torch.float)
+    dh = k.new_empty(
+        B, NS, HQ, *state_shape, dtype=k.dtype if not states_in_fp32 else torch.float
+    )
     dh0 = torch.empty_like(h0, dtype=torch.float) if h0 is not None else None
 
-    def grid(meta): return (triton.cdiv(K, meta['BK']), triton.cdiv(V, meta['BV']), N * H)
+    def grid(meta):
+        return (triton.cdiv(K, meta["BK"]), triton.cdiv(V, meta["BV"]), N * H)
+
     chunk_bwd_kernel_dh[grid](
         q=q,
         g=g,

--- a/src/flaggems_vllm/ops/FLA/chunk_h.py
+++ b/src/flaggems_vllm/ops/FLA/chunk_h.py
@@ -1,0 +1,416 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import torch
+import triton
+import triton.language as tl
+
+from flaggems_vllm.ops.FLA.index import prepare_chunk_offsets
+
+from flaggems_vllm.ops.FLA.triton_ops_helper import exp 
+from flaggems_vllm.ops.FLA.utils import check_shared_mem
+
+BKV_LIST = [32, 64] if check_shared_mem() else [16, 32]
+
+
+@triton.heuristics({
+    'USE_INITIAL_STATE': lambda args: args['h0'] is not None,
+    'STORE_FINAL_STATE': lambda args: args['ht'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({'BK': BK, 'BV': BV}, num_warps=num_warps, num_stages=num_stages)
+        for BK in BKV_LIST
+        for BV in BKV_LIST
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=['BT', 'USE_G', 'USE_GK', 'USE_GV', 'STATE_V_FIRST'],
+)
+@triton.jit(do_not_specialize=['T'])
+def chunk_fwd_kernel_h(
+    k,
+    v,
+    h,
+    g,
+    g_gamma,
+    gk,
+    gv,
+    h0,
+    ht,
+    cu_seqlens,
+    split_offsets,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_G_GAMMA: tl.constexpr,
+    USE_GK: tl.constexpr,
+    USE_GV: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
+):
+    i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_n, i_h = i_nh // H, i_nh % H
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        NT, NS = tl.cdiv(T, BT), tl.cdiv(T, BS)
+        boh = tl.load(split_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        NT, NS = tl.cdiv(T, BT), tl.cdiv(T, BS)
+        boh = i_n * NS
+    NTS = BS // BT
+
+    if USE_G_GAMMA:
+        # decay rate given the head index
+        b_gamma = tl.load(g_gamma + i_h)
+        b_g = b_gamma * (tl.arange(0, BT) + 1)
+
+    # [BK, BV] accumulator; STATE_V_FIRST only flips the stored state's HBM layout to [V, K], applied at the load/store below.
+    b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    if USE_INITIAL_STATE:
+        if STATE_V_FIRST:
+            p_h0 = tl.make_block_ptr(h0 + i_nh * K*V, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            b_h = tl.trans(tl.load(p_h0, boundary_check=(0, 1))).to(tl.float32)
+        else:
+            p_h0 = tl.make_block_ptr(h0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            b_h = tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+
+    for i_t in range(NT):
+        i_s = i_t // NTS
+        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
+        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+
+        o_h = ((boh + i_s) * H + i_h).to(tl.int64) * K*V
+        if STATE_V_FIRST:
+            p_h = tl.make_block_ptr(h + o_h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+        else:
+            p_h = tl.make_block_ptr(h + o_h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+
+        if i_t % NTS == 0:
+            tl.store(p_h, (tl.trans(b_h) if STATE_V_FIRST else b_h).to(p_h.dtype.element_ty), boundary_check=(0, 1))
+        # [BK, BT]
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        # [BT, BV]
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        last_idx = min((i_t + 1) * BT, T) - 1
+
+        # scalar decay
+        if USE_G:
+            b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
+            p_g = g + bos*H + (i_t * BT + tl.arange(0, BT)) * H + i_h
+            b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.)
+            b_h *= exp(b_g_last)
+            b_v = (b_v * exp(b_g_last - b_g)[:, None]).to(b_v.dtype)
+
+        if USE_G_GAMMA:
+            b_g_last = b_gamma * min(BT, T - i_t * BT)
+            b_h *= exp(b_g_last)
+            b_v = (b_v * exp(b_g_last - b_g)[:, None]).to(b_v.dtype)
+
+        # vector decay, h = Diag(gk) @ h
+        if USE_GK:
+            p_gk = tl.make_block_ptr(gk + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
+            p_gk_last = gk + (bos + last_idx) * H*K + i_h * K + i_k * BK + tl.arange(0, BK)
+
+            b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.)
+            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            b_h *= exp(b_gk_last)[:, None]
+            b_k = (b_k * exp(b_gk_last[:, None] - b_gk)).to(b_k.dtype)
+
+        # vector decay, h = h @ Diag(gv)
+        if USE_GV:
+            p_gv = tl.make_block_ptr(gv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_gv_last = gv + (bos + last_idx) * H*V + i_h * V + i_v * BV + tl.arange(0, BV)
+
+            b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.)
+            b_gv = tl.load(p_gv, boundary_check=(0, 1))
+            b_h *= exp(b_gv_last)[None, :]
+            b_v = (b_v * exp(b_gv_last[None, :] - b_gv)).to(b_v.dtype)
+
+        b_h += tl.dot(b_k, b_v)
+
+    if STORE_FINAL_STATE:
+        if STATE_V_FIRST:
+            p_ht = tl.make_block_ptr(ht + i_nh * K*V, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            tl.store(p_ht, tl.trans(b_h).to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        else:
+            p_ht = tl.make_block_ptr(ht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics({
+    'STORE_INITIAL_STATE_GRADIENT': lambda args: args['dh0'] is not None,
+    'USE_FINAL_STATE_GRADIENT': lambda args: args['dht'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({'BK': BK, 'BV': BV}, num_warps=num_warps, num_stages=num_stages)
+        for BK in BKV_LIST
+        for BV in BKV_LIST
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=['BT', 'USE_G', 'USE_GK', 'USE_GV', 'STATE_V_FIRST'],
+)
+@triton.jit(do_not_specialize=['T'])
+def chunk_bwd_kernel_dh(
+    q,
+    g,
+    g_gamma,
+    gk,
+    gv,
+    do,
+    dh,
+    dht,
+    dh0,
+    cu_seqlens,
+    split_offsets,
+    scale,
+    T,
+    HQ: tl.constexpr,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    NG: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_G_GAMMA: tl.constexpr,
+    USE_GK: tl.constexpr,
+    USE_GV: tl.constexpr,
+    STORE_INITIAL_STATE_GRADIENT: tl.constexpr,
+    USE_FINAL_STATE_GRADIENT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
+):
+    i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_n, i_hq = i_nh // HQ, i_nh % HQ
+    i_h = i_hq // NG
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+        NS = tl.cdiv(T, BS)
+        boh = tl.load(split_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        NT = tl.cdiv(T, BT)
+        NS = tl.cdiv(T, BS)
+        boh = i_n * NS
+
+    if USE_G_GAMMA:
+        b_gamma = tl.load(g_gamma + i_h)
+        b_g = b_gamma * (tl.arange(0, BT) + 1)
+
+    # [BK, BV] accumulator; STATE_V_FIRST only flips the stored state's HBM layout to [V, K], applied at the load/store below.
+    b_dh = tl.zeros([BK, BV], dtype=tl.float32)
+    if USE_FINAL_STATE_GRADIENT:
+        if STATE_V_FIRST:
+            p_dht = tl.make_block_ptr(dht + i_nh * K*V, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            b_dh += tl.trans(tl.load(p_dht, boundary_check=(0, 1))).to(tl.float32)
+        else:
+            p_dht = tl.make_block_ptr(dht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            b_dh += tl.load(p_dht, boundary_check=(0, 1)).to(tl.float32)
+
+    for i_t in range(NT - 1, -1, -1):
+        i_s = i_t // (BS // BT)
+        o_dh = ((boh + i_s) * H + i_h).to(tl.int64) * K*V
+        if STATE_V_FIRST:
+            p_dh = tl.make_block_ptr(dh + o_dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+        else:
+            p_dh = tl.make_block_ptr(dh + o_dh, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+
+        if i_t % (BS // BT) == 0:
+            tl.store(p_dh, (tl.trans(b_dh) if STATE_V_FIRST else b_dh).to(p_dh.dtype.element_ty), boundary_check=(0, 1))
+        last_idx = min(i_t * BT + BT, T) - 1
+        # [BK, BT]
+        p_q = tl.make_block_ptr(q + (bos*HQ + i_hq) * K, (K, T), (1, HQ*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
+        p_do = tl.make_block_ptr(do + (bos*HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = (b_q * scale).to(b_q.dtype)
+        # [BT, BV]
+        b_do = tl.load(p_do, boundary_check=(0, 1))
+
+        if USE_G:
+            p_g = g + (bos + i_t * BT + tl.arange(0, BT)) * H + i_h
+            b_g_last = tl.load(g + (bos + last_idx) * H + i_h)
+            b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.)
+            b_q = (b_q * exp(b_g)[None, :]).to(b_q.dtype)
+            b_dh *= exp(b_g_last)
+
+        if USE_G_GAMMA:
+            b_g_last = b_gamma * min(BT, T - i_t * BT)
+            b_q = (b_q * exp(b_g)[None, :]).to(b_q.dtype)
+            b_dh *= exp(b_g_last)
+
+        if USE_GK:
+            p_gk = tl.make_block_ptr(gk + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
+            p_gk_last = gk + (bos + last_idx) * H*K + i_h * K + i_k * BK + tl.arange(0, BK)
+
+            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.)
+            b_q = (b_q * exp(b_gk)).to(b_q.dtype)
+            b_dh *= exp(b_gk_last)[:, None]
+
+        if USE_GV:
+            p_gv = tl.make_block_ptr(gv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_gv_last = gv + (bos + last_idx) * H*V + i_h * V + i_v * BV + tl.arange(0, BV)
+
+            b_gv = tl.load(p_gv, boundary_check=(0, 1))
+            b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.)
+            b_do = (b_do * exp(b_gv))
+            b_dh *= exp(b_gv_last)[None, :]
+
+        b_dh += tl.dot(b_q, b_do.to(b_q.dtype))
+
+    if STORE_INITIAL_STATE_GRADIENT:
+        if STATE_V_FIRST:
+            p_dh0 = tl.make_block_ptr(dh0 + i_nh * K*V, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            tl.store(p_dh0, tl.trans(b_dh).to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+        else:
+            p_dh0 = tl.make_block_ptr(dh0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_fwd_h(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor | None = None,
+    g_gamma: torch.Tensor | None = None,
+    gk: torch.Tensor | None = None,
+    gv: torch.Tensor | None = None,
+    h0: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    state_v_first: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_size: int = 64,
+    split_size: int | None = None,
+    states_in_fp32: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    BT = chunk_size
+    BS = BT if split_size is None else split_size
+    assert BS % BT == 0, f"The `split_size` (got {BS}) must be a multiple of `chunk_size` {BT}"
+    # N: the actual number of sequences in the batch with either equal or variable lengths
+    if cu_seqlens is None:
+        N, NS, split_offsets = B, triton.cdiv(T, BS), None
+    else:
+        split_offsets = prepare_chunk_offsets(cu_seqlens, BS)
+        N, NS = len(cu_seqlens) - 1, split_offsets[-1].item()
+
+    # `state_v_first` stores the states in V-first `[V, K]` layout instead of `[K, V]`
+    state_shape = (V, K) if state_v_first else (K, V)
+    h = k.new_empty(B, NS, H, *state_shape, dtype=k.dtype if not states_in_fp32 else torch.float)
+    ht = k.new_empty(N, H, *state_shape, dtype=torch.float) if output_final_state else None
+    def grid(meta): return (triton.cdiv(K, meta['BK']), triton.cdiv(V, meta['BV']), N * H)
+    chunk_fwd_kernel_h[grid](
+        k=k,
+        v=v,
+        h=h,
+        g=g,
+        g_gamma=g_gamma,
+        gk=gk,
+        gv=gv,
+        h0=h0,
+        ht=ht,
+        cu_seqlens=cu_seqlens,
+        split_offsets=split_offsets,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        BS=BS,
+        USE_G=g is not None,
+        USE_G_GAMMA=g_gamma is not None,
+        USE_GK=gk is not None,
+        USE_GV=gv is not None,
+        STATE_V_FIRST=state_v_first,
+    )
+    return h, ht
+
+
+def chunk_bwd_dh(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    do: torch.Tensor,
+    h0: torch.Tensor,
+    dht: torch.Tensor,
+    scale: float,
+    g: torch.Tensor | None = None,
+    g_gamma: torch.Tensor | None = None,
+    gk: torch.Tensor | None = None,
+    gv: torch.Tensor | None = None,
+    state_v_first: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_size: int = 64,
+    split_size: int | None = None,
+    states_in_fp32: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    HQ = q.shape[2]
+    BT = chunk_size
+    BS = BT if split_size is None else split_size
+    assert BS % BT == 0, f"The `split_size` (got {BS}) must be a multiple of `chunk_size` {BT}"
+    # N: the actual number of sequences in the batch with either equal or variable lengths
+    # NG: number of groups in GQA
+    if cu_seqlens is None:
+        N, NS, split_offsets = B, triton.cdiv(T, BS), None
+    else:
+        split_offsets = prepare_chunk_offsets(cu_seqlens, BS)
+        N, NS = len(cu_seqlens) - 1, split_offsets[-1].item()
+    NG = HQ // H
+
+    # `state_v_first` stores the states in V-first `[V, K]` layout instead of `[K, V]`
+    state_shape = (V, K) if state_v_first else (K, V)
+    dh = k.new_empty(B, NS, HQ, *state_shape, dtype=k.dtype if not states_in_fp32 else torch.float)
+    dh0 = torch.empty_like(h0, dtype=torch.float) if h0 is not None else None
+
+    def grid(meta): return (triton.cdiv(K, meta['BK']), triton.cdiv(V, meta['BV']), N * H)
+    chunk_bwd_kernel_dh[grid](
+        q=q,
+        g=g,
+        g_gamma=g_gamma,
+        gk=gk,
+        gv=gv,
+        do=do,
+        dh=dh,
+        dht=dht,
+        dh0=dh0,
+        cu_seqlens=cu_seqlens,
+        split_offsets=split_offsets,
+        scale=scale,
+        T=T,
+        HQ=HQ,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        BS=BS,
+        NG=NG,
+        USE_G=g is not None,
+        USE_G_GAMMA=g_gamma is not None,
+        USE_GK=gk is not None,
+        USE_GV=gv is not None,
+        STATE_V_FIRST=state_v_first,
+    )
+    return dh, dh0

--- a/src/flaggems_vllm/ops/FLA/chunk_h.py
+++ b/src/flaggems_vllm/ops/FLA/chunk_h.py
@@ -10,10 +10,14 @@ import triton
 import triton.language as tl
 
 from flaggems_vllm.ops.FLA.index import prepare_chunk_offsets
-from flaggems_vllm.ops.FLA.triton_ops_helper import exp
 from flaggems_vllm.ops.FLA.utils import check_shared_mem
 
 BKV_LIST = [32, 64] if check_shared_mem() else [16, 32]
+
+
+@triton.jit
+def exp2(x):
+    return tl.math.exp2(x.to(tl.float32))
 
 
 @triton.heuristics(
@@ -83,7 +87,8 @@ def chunk_fwd_kernel_h(
         b_gamma = tl.load(g_gamma + i_h)
         b_g = b_gamma * (tl.arange(0, BT) + 1)
 
-    # [BK, BV] accumulator; STATE_V_FIRST only flips the stored state's HBM layout to [V, K], applied at the load/store below.
+    # [BK, BV] accumulator; STATE_V_FIRST only flips the stored state's HBM layout to [V, K]
+    # applied at the load/store below.
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_INITIAL_STATE:
         if STATE_V_FIRST:
@@ -153,13 +158,13 @@ def chunk_fwd_kernel_h(
             b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
             p_g = g + bos * H + (i_t * BT + tl.arange(0, BT)) * H + i_h
             b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.0)
-            b_h *= exp(b_g_last)
-            b_v = (b_v * exp(b_g_last - b_g)[:, None]).to(b_v.dtype)
+            b_h *= exp2(b_g_last)
+            b_v = (b_v * exp2(b_g_last - b_g)[:, None]).to(b_v.dtype)
 
         if USE_G_GAMMA:
             b_g_last = b_gamma * min(BT, T - i_t * BT)
-            b_h *= exp(b_g_last)
-            b_v = (b_v * exp(b_g_last - b_g)[:, None]).to(b_v.dtype)
+            b_h *= exp2(b_g_last)
+            b_v = (b_v * exp2(b_g_last - b_g)[:, None]).to(b_v.dtype)
 
         # vector decay, h = Diag(gk) @ h
         if USE_GK:
@@ -179,8 +184,8 @@ def chunk_fwd_kernel_h(
                 p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.0
             )
             b_gk = tl.load(p_gk, boundary_check=(0, 1))
-            b_h *= exp(b_gk_last)[:, None]
-            b_k = (b_k * exp(b_gk_last[:, None] - b_gk)).to(b_k.dtype)
+            b_h *= exp2(b_gk_last)[:, None]
+            b_k = (b_k * exp2(b_gk_last[:, None] - b_gk)).to(b_k.dtype)
 
         # vector decay, h = h @ Diag(gv)
         if USE_GV:
@@ -200,8 +205,8 @@ def chunk_fwd_kernel_h(
                 p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.0
             )
             b_gv = tl.load(p_gv, boundary_check=(0, 1))
-            b_h *= exp(b_gv_last)[None, :]
-            b_v = (b_v * exp(b_gv_last[None, :] - b_gv)).to(b_v.dtype)
+            b_h *= exp2(b_gv_last)[None, :]
+            b_v = (b_v * exp2(b_gv_last[None, :] - b_gv)).to(b_v.dtype)
 
         b_h += tl.dot(b_k, b_v)
 
@@ -301,7 +306,8 @@ def chunk_bwd_kernel_dh(
         b_gamma = tl.load(g_gamma + i_h)
         b_g = b_gamma * (tl.arange(0, BT) + 1)
 
-    # [BK, BV] accumulator; STATE_V_FIRST only flips the stored state's HBM layout to [V, K], applied at the load/store below.
+    # [BK, BV] accumulator; STATE_V_FIRST only flips the stored state's HBM layout to [V, K]
+    # applied at the load/store below.
     b_dh = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_FINAL_STATE_GRADIENT:
         if STATE_V_FIRST:
@@ -370,13 +376,13 @@ def chunk_bwd_kernel_dh(
             p_g = g + (bos + i_t * BT + tl.arange(0, BT)) * H + i_h
             b_g_last = tl.load(g + (bos + last_idx) * H + i_h)
             b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.0)
-            b_q = (b_q * exp(b_g)[None, :]).to(b_q.dtype)
-            b_dh *= exp(b_g_last)
+            b_q = (b_q * exp2(b_g)[None, :]).to(b_q.dtype)
+            b_dh *= exp2(b_g_last)
 
         if USE_G_GAMMA:
             b_g_last = b_gamma * min(BT, T - i_t * BT)
-            b_q = (b_q * exp(b_g)[None, :]).to(b_q.dtype)
-            b_dh *= exp(b_g_last)
+            b_q = (b_q * exp2(b_g)[None, :]).to(b_q.dtype)
+            b_dh *= exp2(b_g_last)
 
         if USE_GK:
             p_gk = tl.make_block_ptr(
@@ -395,8 +401,8 @@ def chunk_bwd_kernel_dh(
             b_gk_last = tl.load(
                 p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.0
             )
-            b_q = (b_q * exp(b_gk)).to(b_q.dtype)
-            b_dh *= exp(b_gk_last)[:, None]
+            b_q = (b_q * exp2(b_gk)).to(b_q.dtype)
+            b_dh *= exp2(b_gk_last)[:, None]
 
         if USE_GV:
             p_gv = tl.make_block_ptr(
@@ -415,8 +421,8 @@ def chunk_bwd_kernel_dh(
             b_gv_last = tl.load(
                 p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.0
             )
-            b_do = b_do * exp(b_gv)
-            b_dh *= exp(b_gv_last)[None, :]
+            b_do = b_do * exp2(b_gv)
+            b_dh *= exp2(b_gv_last)[None, :]
 
         b_dh += tl.dot(b_q, b_do.to(b_q.dtype))
 

--- a/src/flaggems_vllm/ops/FLA/cumsum_gla.py
+++ b/src/flaggems_vllm/ops/FLA/cumsum_gla.py
@@ -1,0 +1,566 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+
+import torch
+import triton
+import triton.language as tl
+
+from flaggems_vllm.ops.FLA.index import prepare_chunk_indices
+from flaggems_vllm.ops.FLA.utils import check_shared_mem, input_guard
+from flaggems_vllm.utils import libtuner
+
+BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
+
+
+@triton.heuristics(
+    {
+        "HAS_SCALE": lambda args: args["scale"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@libtuner(
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4, 8]],
+    key=["B", "H", "BT", "IS_VARLEN", "REVERSE"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_local_cumsum_scalar_kernel(
+    s,
+    o,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    REVERSE: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HEAD_FIRST: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if HEAD_FIRST:
+        p_s = tl.make_block_ptr(
+            s + bos * H + i_h * T, (T,), (1,), (i_t * BT,), (BT,), (0,)
+        )
+        p_o = tl.make_block_ptr(
+            o + bos * H + i_h * T, (T,), (1,), (i_t * BT,), (BT,), (0,)
+        )
+    else:
+        p_s = tl.make_block_ptr(s + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+        p_o = tl.make_block_ptr(o + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    # [BT]
+    b_s = tl.load(p_s, boundary_check=(0,)).to(tl.float32)
+    b_o = tl.cumsum(b_s, axis=0)
+    if REVERSE:
+        b_z = tl.sum(b_s, axis=0)
+        b_o = -b_o + b_z[None] + b_s
+    if HAS_SCALE:
+        b_o *= scale
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
+
+
+@triton.heuristics(
+    {
+        "HAS_SCALE": lambda args: args["scale"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BS": BS}, num_warps=num_warps)
+        for BS in BS_LIST
+        for num_warps in [2, 4, 8]
+    ],
+    key=["B", "H", "S", "BT", "IS_VARLEN", "REVERSE"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_local_cumsum_vector_kernel(
+    s,
+    o,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+    REVERSE: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HEAD_FIRST: tl.constexpr,
+):
+    i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if HEAD_FIRST:
+        p_s = tl.make_block_ptr(
+            s + (bos * H + i_h * T) * S,
+            (T, S),
+            (S, 1),
+            (i_t * BT, i_s * BS),
+            (BT, BS),
+            (1, 0),
+        )
+        p_o = tl.make_block_ptr(
+            o + (bos * H + i_h * T) * S,
+            (T, S),
+            (S, 1),
+            (i_t * BT, i_s * BS),
+            (BT, BS),
+            (1, 0),
+        )
+    else:
+        p_s = tl.make_block_ptr(
+            s + (bos * H + i_h) * S,
+            (T, S),
+            (H * S, 1),
+            (i_t * BT, i_s * BS),
+            (BT, BS),
+            (1, 0),
+        )
+        p_o = tl.make_block_ptr(
+            o + (bos * H + i_h) * S,
+            (T, S),
+            (H * S, 1),
+            (i_t * BT, i_s * BS),
+            (BT, BS),
+            (1, 0),
+        )
+    # [BT, BS]
+    b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+    if REVERSE:
+        b_o = tl.cumsum(b_s, axis=0, reverse=True)
+    else:
+        b_o = tl.cumsum(b_s, axis=0)
+    if HAS_SCALE:
+        b_o *= scale
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "HAS_SCALE": lambda args: args["scale"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BT": BT}, num_warps=num_warps, num_stages=num_stages)
+        for BT in [32, 64, 128, 256]
+        for num_warps in [2, 4, 8]
+        for num_stages in [1, 2, 3, 4]
+    ],
+    key=["B", "H", "IS_VARLEN", "REVERSE"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_global_cumsum_scalar_kernel(
+    s,
+    o,
+    scale,
+    cu_seqlens,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    REVERSE: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HEAD_FIRST: tl.constexpr,
+):
+    i_nh = tl.program_id(0)
+    i_n, i_h = i_nh // H, i_nh % H
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+    T = eos - bos
+
+    b_z = tl.zeros([], dtype=tl.float32)
+    NT = tl.cdiv(T, BT)
+    for i_c in range(NT):
+        i_t = NT - 1 - i_c if REVERSE else i_c
+        if HEAD_FIRST:
+            p_s = tl.make_block_ptr(
+                s + bos * H + i_h * T, (T,), (1,), (i_t * BT,), (BT,), (0,)
+            )
+            p_o = tl.make_block_ptr(
+                o + bos * H + i_h * T, (T,), (1,), (i_t * BT,), (BT,), (0,)
+            )
+        else:
+            p_s = tl.make_block_ptr(
+                s + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+            )
+            p_o = tl.make_block_ptr(
+                o + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+            )
+        b_s = tl.load(p_s, boundary_check=(0,)).to(tl.float32)
+        b_o = tl.cumsum(b_s, axis=0)
+        b_ss = tl.sum(b_s, 0)
+        if REVERSE:
+            b_o = -b_o + b_ss + b_s
+        b_o += b_z
+        if i_c >= 0:
+            b_z += b_ss
+        if HAS_SCALE:
+            b_o *= scale
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
+
+
+@triton.heuristics(
+    {
+        "HAS_SCALE": lambda args: args["scale"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BT": BT}, num_warps=num_warps, num_stages=num_stages)
+        for BT in [16, 32, 64, 128]
+        for num_warps in [2, 4, 8]
+        for num_stages in [1, 2, 3, 4]
+    ],
+    key=["B", "H", "S", "IS_VARLEN", "REVERSE"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_global_cumsum_vector_kernel(
+    s,
+    o,
+    scale,
+    cu_seqlens,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+    REVERSE: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HEAD_FIRST: tl.constexpr,
+):
+    i_s, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_h = i_nh // H, i_nh % H
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+    T = eos - bos
+
+    b_z = tl.zeros([BS], dtype=tl.float32)
+    NT = tl.cdiv(T, BT)
+    for i_c in range(NT):
+        i_t = NT - 1 - i_c if REVERSE else i_c
+        if HEAD_FIRST:
+            p_s = tl.make_block_ptr(
+                s + (bos * H + i_h * T) * S,
+                (T, S),
+                (S, 1),
+                (i_t * BT, i_s * BS),
+                (BT, BS),
+                (1, 0),
+            )
+            p_o = tl.make_block_ptr(
+                o + (bos * H + i_h * T) * S,
+                (T, S),
+                (S, 1),
+                (i_t * BT, i_s * BS),
+                (BT, BS),
+                (1, 0),
+            )
+        else:
+            p_s = tl.make_block_ptr(
+                s + (bos * H + i_h) * S,
+                (T, S),
+                (H * S, 1),
+                (i_t * BT, i_s * BS),
+                (BT, BS),
+                (1, 0),
+            )
+            p_o = tl.make_block_ptr(
+                o + (bos * H + i_h) * S,
+                (T, S),
+                (H * S, 1),
+                (i_t * BT, i_s * BS),
+                (BT, BS),
+                (1, 0),
+            )
+        # [BT, BS]
+        b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+        if REVERSE:
+            b_c = b_z[None, :] + tl.cumsum(b_s, axis=0, reverse=True)
+        else:
+            b_c = b_z[None, :] + tl.cumsum(b_s, axis=0)
+        if HAS_SCALE:
+            b_c *= scale
+        tl.store(p_o, b_c.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+        b_z += tl.sum(b_s, 0)
+
+
+def chunk_local_cumsum_scalar(
+    g: torch.Tensor,
+    chunk_size: int,
+    reverse: bool = False,
+    scale: float = None,
+    cu_seqlens: torch.Tensor | None = None,
+    head_first: bool = False,
+    output_dtype: torch.dtype | None = torch.float,
+    chunk_indices: torch.LongTensor | None = None,
+) -> torch.Tensor:
+    if head_first:
+        B, H, T = g.shape
+    else:
+        B, T, H = g.shape
+    assert chunk_size == 2 ** (
+        chunk_size.bit_length() - 1
+    ), "chunk_size must be a power of 2"
+    BT = chunk_size
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    g_org, g = g, torch.empty_like(g, dtype=output_dtype or g.dtype)
+    grid = (NT, B * H)
+    chunk_local_cumsum_scalar_kernel[grid](
+        s=g_org,
+        o=g,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        B=B,
+        H=H,
+        BT=BT,
+        HEAD_FIRST=head_first,
+        REVERSE=reverse,
+    )
+    return g
+
+
+def chunk_local_cumsum_vector(
+    g: torch.Tensor,
+    chunk_size: int,
+    reverse: bool = False,
+    scale: float = None,
+    cu_seqlens: torch.Tensor | None = None,
+    head_first: bool = False,
+    output_dtype: torch.dtype | None = torch.float,
+    chunk_indices: torch.LongTensor | None = None,
+) -> torch.Tensor:
+    if head_first:
+        B, H, T, S = g.shape
+    else:
+        B, T, H, S = g.shape
+    BT = chunk_size
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    assert chunk_size == 2 ** (
+        chunk_size.bit_length() - 1
+    ), "chunk_size must be a power of 2"
+
+    g_org, g = g, torch.empty_like(g, dtype=output_dtype or g.dtype)
+
+    def grid(meta):
+        return (triton.cdiv(meta["S"], meta["BS"]), NT, B * H)
+
+    # keep cummulative normalizer in fp32
+    # this kernel is equivalent to
+    # g = g.view(B, H, NT, BT, -1).cumsum(-2).view(B, H, T, -1)
+    chunk_local_cumsum_vector_kernel[grid](
+        s=g_org,
+        o=g,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        B=B,
+        H=H,
+        S=S,
+        BT=BT,
+        HEAD_FIRST=head_first,
+        REVERSE=reverse,
+    )
+    return g
+
+
+@input_guard
+def chunk_global_cumsum_scalar(
+    s: torch.Tensor,
+    reverse: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    scale: float = None,
+    head_first: bool = False,
+    output_dtype: torch.dtype | None = torch.float,
+) -> torch.Tensor:
+    if head_first:
+        B, H, T = s.shape
+    else:
+        B, T, H = s.shape
+    N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
+
+    z = torch.empty_like(s, dtype=output_dtype or s.dtype)
+    grid = (N * H,)
+    chunk_global_cumsum_scalar_kernel[grid](
+        s=s,
+        o=z,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        T=T,
+        B=B,
+        H=H,
+        HEAD_FIRST=head_first,
+        REVERSE=reverse,
+    )
+    return z
+
+
+@input_guard
+def chunk_global_cumsum_vector(
+    s: torch.Tensor,
+    reverse: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    scale: float = None,
+    head_first: bool = False,
+    output_dtype: torch.dtype | None = torch.float,
+) -> torch.Tensor:
+    if head_first:
+        B, H, T, S = s.shape
+    else:
+        B, T, H, S = s.shape
+    N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
+    BS = min(32, triton.next_power_of_2(S))
+
+    z = torch.empty_like(s, dtype=output_dtype or s.dtype)
+    grid = (triton.cdiv(S, BS), N * H)
+    chunk_global_cumsum_vector_kernel[grid](
+        s=s,
+        o=z,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        T=T,
+        B=B,
+        H=H,
+        S=S,
+        BS=BS,
+        HEAD_FIRST=head_first,
+        REVERSE=reverse,
+    )
+    return z
+
+
+@input_guard
+def chunk_global_cumsum(
+    s: torch.Tensor,
+    reverse: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    scale: float = None,
+    head_first: bool = False,
+    output_dtype: torch.dtype | None = torch.float,
+) -> torch.Tensor:
+    if cu_seqlens is not None:
+        assert (
+            s.shape[0] == 1
+        ), "Only batch size 1 is supported when cu_seqlens are provided"
+    if len(s.shape) == 3:
+        return chunk_global_cumsum_scalar(
+            s=s,
+            reverse=reverse,
+            cu_seqlens=cu_seqlens,
+            scale=scale,
+            head_first=head_first,
+            output_dtype=output_dtype,
+        )
+    elif len(s.shape) == 4:
+        return chunk_global_cumsum_vector(
+            s=s,
+            reverse=reverse,
+            cu_seqlens=cu_seqlens,
+            scale=scale,
+            head_first=head_first,
+            output_dtype=output_dtype,
+        )
+    else:
+        raise ValueError(
+            f"Unsupported input shape {s.shape}, "
+            f"which should be [B, T, H]/[B, T, H, D] if `head_first=False` "
+            f"or [B, H, T]/[B, H, T, D] otherwise",
+        )
+
+
+@input_guard
+def chunk_local_cumsum(
+    g: torch.Tensor,
+    chunk_size: int,
+    reverse: bool = False,
+    scale: float = None,
+    cu_seqlens: torch.Tensor | None = None,
+    head_first: bool = False,
+    output_dtype: torch.dtype | None = torch.float,
+    chunk_indices: torch.LongTensor | None = None,
+    **kwargs,
+) -> torch.Tensor:
+    if cu_seqlens is not None:
+        assert (
+            g.shape[0] == 1
+        ), "Only batch size 1 is supported when cu_seqlens are provided"
+    if len(g.shape) == 3:
+        return chunk_local_cumsum_scalar(
+            g=g,
+            chunk_size=chunk_size,
+            reverse=reverse,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            head_first=head_first,
+            output_dtype=output_dtype,
+            chunk_indices=chunk_indices,
+        )
+    elif len(g.shape) == 4:
+        return chunk_local_cumsum_vector(
+            g=g,
+            chunk_size=chunk_size,
+            reverse=reverse,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            head_first=head_first,
+            output_dtype=output_dtype,
+            chunk_indices=chunk_indices,
+        )
+    else:
+        raise ValueError(
+            f"Unsupported input shape {g.shape}, "
+            f"which should be (B, T, H, D) if `head_first=False` "
+            f"or (B, H, T, D) otherwise",
+        )

--- a/tests/test_FLA/test_chunk_gla.py
+++ b/tests/test_FLA/test_chunk_gla.py
@@ -1,14 +1,874 @@
+# Self-contained fused_recurrent_gla implementation
+# Inlined from:
+#   fla/ops/gla/fused_recurrent.py
+#   fla/ops/common/fused_recurrent.py
+#   fla/ops/utils/op.py (exp only)
+#   fla/utils.py (autocast, input_guard, autotune_cache_kwargs)
+
+import contextlib
+import functools
 import inspect
+import inspect as _inspect
 import os
+import os as _os
 
 import pytest
 import torch
 import torch.nn.functional as F
-from fla.ops.gla import fused_recurrent_gla
+import triton
+import triton.language as tl
 
 import flaggems_vllm
 from flaggems_vllm.ops.FLA.chunk_gla import chunk_gla
 from flaggems_vllm.ops.FLA.index import prepare_chunk_indices as _prepare_chunk_indices
+
+
+# --- From fla/ops/utils/op.py: exp ---
+@triton.jit
+def exp(x):
+    return tl.exp(x.to(tl.float32))
+
+
+# --- From fla/utils.py: autotune_cache_kwargs ---
+if "cache_results" in _inspect.signature(triton.autotune).parameters:
+    _autotune_cache_kwargs = {
+        "cache_results": _os.getenv("FLA_CACHE_RESULTS", "1") == "1"
+    }
+else:
+    _autotune_cache_kwargs = {}
+
+# --- From fla/utils.py: autocast helpers ---
+_autocast_custom_fwd = torch.amp.custom_fwd(device_type="cuda")
+_autocast_custom_bwd = torch.amp.custom_bwd(device_type="cuda")
+
+
+# --- From fla/utils.py: input_guard (minimal) ---
+def _input_guard(fn=None, *, no_guard_contiguous=False):
+    def _decorator(fn):
+        sig = _inspect.signature(fn)
+        param_names = list(sig.parameters.keys())
+        skip_params = set()
+        if isinstance(no_guard_contiguous, list):
+            skip_params = set(no_guard_contiguous)
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            processed_args = []
+            for i, arg in enumerate(args):
+                if i < len(param_names):
+                    pname = param_names[i]
+                else:
+                    pname = "__arg_{}".format(i)
+                if isinstance(arg, torch.Tensor):
+                    if no_guard_contiguous is True or pname in skip_params:
+                        processed_args.append(arg)
+                    else:
+                        processed_args.append(arg.contiguous())
+                else:
+                    processed_args.append(arg)
+
+            processed_kwargs = {}
+            for k, v in kwargs.items():
+                if isinstance(v, torch.Tensor):
+                    if no_guard_contiguous is True or k in skip_params:
+                        processed_kwargs[k] = v
+                    else:
+                        processed_kwargs[k] = v.contiguous()
+                else:
+                    processed_kwargs[k] = v
+
+            tensor = None
+            for arg in args:
+                if isinstance(arg, torch.Tensor):
+                    tensor = arg
+                    break
+            if tensor is None:
+                for v in kwargs.values():
+                    if isinstance(v, torch.Tensor):
+                        tensor = v
+                        break
+
+            if tensor is not None and tensor.device.type == "cuda":
+                ctx = torch.cuda.device(tensor.device.index)
+            else:
+                ctx = contextlib.nullcontext()
+            with ctx:
+                return fn(*processed_args, **processed_kwargs)
+
+        return wrapper
+
+    if fn is not None:
+        return _decorator(fn)
+    return _decorator
+
+
+# --- From fla/ops/common/fused_recurrent.py: fwd kernel ---
+@triton.heuristics(
+    {
+        "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+        "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [4, 8]],
+    key=["BK", "BV", "USE_G", "USE_G_GAMMA", "USE_GK", "USE_GV", "STATE_V_FIRST"],
+    **_autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["B", "T"])
+def _fused_recurrent_fwd_kernel(
+    q,
+    k,
+    v,
+    g,
+    g_gamma,
+    gk,
+    gv,
+    o,
+    h0,
+    ht,
+    cu_seqlens,
+    scale,
+    B,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    REVERSE: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_G_GAMMA: tl.constexpr,
+    USE_GK: tl.constexpr,
+    USE_GV: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr = False,
+):
+    i_v, i_k, i_nh = (
+        tl.program_id(0).to(tl.int64),
+        tl.program_id(1).to(tl.int64),
+        tl.program_id(2).to(tl.int64),
+    )
+    i_n, i_h = i_nh // H, i_nh % H
+
+    all = B * T
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int64)
+        T = eos - bos
+    else:
+        bos, eos = i_n * T, i_n * T + T
+
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    p_q = q + (bos + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+    p_k = k + (bos + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+    p_v = v + (bos + ((T - 1) if REVERSE else 0)) * H * V + i_h * V + o_v
+    p_o = o + ((i_k * all + bos) + ((T - 1) if REVERSE else 0)) * H * V + i_h * V + o_v
+    if USE_G:
+        p_g = g + (bos + ((T - 1) if REVERSE else 0)) * H + i_h
+    if USE_GK:
+        p_gk = gk + (bos + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+    if USE_GV:
+        p_gv = gv + (bos + ((T - 1) if REVERSE else 0)) * H * V + i_h * V + o_v
+    if USE_G_GAMMA:
+        b_g_gamma = tl.load(g_gamma + i_h)
+
+    m_k = o_k < K
+    m_v = o_v < V
+    if STATE_V_FIRST:
+        m_h = m_v[:, None] & m_k[None, :]
+        b_h = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        m_h = m_k[:, None] & m_v[None, :]
+        b_h = tl.zeros([BK, BV], dtype=tl.float32)
+
+    if USE_INITIAL_STATE:
+        if STATE_V_FIRST:
+            p_h0 = h0 + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_h0 = h0 + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+        b_h += tl.load(p_h0, mask=m_h, other=0).to(tl.float32)
+
+    for _ in range(0, T):
+        b_q = tl.load(p_q, mask=m_k, other=0).to(tl.float32) * scale
+        b_k = tl.load(p_k, mask=m_k, other=0).to(tl.float32)
+        b_v = tl.load(p_v, mask=m_v, other=0).to(tl.float32)
+        if USE_G:
+            b_g = tl.load(p_g).to(tl.float32)
+            b_h = b_h * exp(b_g)
+        if USE_G_GAMMA:
+            b_h = b_h * exp(b_g_gamma)
+        if USE_GK:
+            b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
+            if STATE_V_FIRST:
+                b_h = b_h * exp(b_gk[None, :])
+            else:
+                b_h = b_h * exp(b_gk[:, None])
+        if USE_GV:
+            b_gv = tl.load(p_gv, mask=m_v, other=0).to(tl.float32)
+            if STATE_V_FIRST:
+                b_h = b_h * exp(b_gv[:, None])
+            else:
+                b_h = b_h * exp(b_gv[None, :])
+        if STATE_V_FIRST:
+            b_h += b_v[:, None] * b_k[None, :]
+            b_o = tl.sum(b_h * b_q[None, :], axis=1)
+        else:
+            b_h += b_k[:, None] * b_v[None, :]
+            b_o = tl.sum(b_h * b_q[:, None], axis=0)
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_v)
+        p_q += (-1 if REVERSE else 1) * H * K
+        p_k += (-1 if REVERSE else 1) * H * K
+        p_v += (-1 if REVERSE else 1) * H * V
+        p_o += (-1 if REVERSE else 1) * H * V
+        if USE_G:
+            p_g += (-1 if REVERSE else 1) * H
+        if USE_GK:
+            p_gk += (-1 if REVERSE else 1) * H * K
+        if USE_GV:
+            p_gv += (-1 if REVERSE else 1) * H * V
+
+    if STORE_FINAL_STATE:
+        if STATE_V_FIRST:
+            p_ht = ht + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_ht = ht + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=m_h)
+
+
+# --- From fla/ops/common/fused_recurrent.py: bwd kernel ---
+@triton.heuristics(
+    {
+        "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+        "STORE_INITIAL_STATE_GRADIENT": lambda args: args["dh0"] is not None,
+        "USE_FINAL_STATE_GRADIENT": lambda args: args["dht"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [4]],
+    key=["BK", "BV", "USE_G", "USE_G_GAMMA", "USE_GK", "USE_GV", "STATE_V_FIRST"],
+    **_autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["B", "T"])
+def _fused_recurrent_bwd_kernel(
+    q,
+    k,
+    v,
+    g,
+    g_gamma,
+    gk,
+    gv,
+    o,
+    h0,
+    do,
+    dq,
+    dk,
+    dv,
+    dg,
+    dgk,
+    dgv,
+    dht,
+    dh0,
+    cu_seqlens,
+    scale,
+    B,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    REVERSE: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_G_GAMMA: tl.constexpr,
+    USE_GK: tl.constexpr,
+    USE_GV: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_INITIAL_STATE_GRADIENT: tl.constexpr,
+    USE_FINAL_STATE_GRADIENT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr = False,
+):
+    i_v, i_k, i_nh = (
+        tl.program_id(0).to(tl.int64),
+        tl.program_id(1).to(tl.int64),
+        tl.program_id(2).to(tl.int64),
+    )
+    i_n, i_h = i_nh // H, i_nh % H
+
+    all = B * T
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int64)
+        T = eos - bos
+    else:
+        bos, eos = i_n * T, i_n * T + T
+    NV = tl.cdiv(V, BV)
+
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_k = o_k < K
+    m_v = o_v < V
+    if STATE_V_FIRST:
+        m_h = m_v[:, None] & m_k[None, :]
+    else:
+        m_h = m_k[:, None] & m_v[None, :]
+
+    p_k = k + (bos + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+    p_v = v + (bos + ((T - 1) if REVERSE else 0)) * H * V + i_h * V + o_v
+    p_do = do + (bos + ((T - 1) if REVERSE else 0)) * H * V + i_h * V + o_v
+    p_dq = (
+        dq + ((i_v * all + bos) + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+    )
+    if USE_G:
+        p_g = g + (bos + ((T - 1) if REVERSE else 0)) * H + i_h
+    if USE_GK:
+        p_gk = gk + (bos + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+    if USE_GV:
+        p_gv = gv + (bos + ((T - 1) if REVERSE else 0)) * H * V + i_h * V + o_v
+    if USE_G_GAMMA:
+        b_g_gamma = tl.load(g_gamma + i_h)
+
+    if STATE_V_FIRST:
+        b_h = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    if USE_INITIAL_STATE:
+        if STATE_V_FIRST:
+            p_h0 = h0 + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_h0 = h0 + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+        b_h += tl.load(p_h0, mask=m_h, other=0).to(tl.float32)
+
+    for _ in range(0, T):
+        b_k = tl.load(p_k, mask=m_k, other=0).to(tl.float32)
+        b_v = tl.load(p_v, mask=m_v, other=0).to(tl.float32)
+        b_do = tl.load(p_do, mask=m_v, other=0).to(tl.float32)
+        if USE_G:
+            b_g = tl.load(p_g).to(tl.float32)
+            b_h = b_h * exp(b_g)
+        if USE_G_GAMMA:
+            b_h = b_h * exp(b_g_gamma)
+        if USE_GK:
+            b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
+            if STATE_V_FIRST:
+                b_h = b_h * exp(b_gk[None, :])
+            else:
+                b_h = b_h * exp(b_gk[:, None])
+        if USE_GV:
+            b_gv = tl.load(p_gv, mask=m_v, other=0).to(tl.float32)
+            if STATE_V_FIRST:
+                b_h = b_h * exp(b_gv[:, None])
+            else:
+                b_h = b_h * exp(b_gv[None, :])
+        if STATE_V_FIRST:
+            b_h += b_v[:, None] * b_k[None, :]
+            b_dq = tl.sum(b_h * b_do[:, None], axis=0) * scale
+        else:
+            b_h += b_k[:, None] * b_v[None, :]
+            b_dq = tl.sum(b_h * b_do[None, :], axis=1) * scale
+        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_k)
+
+        p_k += (-1 if REVERSE else 1) * H * K
+        p_v += (-1 if REVERSE else 1) * H * V
+        p_do += (-1 if REVERSE else 1) * H * V
+        p_dq += (-1 if REVERSE else 1) * H * K
+        if USE_G:
+            p_g += (-1 if REVERSE else 1) * H
+        if USE_GK:
+            p_gk += (-1 if REVERSE else 1) * H * K
+        if USE_GV:
+            p_gv += (-1 if REVERSE else 1) * H * V
+
+    # sync threads
+    tl.debug_barrier()
+
+    p_q = q + (bos + ((T - 1) if not REVERSE else 0)) * H * K + i_h * K + o_k
+    p_k = k + (bos + ((T - 1) if not REVERSE else 0)) * H * K + i_h * K + o_k
+    p_v = v + (bos + ((T - 1) if not REVERSE else 0)) * H * V + i_h * V + o_v
+
+    p_do = do + (bos + ((T - 1) if not REVERSE else 0)) * H * V + i_h * V + o_v
+    p_dq = (
+        dq
+        + ((i_v * all + bos) + ((T - 1) if not REVERSE else 0)) * H * K
+        + i_h * K
+        + o_k
+    )
+    p_dk = (
+        dk
+        + ((i_v * all + bos) + ((T - 1) if not REVERSE else 0)) * H * K
+        + i_h * K
+        + o_k
+    )
+    p_dv = (
+        dv
+        + ((i_k * all + bos) + ((T - 1) if not REVERSE else 0)) * H * V
+        + i_h * V
+        + o_v
+    )
+    if USE_G:
+        p_g = g + (bos + ((T - 1) if not REVERSE else 0)) * H + i_h
+        p_dg = (
+            dg
+            + ((i_k * NV + i_v) * all + bos + ((T - 1) if not REVERSE else 0)) * H
+            + i_h
+        )
+    if USE_GK:
+        p_gk = gk + (bos + ((T - 1) if not REVERSE else 0)) * H * K + i_h * K + o_k
+        p_dgk = (
+            dgk
+            + ((i_v * all + bos) + ((T - 1) if not REVERSE else 0)) * H * K
+            + i_h * K
+            + o_k
+        )
+    if USE_GV:
+        p_o = o + (bos + ((T - 1) if not REVERSE else 0)) * H * V + i_h * V + o_v
+        p_gv = gv + (bos + ((T - 1) if not REVERSE else 0)) * H * V + i_h * V + o_v
+        p_dgv = (
+            dgv
+            + ((i_k * all + bos) + ((T - 1) if not REVERSE else 0)) * H * V
+            + i_h * V
+            + o_v
+        )
+
+    if STATE_V_FIRST:
+        b_dh = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_dh = tl.zeros([BK, BV], dtype=tl.float32)
+    if USE_FINAL_STATE_GRADIENT:
+        if STATE_V_FIRST:
+            p_dht = dht + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_dht = dht + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+        b_dh += tl.load(p_dht, mask=m_h, other=0).to(tl.float32)
+
+    if USE_G:
+        b_dg = tl.sum(b_h * b_dh)
+    if USE_GK:
+        if STATE_V_FIRST:
+            b_dgk = tl.sum(b_h * b_dh, 0)
+        else:
+            b_dgk = tl.sum(b_h * b_dh, 1)
+    if USE_GV:
+        if STATE_V_FIRST:
+            b_dgv = tl.sum(b_h * b_dh, 1)
+        else:
+            b_dgv = tl.sum(b_h * b_dh, 0)
+
+    for _ in range(T):
+        b_q = tl.load(p_q, mask=m_k, other=0).to(tl.float32)
+        b_k = tl.load(p_k, mask=m_k, other=0).to(tl.float32)
+        b_v = tl.load(p_v, mask=m_v, other=0).to(tl.float32)
+        b_do = tl.load(p_do, mask=m_v, other=0).to(tl.float32)
+        if STATE_V_FIRST:
+            b_dh += b_do[:, None] * (b_q * scale)[None, :]
+            b_dk = tl.sum(b_dh * b_v[:, None], axis=0)
+            b_dv = tl.sum(b_dh * b_k[None, :], axis=1)
+        else:
+            b_dh += (b_q * scale)[:, None] * b_do[None, :]
+            b_dk = tl.sum(b_dh * b_v[None, :], axis=1)
+            b_dv = tl.sum(b_dh * b_k[:, None], axis=0)
+
+        if USE_G:
+            b_g = tl.load(p_g).to(tl.float32)
+            b_dq = tl.load(p_dq, mask=m_k, other=0).to(tl.float32)
+            b_dg += tl.sum(b_q * b_dq - b_k * b_dk)
+            b_dh *= exp(b_g)
+            tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty))
+        if USE_G_GAMMA:
+            b_dh *= exp(b_g_gamma)
+        if USE_GK:
+            b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
+            b_dq = tl.load(p_dq, mask=m_k, other=0).to(tl.float32)
+            b_dgk += b_q * b_dq - b_k * b_dk
+            if STATE_V_FIRST:
+                b_dh *= exp(b_gk)[None, :]
+            else:
+                b_dh *= exp(b_gk)[:, None]
+            tl.store(p_dgk, b_dgk.to(p_dgk.dtype.element_ty), mask=m_k)
+        if USE_GV:
+            b_o = tl.load(p_o, mask=m_v, other=0).to(tl.float32)
+            b_gv = tl.load(p_gv, mask=m_v, other=0).to(tl.float32)
+            if i_k == 0:
+                b_dgv += b_o * b_do
+            b_dgv -= b_v * b_dv
+            if STATE_V_FIRST:
+                b_dh *= exp(b_gv)[:, None]
+            else:
+                b_dh *= exp(b_gv)[None, :]
+            tl.store(p_dgv, b_dgv.to(p_dgv.dtype.element_ty), mask=m_v)
+
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k)
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_v)
+
+        p_q += (1 if REVERSE else -1) * H * K
+        p_k += (1 if REVERSE else -1) * H * K
+        p_v += (1 if REVERSE else -1) * H * V
+
+        p_do += (1 if REVERSE else -1) * H * V
+        p_dq += (1 if REVERSE else -1) * H * K
+        p_dk += (1 if REVERSE else -1) * H * K
+        p_dv += (1 if REVERSE else -1) * H * V
+        if USE_G:
+            p_g += (1 if REVERSE else -1) * H
+            p_dg += (1 if REVERSE else -1) * H
+        if USE_GK:
+            p_gk += (1 if REVERSE else -1) * H * K
+            p_dgk += (1 if REVERSE else -1) * H * K
+        if USE_GV:
+            p_o += (1 if REVERSE else -1) * H * V
+            p_gv += (1 if REVERSE else -1) * H * V
+            p_dgv += (1 if REVERSE else -1) * H * V
+
+    if STORE_INITIAL_STATE_GRADIENT:
+        if STATE_V_FIRST:
+            p_dh0 = dh0 + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_dh0 = dh0 + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=m_h)
+
+
+# --- From fla/ops/common/fused_recurrent.py: Python wrappers ---
+
+
+def _fused_recurrent_fwd(
+    q,
+    k,
+    v,
+    g=None,
+    g_gamma=None,
+    gk=None,
+    gv=None,
+    scale=None,
+    initial_state=None,
+    output_final_state=False,
+    reverse=False,
+    state_v_first=False,
+    cu_seqlens=None,
+):
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    N = B if cu_seqlens is None else len(cu_seqlens) - 1
+    BK, BV = min(triton.next_power_of_2(K), 64), min(triton.next_power_of_2(V), 64)
+    NK, NV = triton.cdiv(K, BK), triton.cdiv(V, BV)
+
+    h0 = initial_state
+    if output_final_state:
+        if state_v_first:
+            ht = q.new_empty(N, H, V, K, dtype=torch.float32)
+        else:
+            ht = q.new_empty(N, H, K, V, dtype=torch.float32)
+    else:
+        ht = None
+    o = q.new_empty(NK, *v.shape, dtype=torch.float32)
+
+    grid = (NV, NK, N * H)
+    _fused_recurrent_fwd_kernel[grid](
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        g_gamma=g_gamma,
+        gk=gk,
+        gv=gv,
+        o=o,
+        h0=h0,
+        ht=ht,
+        cu_seqlens=cu_seqlens,
+        scale=scale,
+        T=T,
+        B=B,
+        H=H,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        USE_G=g is not None,
+        USE_G_GAMMA=g_gamma is not None,
+        USE_GK=gk is not None,
+        USE_GV=gv is not None,
+        REVERSE=reverse,
+        STATE_V_FIRST=state_v_first,
+    )
+    o = o.sum(0)
+    return o, ht
+
+
+def _fused_recurrent_bwd(
+    q,
+    k,
+    v,
+    g=None,
+    g_gamma=None,
+    gk=None,
+    gv=None,
+    o=None,
+    do=None,
+    dht=None,
+    scale=None,
+    initial_state=None,
+    reverse=False,
+    state_v_first=False,
+    cu_seqlens=None,
+):
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    N = B if cu_seqlens is None else len(cu_seqlens) - 1
+
+    BK, BV = min(triton.next_power_of_2(K), 64), min(triton.next_power_of_2(V), 64)
+    NK, NV = triton.cdiv(K, BK), triton.cdiv(V, BV)
+
+    h0 = initial_state
+    dq = q.new_empty(NV, *q.shape, dtype=torch.float32)
+    dk = q.new_empty(NV, *k.shape, dtype=torch.float32)
+    dv = q.new_empty(NK, *v.shape, dtype=torch.float32)
+    dh0 = torch.empty_like(h0) if h0 is not None else None
+
+    dg, dgk, dgv = None, None, None
+    if g is not None:
+        dg = g.new_empty(NK * NV, *g.shape, dtype=torch.float32)
+    if gk is not None:
+        dgk = gk.new_empty(NV, *gk.shape, dtype=torch.float32)
+    if gv is not None:
+        dgv = gv.new_empty(NK, *gv.shape, dtype=torch.float32)
+
+    grid = (NV, NK, N * H)
+    _fused_recurrent_bwd_kernel[grid](
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        g_gamma=g_gamma,
+        gk=gk,
+        gv=gv,
+        o=o,
+        h0=h0,
+        do=do,
+        dq=dq,
+        dk=dk,
+        dv=dv,
+        dg=dg,
+        dgk=dgk,
+        dgv=dgv,
+        dht=dht,
+        dh0=dh0,
+        cu_seqlens=cu_seqlens,
+        scale=scale,
+        B=B,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        USE_G=g is not None,
+        USE_G_GAMMA=g_gamma is not None,
+        USE_GK=gk is not None,
+        USE_GV=gv is not None,
+        REVERSE=reverse,
+        STATE_V_FIRST=state_v_first,
+    )
+    dq = dq.sum(0)
+    dk = dk.sum(0)
+    dv = dv.sum(0)
+    if g is not None:
+        dg = dg.sum(0).to(g)
+    if gk is not None:
+        dgk = dgk.sum(0).to(gk)
+    if gv is not None:
+        dgv = dgv.sum(0).to(gv)
+
+    return dq, dk, dv, dg, dgk, dgv, dh0
+
+
+# --- From fla/ops/common/fused_recurrent.py: autograd Function ---
+class _FusedRecurrentFunction(torch.autograd.Function):
+
+    @staticmethod
+    @_input_guard
+    @_autocast_custom_fwd
+    def forward(
+        ctx,
+        q,
+        k,
+        v,
+        g=None,
+        g_gamma=None,
+        gk=None,
+        gv=None,
+        scale=None,
+        initial_state=None,
+        output_final_state=False,
+        reverse=False,
+        state_v_first=False,
+        cu_seqlens=None,
+    ):
+        o, ht = _fused_recurrent_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            g_gamma=g_gamma,
+            gk=gk,
+            gv=gv,
+            scale=scale,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            reverse=reverse,
+            cu_seqlens=cu_seqlens,
+            state_v_first=state_v_first,
+        )
+        ctx.save_for_backward(q, k, v, g, g_gamma, gk, gv, initial_state, o)
+        ctx.scale = scale
+        ctx.reverse = reverse
+        ctx.cu_seqlens = cu_seqlens
+        ctx.state_v_first = state_v_first
+        return o.to(q.dtype), ht
+
+    @staticmethod
+    @_input_guard
+    @_autocast_custom_bwd
+    def backward(ctx, do, dht):
+        q, k, v, g, g_gamma, gk, gv, initial_state, o = ctx.saved_tensors
+        dq, dk, dv, dg, dgk, dgv, dh0 = _fused_recurrent_bwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            g_gamma=g_gamma,
+            gk=gk,
+            gv=gv,
+            o=o,
+            do=do,
+            dht=dht,
+            scale=ctx.scale,
+            initial_state=initial_state,
+            reverse=ctx.reverse,
+            cu_seqlens=ctx.cu_seqlens,
+            state_v_first=ctx.state_v_first,
+        )
+        return (
+            dq.to(q.dtype),
+            dk.to(k.dtype),
+            dv.to(v.dtype),
+            dg,
+            None,
+            dgk,
+            dgv,
+            None,
+            dh0,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+# --- From fla/ops/common/fused_recurrent.py: fused_recurrent ---
+
+
+def _fused_recurrent(
+    q,
+    k,
+    v,
+    g=None,
+    g_gamma=None,
+    gk=None,
+    gv=None,
+    scale=None,
+    initial_state=None,
+    output_final_state=False,
+    reverse=False,
+    state_v_first=False,
+    cu_seqlens=None,
+):
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    return _FusedRecurrentFunction.apply(
+        q,
+        k,
+        v,
+        g,
+        g_gamma,
+        gk,
+        gv,
+        scale,
+        initial_state,
+        output_final_state,
+        reverse,
+        state_v_first,
+        cu_seqlens,
+    )
+
+
+# --- From fla/ops/gla/fused_recurrent.py: fused_recurrent_gla ---
+
+
+def fused_recurrent_gla(
+    q,
+    k,
+    v,
+    gk=None,
+    gv=None,
+    scale=None,
+    initial_state=None,
+    output_final_state=False,
+    reverse=False,
+    state_v_first=False,
+    cu_seqlens=None,
+    **kwargs,
+):
+    if "transpose_state_layout" in kwargs:
+        if state_v_first:
+            raise ValueError(
+                "Cannot pass both state_v_first and the deprecated transpose_state_layout."
+            )
+        import warnings as _w
+
+        _w.warn(
+            "transpose_state_layout is deprecated and renamed to state_v_first.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        state_v_first = kwargs.pop("transpose_state_layout")
+
+    if cu_seqlens is not None:
+        if q.shape[0] != 1:
+            raise ValueError(
+                "The batch size is expected to be 1 rather than {} when using cu_seqlens."
+                "Please flatten variable-length inputs before processing.".format(
+                    q.shape[0]
+                ),
+            )
+        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
+            raise ValueError(
+                "The number of initial states is expected to be equal to the number of input sequences, "
+                "i.e., {} rather than {}.".format(
+                    len(cu_seqlens) - 1, initial_state.shape[0]
+                ),
+            )
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    o, final_state = _fused_recurrent(
+        q=q,
+        k=k,
+        v=v,
+        g=None,
+        g_gamma=None,
+        gk=gk,
+        gv=gv,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        reverse=reverse,
+        cu_seqlens=cu_seqlens,
+        state_v_first=state_v_first,
+    )
+    return o, final_state
 
 
 def _cuda_available() -> bool:
@@ -44,7 +904,6 @@ def _compat_prepare_chunk_indices_kwarg():
 
 
 def _assert_close(name, actual, expected, ratio, err_atol=1e-6):
-    """对标 FLA assert_close：error_rate（RMSE/信号RMS）判断。"""
     abs_atol = (actual.detach() - expected.detach()).flatten().abs().max().item()
     error_rate = (
         (actual.detach() - expected.detach()).flatten().square().mean().sqrt()

--- a/tests/test_FLA/test_chunk_gla.py
+++ b/tests/test_FLA/test_chunk_gla.py
@@ -1,0 +1,247 @@
+import inspect
+import os
+
+import pytest
+import torch
+import torch.nn.functional as F
+from fla.ops.gla import fused_recurrent_gla
+
+import flaggems_vllm
+from flaggems_vllm.ops.FLA.chunk_gla import chunk_gla
+from flaggems_vllm.ops.FLA.index import prepare_chunk_indices as _prepare_chunk_indices
+
+
+def _cuda_available() -> bool:
+    return torch.cuda.is_available() and flaggems_vllm.device == "cuda"
+
+
+pytestmark = [
+    pytest.mark.chunk_gla,
+    pytest.mark.skipif(not _cuda_available(), reason="CUDA required"),
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _compat_prepare_chunk_indices_kwarg():
+    sig = inspect.signature(_prepare_chunk_indices)
+    if "cu_seqlens_cpu" in sig.parameters:
+        yield
+        return
+    import sys
+
+    mod = sys.modules["flaggems_vllm.ops.FLA.chunk_gla"]
+    old = mod.prepare_chunk_indices
+
+    def _wrapped(cu_seqlens, chunk_size, cu_seqlens_cpu=None):
+        del cu_seqlens_cpu
+        return _prepare_chunk_indices(cu_seqlens, chunk_size)
+
+    mod.prepare_chunk_indices = _wrapped
+    try:
+        yield
+    finally:
+        mod.prepare_chunk_indices = old
+
+
+def _assert_close(name, actual, expected, ratio, err_atol=1e-6):
+    """对标 FLA assert_close：error_rate（RMSE/信号RMS）判断。"""
+    abs_atol = (actual.detach() - expected.detach()).flatten().abs().max().item()
+    error_rate = (
+        (actual.detach() - expected.detach()).flatten().square().mean().sqrt()
+        / actual.detach().flatten().square().mean().sqrt().clamp_min(1e-8)
+    ).item()
+    print(f"[{name}] diff: {abs_atol:.6f} ratio: {error_rate:.6f}")
+    if abs_atol <= err_atol:
+        return
+    assert not torch.isnan(actual).any(), f"{name}: NaN detected in actual"
+    assert not torch.isnan(expected).any(), f"{name}: NaN detected in expected"
+    assert error_rate < ratio, f"{name}: diff: {abs_atol:.6f} ratio: {error_rate:.6f}"
+
+
+@pytest.mark.parametrize(
+    ("B", "T", "H", "D", "gate_logit_normalizer", "dtype"),
+    [
+        pytest.param(*c, id="B{}-T{}-H{}-D{}-gate_logit_normalizer{}-{}".format(*c))
+        for c in [
+            (1, 63, 1, 64, 1.0, torch.float16),
+            (2, 1024, 4, 60, 1.0, torch.float16),
+            (2, 1024, 8, 128, 0.1, torch.float16),
+            (2, 1024, 8, 128, 1.0, torch.float16),
+            (2, 1024, 8, 128, 10.0, torch.float16),
+            (4, 2048, 8, 64, 1.0, torch.float16),
+        ]
+    ],
+)
+def test_chunk(B, T, H, D, dtype, gate_logit_normalizer):
+    torch.manual_seed(42)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+    device = flaggems_vllm.device
+
+    q = torch.rand(B, T, H, D, dtype=dtype, device=device).requires_grad_()
+    k = torch.rand(B, T, H, D, dtype=dtype, device=device).requires_grad_()
+    v = torch.rand(B, T, H, D, dtype=dtype, device=device).requires_grad_()
+    g = (
+        F.logsigmoid(torch.rand(B, T, H, D, dtype=dtype, device=device))
+        / gate_logit_normalizer
+    ).requires_grad_()
+    h0 = torch.rand(B, H, D, D, dtype=torch.float32, device=device).requires_grad_()
+    do = torch.randn_like(v)
+    dht = torch.randn(B, H, D, D, dtype=torch.float32, device=device)
+
+    tri, tri_ht = chunk_gla(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        scale=D**-0.5,
+        initial_state=h0,
+        output_final_state=True,
+        cu_seqlens=None,
+    )
+    ((tri * do).sum() + (tri_ht * dht).sum().to(do.dtype)).backward()
+    tri_dq, tri_dk, tri_dv = q.grad.clone(), k.grad.clone(), v.grad.clone()
+    tri_dg, tri_dh0 = g.grad.clone(), h0.grad.clone()
+    q.grad = k.grad = v.grad = g.grad = h0.grad = None
+
+    ref, ref_ht = fused_recurrent_gla(
+        q=q,
+        k=k,
+        v=v,
+        gk=g,
+        initial_state=h0,
+        output_final_state=True,
+    )
+    ((ref * do).sum() + (ref_ht * dht).sum()).backward()
+    ref_dq, ref_dk, ref_dv = q.grad.clone(), k.grad.clone(), v.grad.clone()
+    ref_dg, ref_dh0 = g.grad.clone(), h0.grad.clone()
+
+    _assert_close("o", ref, tri, 0.004)
+    _assert_close("ht", ref_ht, tri_ht, 0.005)
+    _assert_close("dq", ref_dq, tri_dq, 0.005)
+    _assert_close("dk", ref_dk, tri_dk, 0.005)
+    _assert_close("dv", ref_dv, tri_dv, 0.005)
+    _assert_close("dg", ref_dg, tri_dg, 0.005)
+    _assert_close("dh0", ref_dh0, tri_dh0, 0.005)
+
+
+@pytest.mark.parametrize(
+    ("B", "T", "H", "D", "dtype"),
+    [
+        pytest.param(*c, id="B{}-T{}-H{}-D{}-{}".format(*c))
+        for c in [
+            (2, 256, 4, 64, torch.float),
+            (2, 1024, 4, 128, torch.float16),
+        ]
+    ],
+)
+def test_chunk_state_v_first(B, T, H, D, dtype):
+    torch.manual_seed(42)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+    device = flaggems_vllm.device
+
+    q = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    k = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    v = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    g = F.logsigmoid(torch.rand(B, T, H, D, dtype=dtype, device=device))
+    h0 = torch.rand(B, H, D, D, dtype=torch.float32, device=device)
+    do = torch.randn_like(v)
+    dht = torch.randn_like(h0)
+
+    def run(state_v_first):
+        q_ = q.detach().clone().requires_grad_()
+        k_ = k.detach().clone().requires_grad_()
+        v_ = v.detach().clone().requires_grad_()
+        g_ = g.detach().clone().requires_grad_()
+        h0_in = h0.transpose(-1, -2).contiguous() if state_v_first else h0.clone()
+        dht_in = dht.transpose(-1, -2).contiguous() if state_v_first else dht
+        h0_in = h0_in.requires_grad_()
+        out, ht = chunk_gla(
+            q=q_,
+            k=k_,
+            v=v_,
+            g=g_,
+            scale=D**-0.5,
+            initial_state=h0_in,
+            output_final_state=True,
+            state_v_first=state_v_first,
+        )
+        ((out * do).sum() + (ht * dht_in).sum()).backward()
+        return out, ht, q_.grad, k_.grad, v_.grad, g_.grad, h0_in.grad
+
+    ref_o, ref_ht, ref_dq, ref_dk, ref_dv, ref_dg, ref_dh0 = run(False)
+    tri_o, tri_ht, tri_dq, tri_dk, tri_dv, tri_dg, tri_dh0 = run(True)
+
+    _assert_close("o", ref_o, tri_o, 0.005)
+    _assert_close("ht", ref_ht, tri_ht.transpose(-1, -2), 0.005)
+    _assert_close("dq", ref_dq, tri_dq, 0.005)
+    _assert_close("dk", ref_dk, tri_dk, 0.005)
+    _assert_close("dv", ref_dv, tri_dv, 0.005)
+    _assert_close("dg", ref_dg, tri_dg, 0.005)
+    _assert_close("dh0", ref_dh0, tri_dh0.transpose(-1, -2), 0.005)
+
+
+@pytest.mark.parametrize(
+    ("H", "D", "cu_seqlens", "dtype"),
+    [
+        pytest.param(*c, id="H{}-D{}-cu_seqlens{}-{}".format(*c))
+        for c in [
+            (4, 64, [0, 15], torch.float16),
+            (4, 64, [0, 256, 500, 1000], torch.float16),
+            (4, 100, [0, 15, 100, 300, 1200, 2000], torch.float16),
+        ]
+    ],
+)
+def test_chunk_varlen(H, D, cu_seqlens, dtype):
+    torch.manual_seed(42)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+    device = flaggems_vllm.device
+
+    N = len(cu_seqlens) - 1
+    T = cu_seqlens[-1]
+    cu = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+
+    q = torch.rand(1, T, H, D, dtype=dtype, device=device).requires_grad_()
+    k = torch.rand(1, T, H, D, dtype=dtype, device=device).requires_grad_()
+    v = torch.rand(1, T, H, D, dtype=dtype, device=device).requires_grad_()
+    g = F.logsigmoid(
+        torch.rand(1, T, H, D, dtype=dtype, device=device)
+    ).requires_grad_()
+    h0 = torch.rand(N, H, D, D, dtype=torch.float32, device=device).requires_grad_()
+    do = torch.randn_like(v)
+    dht = torch.rand(N, H, D, D, dtype=torch.float32, device=device)
+
+    ref, ref_ht = fused_recurrent_gla(
+        q=q,
+        k=k,
+        v=v,
+        gk=g,
+        initial_state=h0,
+        output_final_state=True,
+        cu_seqlens=cu,
+    )
+    ((ref * do).sum() + (ref_ht * dht).sum().to(do.dtype)).backward()
+    ref_dq, ref_dk, ref_dv = q.grad.clone(), k.grad.clone(), v.grad.clone()
+    ref_dg, ref_dh0 = g.grad.clone(), h0.grad.clone()
+    q.grad = k.grad = v.grad = g.grad = h0.grad = None
+
+    tri, tri_ht = chunk_gla(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        scale=D**-0.5,
+        initial_state=h0,
+        output_final_state=True,
+        cu_seqlens=cu,
+    )
+    ((tri * do).sum() + (tri_ht * dht).sum()).backward()
+    tri_dq, tri_dk, tri_dv = q.grad.clone(), k.grad.clone(), v.grad.clone()
+    tri_dg, tri_dh0 = g.grad.clone(), h0.grad.clone()
+
+    _assert_close("o", ref, tri, 0.004)
+    _assert_close("ht", ref_ht, tri_ht, 0.005)
+    _assert_close("dq", ref_dq, tri_dq, 0.005)
+    _assert_close("dk", ref_dk, tri_dk, 0.005)
+    _assert_close("dv", ref_dv, tri_dv, 0.005)
+    _assert_close("dg", ref_dg, tri_dg, 0.005)
+    _assert_close("dh0", ref_dh0, tri_dh0, 0.005)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
# Benchmark 
## Float32 Benchmark 性能对比
| B   | T     | H   | D    | dtype     | Torch (ms) | FLA (ms) | GEMS (ms) | GEMS/Torch | GEMS/FLA |
|-----|-------|-----|------|-----------|------------|----------|-----------|------------|----------|
| 2   | 512   | 8   | 64   | float32   | 53.138     | 0.497    | 0.346     | **153.46x** | **1.44x** |
| 4   | 1024  | 8   | 64   | float32   | 106.869    | 0.389    | 0.328     | **325.63x** | **1.19x** |
| 12  | 2048  | 8   | 64   | float32   | 210.412    | 0.401    | 0.349     | **603.24x** | **1.15x** |
| 40  | 9616  | 64  | 128  | float32   | 245.633    | 0.227    | 0.212     | **1160.49x**| **1.07x** |
| 8   | 19296 | 128 | 128  | float32   | 522.879    | 3.776    | 3.657     | **143.00x** | **1.03x** |
| 2   | 2048  | 16  | 512  | float32   | 341.052    | 2.626    | 2.708     | **125.95x** | **0.97x** |
| 16  | 384   | 16  | 128  | float32   | 1719.978   | 2.549    | 2.569     | **669.52x** | **0.99x** |
| 2   | 2048  | 16  | 128  | float32   | 215.899    | 0.671    | 0.637     | **339.00x** | **1.05x** |
| 4   | 4096  | 64  | 128  | float32   | 431.866    | 4.959    | 4.717     | **91.55x**  | **1.05x** |
| 8   | 1024  | 64  | 128  | float32   | 109.554    | 0.515    | 0.428     | **256.04x** | **1.20x** |
| 8   | 2048  | 32  | 256  | float32   | 583.048    | 6.889    | 6.549     | **89.03x**  | **1.05x** |

## Float16 Benchmark 性能对比

| B   | T     | H   | D    | dtype    | Torch (ms) | FLA (ms) | GEMS (ms) | GEMS/Torch   | GEMS/FLA |
|-----|-------|-----|------|----------|------------|----------|-----------|--------------|----------|
| 2   | 512   | 8   | 64   | float16  | 54.274     | 0.415    | 0.170     | **319.77x**  | **2.45x** |
| 4   | 1024  | 8   | 64   | float16  | 54.941     | 0.171    | 0.148     | **372.15x**  | **1.16x** |
| 12  | 2048  | 8   | 64   | float16  | 123.746    | 0.178    | 0.147     | **844.61x**  | **1.21x** |
| 40  | 9616  | 64  | 128  | float16  | 255.649    | 0.239    | 0.171     | **1494.82x** | **1.40x** |
| 8   | 19296 | 128 | 128  | float16  | 440.652    | 2.768    | 2.543     | **173.26x**  | **1.09x** |
| 2   | 2048  | 16  | 512  | float16  | 341.873    | 1.780    | 1.776     | **192.47x**  | **1.00x** |
| 16  | 384   | 16  | 128  | float16  | 1045.581   | 1.886    | 1.730     | **604.24x**  | **1.09x** |
| 2   | 2048  | 16  | 128  | float16  | 110.035    | 0.507    | 0.468     | **235.23x**  | **1.08x** |
| 4   | 4096  | 64  | 128  | float16  | 338.133    | 3.637    | 3.294     | **102.65x**  | **1.10x** |
| 8   | 1024  | 64  | 128  | float16  | 64.640     | 0.505    | 0.434     | **148.93x**  | **1.16x** |
| 8   | 2048  | 32  | 256  | float16  | 582.709    | 4.754    | 4.344     | **134.14x**  | **1.09x** |

 ## BFloat16 Benchmark 性能对比

| B   | T     | H   | D    | dtype     | Torch (ms) | FLA (ms) | GEMS (ms) | GEMS/Torch   | GEMS/FLA |
|-----|-------|-----|------|-----------|------------|----------|-----------|--------------|----------|
| 2   | 512   | 8   | 64   | bfloat16  | 27.744     | 0.171    | 0.174     | **159.35x**  | **0.98x** |
| 4   | 1024  | 8   | 64   | bfloat16  | 64.396     | 0.229    | 0.138     | **467.34x**  | **1.66x** |
| 12  | 2048  | 8   | 64   | bfloat16  | 109.900    | 0.174    | 0.138     | **796.10x**  | **1.26x** |
| 40  | 9616  | 64  | 128  | bfloat16  | 223.874    | 0.214    | 0.178     | **1260.33x** | **1.21x** |
| 8   | 19296 | 128 | 128  | bfloat16  | 433.653    | 2.445    | 2.558     | **169.55x**  | **0.96x** |
| 2   | 2048  | 16  | 512  | bfloat16  | 341.588    | 1.249    | 1.780     | **191.93x**  | **0.70x** |
| 16  | 384   | 16  | 128  | bfloat16  | 875.532    | 1.842    | 1.751     | **499.89x**  | **1.05x** |
| 2   | 2048  | 16  | 128  | bfloat16  | 120.317    | 0.450    | 0.475     | **253.04x**  | **0.95x** |
| 4   | 4096  | 64  | 128  | bfloat16  | 336.313    | 3.242    | 3.305     | **101.76x**  | **0.98x** |
| 8   | 1024  | 64  | 128  | bfloat16  | 58.541     | 0.195    | 0.140     | **417.77x**  | **1.39x** |
| 8   | 2048  | 32  | 256  | bfloat16  | 583.595    | 3.666    | 4.358     | **133.96x**  | **0.84x** |
 
# Test
### 1. test_chunk [B1-T63-H1-D64-gate_logit_normalizer1.0-torch.float16]

- **[o]** diff: 0.003906 | ratio: 0.000255  
- **[ht]** diff: 0.000298 | ratio: 0.000075  
- **[dq]** diff: 0.000488 | ratio: 0.000000  
- **[dk]** diff: 0.007812 | ratio: 0.000253  
- **[dv]** diff: 0.007812 | ratio: 0.000129  
- **[dg]** diff: 0.003906 | ratio: 0.000337  
- **[dh0]** diff: 0.000067 | ratio: 0.000223  

**状态**：PASSED

---

### 2. test_chunk [B2-T1024-H4-D60-gate_logit_normalizer1.0-torch.float16]

- **[o]** diff: 0.003906 | ratio: 0.000260  
- **[ht]** diff: 0.000309 | ratio: 0.000079  
- **[dq]** diff: 0.001953 | ratio: 0.000000  
- **[dk]** diff: 0.007812 | ratio: 0.000000  
- **[dv]** diff: 0.007812 | ratio: 0.000000  
- **[dg]** diff: 0.003906 | ratio: 0.000000  
- **[dh0]** diff: 0.000145 | ratio: 0.000296  

**状态**：PASSED

---

### 3. test_chunk [B2-T1024-H8-D128-gate_logit_normalizer0.1-torch.float16]

- **[o]** diff: 0.001953 | ratio: 0.000362  
- **[ht]** diff: 0.000015 | ratio: 0.000004  
- **[dq]** diff: 0.000977 | ratio: 0.000000  
- **[dk]** diff: 0.015625 | ratio: 0.000000  
- **[dv]** diff: 0.015625 | ratio: 0.000000  
- **[dg]** diff: 0.000488 | ratio: 0.000000  
- **[dh0]** diff: 0.000006 | ratio: 0.000296  

**状态**：PASSED

---

### 4. test_chunk [B2-T1024-H8-D128-gate_logit_normalizer1.0-torch.float16]

- **[o]** diff: 0.003906 | ratio: 0.000253  
- **[ht]** diff: 0.000350 | ratio: 0.000077  
- **[dq]** diff: 0.001953 | ratio: 0.000000  
- **[dk]** diff: 0.015625 | ratio: 0.000000  
- **[dv]** diff: 0.015625 | ratio: 0.000000  
- **[dg]** diff: 0.007812 | ratio: 0.000000  
- **[dh0]** diff: 0.000122 | ratio: 0.000291  

**状态**：PASSED

---

### 5. test_chunk [B2-T1024-H8-D128-gate_logit_normalizer10.0-torch.float16]

- **[o]** diff: 0.031250 | ratio: 0.000141  
- **[ht]** diff: 0.000941 | ratio: 0.000040  
- **[dq]** diff: 0.015625 | ratio: 0.000168  
- **[dk]** diff: 0.015625 | ratio: 0.000270  
- **[dv]** diff: 0.031250 | ratio: 0.000091  
- **[dg]** diff: 0.125000 | ratio: 0.000277  
- **[dh0]** diff: 0.000301 | ratio: 0.000303  

**状态**：PASSED

---

### 6. test_chunk [B4-T2048-H8-D64-gate_logit_normalizer1.0-torch.float16]

- **[o]** diff: 0.003906 | ratio: 0.000252  
- **[ht]** diff: 0.000351 | ratio: 0.000080  
- **[dq]** diff: 0.001953 | ratio: 0.000000  
- **[dk]** diff: 0.007812 | ratio: 0.000000  
- **[dv]** diff: 0.007812 | ratio: 0.000000  
- **[dg]** diff: 0.007812 | ratio: 0.000000  
- **[dh0]** diff: 0.000108 | ratio: 0.000206  

**状态**：PASSED

---

### 7. test_chunk_state_v_first [B2-T256-H4-D64-torch.float32]

- **[o]** diff: 0.000000 | ratio: 0.000000  
- **[ht]** diff: 0.000000 | ratio: 0.000000  
- **[dq]** diff: 0.000000 | ratio: 0.000000  
- **[dk]** diff: 0.000000 | ratio: 0.000000  
- **[dv]** diff: 0.000000 | ratio: 0.000000  
- **[dg]** diff: 0.000006 | ratio: 0.000001  
- **[dh0]** diff: 0.000000 | ratio: 0.000000  

**状态**：PASSED

---

### 8. test_chunk_state_v_first [B2-T1024-H4-D128-torch.float16]

- **[o]** diff: 0.000000 | ratio: 0.000000  
- **[ht]** diff: 0.000000 | ratio: 0.000000  
- **[dq]** diff: 0.000000 | ratio: 0.000000  
- **[dk]** diff: 0.000000 | ratio: 0.000000  
- **[dv]** diff: 0.000000 | ratio: 0.000000  
- **[dg]** diff: 0.000977 | ratio: 0.000000  
- **[dh0]** diff: 0.000000 | ratio: 0.000000  

**状态**：PASSED

---

### 9. test_chunk_varlen [H4-D64-cu_seqlens[0, 15]-torch.float16]

- **[o]** diff: 0.003906 | ratio: 0.000260  
- **[ht]** diff: 0.000284 | ratio: 0.000086  
- **[dq]** diff: 0.000977 | ratio: 0.000000  
- **[dk]** diff: 0.015625 | ratio: 0.000152  
- **[dv]** diff: 0.015625 | ratio: 0.000118  
- **[dg]** diff: 0.015625 | ratio: 0.000128  
- **[dh0]** diff: 0.000110 | ratio: 0.000204  

**状态**：PASSED

---

### 10. test_chunk_varlen [H4-D64-cu_seqlens[0, 256, 500, 1000]-torch.float16]

- **[o]** diff: 0.003906 | ratio: 0.000252  
- **[ht]** diff: 0.000286 | ratio: 0.000077  
- **[dq]** diff: 0.001953 | ratio: 0.000000  
- **[dk]** diff: 0.015625 | ratio: 0.000000  
- **[dv]** diff: 0.015625 | ratio: 0.000000  
- **[dg]** diff: 0.015625 | ratio: 0.000000  
- **[dh0]** diff: 0.000110 | ratio: 0.000210  

**状态**：PASSED

---

### 11. test_chunk_varlen [H4-D100-cu_seqlens[0, 15, 100, 300, 1200, 2000]-torch.float16]

- **[o]** diff: 0.003906 | ratio: 0.000257  
- **[ht]** diff: 0.000322 | ratio: 0.000078  
- **[dq]** diff: 0.001953 | ratio: 0.000000  
- **[dk]** diff: 0.015625 | ratio: 0.000147  
- **[dv]** diff: 0.031250 | ratio: 0.000068  
- **[dg]** diff: 0.031250 | ratio: 0.000000  
- **[dh0]** diff: 0.000147 | ratio: 0.000287  

**状态**：PASSED


# 测试指令
pytest benchmark/test_FLA/test_chunk_gla_perf.py::test_perf_chunk_gla -s --level core --iter 20 --warmup 5
pytest tests/test_FLA/test_chunk_gla.py -v -s