### PR TITLE
Add parallel_nsa op with tests and benchmark

### DIFF
--- a/accuracy_result.json
+++ b/accuracy_result.json
@@ -29436,5 +29436,158 @@
       "flash_attn_varlen_func"
     ],
     "reason": null
+  },
+  "tests/test_parallel_nsa.py::test_parallel[B1-T63-H1-HQ16-D64-S16-block_size32-scale1.0-torch.float16]": {
+    "params": {
+      "B": 1,
+      "T": 63,
+      "H": 1,
+      "HQ": 16,
+      "D": 64,
+      "S": 16,
+      "block_size": 32,
+      "scale": 1.0,
+      "dtype": "torch.float16"
+    },
+    "result": "passed",
+    "opname": [
+      "parallel_nsa"
+    ],
+    "reason": null
+  },
+  "tests/test_parallel_nsa.py::test_parallel[B3-T111-H1-HQ32-D100-S16-block_size32-scale1.0-torch.float16]": {
+    "params": {
+      "B": 3,
+      "T": 111,
+      "H": 1,
+      "HQ": 32,
+      "D": 100,
+      "S": 16,
+      "block_size": 32,
+      "scale": 1.0,
+      "dtype": "torch.float16"
+    },
+    "result": "passed",
+    "opname": [
+      "parallel_nsa"
+    ],
+    "reason": null
+  },
+  "tests/test_parallel_nsa.py::test_parallel[B3-T1024-H2-HQ32-D60-S16-block_size32-scale0.1-torch.float16]": {
+    "params": {
+      "B": 3,
+      "T": 1024,
+      "H": 2,
+      "HQ": 32,
+      "D": 60,
+      "S": 16,
+      "block_size": 32,
+      "scale": 0.1,
+      "dtype": "torch.float16"
+    },
+    "result": "passed",
+    "opname": [
+      "parallel_nsa"
+    ],
+    "reason": null
+  },
+  "tests/test_parallel_nsa.py::test_parallel[B3-T1024-H2-HQ32-D128-S16-block_size32-scale0.1-torch.float16]": {
+    "params": {
+      "B": 3,
+      "T": 1024,
+      "H": 2,
+      "HQ": 32,
+      "D": 128,
+      "S": 16,
+      "block_size": 32,
+      "scale": 0.1,
+      "dtype": "torch.float16"
+    },
+    "result": "passed",
+    "opname": [
+      "parallel_nsa"
+    ],
+    "reason": null
+  },
+  "tests/test_parallel_nsa.py::test_parallel[B4-T2048-H2-HQ32-D64-S16-block_size32-scale0.1-torch.float16]": {
+    "params": {
+      "B": 4,
+      "T": 2048,
+      "H": 2,
+      "HQ": 32,
+      "D": 64,
+      "S": 16,
+      "block_size": 32,
+      "scale": 0.1,
+      "dtype": "torch.float16"
+    },
+    "result": "passed",
+    "opname": [
+      "parallel_nsa"
+    ],
+    "reason": null
+  },
+  "tests/test_parallel_nsa.py::test_parallel_varlen[H1-HQ16-D64-S16-block_size32-cu_seqlens[0, 15]-torch.float16]": {
+    "params": {
+      "H": 1,
+      "HQ": 16,
+      "D": 64,
+      "S": 16,
+      "block_size": 32,
+      "cu_seqlens": [
+        0,
+        15
+      ],
+      "dtype": "torch.float16"
+    },
+    "result": "passed",
+    "opname": [
+      "parallel_nsa"
+    ],
+    "reason": null
+  },
+  "tests/test_parallel_nsa.py::test_parallel_varlen[H2-HQ32-D64-S16-block_size32-cu_seqlens[0, 256, 500, 1000]-torch.float16]": {
+    "params": {
+      "H": 2,
+      "HQ": 32,
+      "D": 64,
+      "S": 16,
+      "block_size": 32,
+      "cu_seqlens": [
+        0,
+        256,
+        500,
+        1000
+      ],
+      "dtype": "torch.float16"
+    },
+    "result": "passed",
+    "opname": [
+      "parallel_nsa"
+    ],
+    "reason": null
+  },
+  "tests/test_parallel_nsa.py::test_parallel_varlen[H2-HQ32-D100-S16-block_size32-cu_seqlens[0, 15, 100, 300, 1200, 2000]-torch.float16]": {
+    "params": {
+      "H": 2,
+      "HQ": 32,
+      "D": 100,
+      "S": 16,
+      "block_size": 32,
+      "cu_seqlens": [
+        0,
+        15,
+        100,
+        300,
+        1200,
+        2000
+      ],
+      "dtype": "torch.float16"
+    },
+    "result": "passed",
+    "opname": [
+      "parallel_nsa"
+    ],
+    "reason": null
   }
 }

--- a/benchmark/test_parallel_nsa.py
+++ b/benchmark/test_parallel_nsa.py
@@ -1,0 +1,72 @@
+import pytest
+import torch
+import triton
+
+import flaggems_vllm
+from benchmark.base import Benchmark
+
+
+class ParallelNSABenchmark(Benchmark):
+    DEFAULT_DTYPES = [torch.bfloat16, torch.float16]
+    # 形状: (B, T, H, HQ, D) — 参考 FLA benchmarks/ops/registry.py _nsa_default_shapes
+    DEFAULT_SHAPES = [
+        # Group 1: Small H regime (低并行度)
+        (1, 16384, 4, 64, 64),     # H4_S16K, G=16
+        # Group 2: Main NSA workload (长上下文, memory throughput)
+        (1, 8192, 16, 256, 64),    # H16_S8K,  G=16
+        (1, 16384, 16, 256, 64),   # H16_S16K, G=16
+        (1, 65536, 16, 256, 64),   # H16_S64K, G=16
+        # Group 3: Large H (接近真实模型)
+        (1, 16384, 32, 512, 64),   # H32_S16K, G=16
+        # Group 4: Head dimension 对比
+        (1, 16384, 16, 256, 128),  # H16_D128, G=16
+        # Group 6: 多序列训练场景
+        (4, 8192, 16, 256, 64),    # B4_H16_S8K
+    ]
+    DEFAULT_SHAPE_DESC = "B, T, H, HQ, D"
+
+    def set_more_shapes(self):
+        return self.DEFAULT_SHAPES
+
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = self.DEFAULT_SHAPES
+        self.shape_desc = self.DEFAULT_SHAPE_DESC
+
+    def get_input_iter(self, cur_dtype):
+        for B, T, H, HQ, D in self.shapes:
+            yield self._build_inputs(B, T, H, HQ, D, cur_dtype)
+
+    def _build_inputs(
+        self, B: int, T: int, H: int, HQ: int, D: int, dtype: torch.dtype
+    ):
+        device = flaggems_vllm.device
+        block_size = 64
+        S = 16
+        n_blocks = triton.cdiv(T, block_size)
+
+        q = torch.randn(B, T, HQ, D, device=device, dtype=dtype)
+        k = torch.randn(B, T, H, D, device=device, dtype=dtype)
+        v = torch.randn(B, T, H, D, device=device, dtype=dtype)
+        scale = D ** -0.5
+
+        # Random block indices for benchmarking
+        block_indices = torch.randint(0, max(1, n_blocks), (B, T, H, S), device=device, dtype=torch.int32)
+
+        # Return positional args + kwargs dict as last element
+        return (q, k, v, {
+            "block_indices": block_indices,
+            "block_counts": S,
+            "block_size": block_size,
+            "scale": scale,
+            "cu_seqlens": None,
+        })
+
+
+@pytest.mark.parallel_nsa
+def test_perf_parallel_nsa():
+    bench = ParallelNSABenchmark(
+        op_name="parallel_nsa",
+        torch_op=flaggems_vllm.parallel_nsa,
+    )
+    bench.set_gems(flaggems_vllm.parallel_nsa)
+    bench.run()

--- a/benchmark/test_parallel_nsa.py
+++ b/benchmark/test_parallel_nsa.py
@@ -11,17 +11,17 @@ class ParallelNSABenchmark(Benchmark):
     # 形状: (B, T, H, HQ, D) — 参考 FLA benchmarks/ops/registry.py _nsa_default_shapes
     DEFAULT_SHAPES = [
         # Group 1: Small H regime (低并行度)
-        (1, 16384, 4, 64, 64),     # H4_S16K, G=16
+        (1, 16384, 4, 64, 64),  # H4_S16K, G=16
         # Group 2: Main NSA workload (长上下文, memory throughput)
-        (1, 8192, 16, 256, 64),    # H16_S8K,  G=16
-        (1, 16384, 16, 256, 64),   # H16_S16K, G=16
-        (1, 65536, 16, 256, 64),   # H16_S64K, G=16
+        (1, 8192, 16, 256, 64),  # H16_S8K,  G=16
+        (1, 16384, 16, 256, 64),  # H16_S16K, G=16
+        (1, 65536, 16, 256, 64),  # H16_S64K, G=16
         # Group 3: Large H (接近真实模型)
-        (1, 16384, 32, 512, 64),   # H32_S16K, G=16
+        (1, 16384, 32, 512, 64),  # H32_S16K, G=16
         # Group 4: Head dimension 对比
         (1, 16384, 16, 256, 128),  # H16_D128, G=16
         # Group 6: 多序列训练场景
-        (4, 8192, 16, 256, 64),    # B4_H16_S8K
+        (4, 8192, 16, 256, 64),  # B4_H16_S8K
     ]
     DEFAULT_SHAPE_DESC = "B, T, H, HQ, D"
 
@@ -47,19 +47,26 @@ class ParallelNSABenchmark(Benchmark):
         q = torch.randn(B, T, HQ, D, device=device, dtype=dtype)
         k = torch.randn(B, T, H, D, device=device, dtype=dtype)
         v = torch.randn(B, T, H, D, device=device, dtype=dtype)
-        scale = D ** -0.5
+        scale = D**-0.5
 
         # Random block indices for benchmarking
-        block_indices = torch.randint(0, max(1, n_blocks), (B, T, H, S), device=device, dtype=torch.int32)
+        block_indices = torch.randint(
+            0, max(1, n_blocks), (B, T, H, S), device=device, dtype=torch.int32
+        )
 
         # Return positional args + kwargs dict as last element
-        return (q, k, v, {
-            "block_indices": block_indices,
-            "block_counts": S,
-            "block_size": block_size,
-            "scale": scale,
-            "cu_seqlens": None,
-        })
+        return (
+            q,
+            k,
+            v,
+            {
+                "block_indices": block_indices,
+                "block_counts": S,
+                "block_size": block_size,
+                "scale": scale,
+                "cu_seqlens": None,
+            },
+        )
 
 
 @pytest.mark.parallel_nsa

--- a/benchmark/test_parallel_nsa_compression.py
+++ b/benchmark/test_parallel_nsa_compression.py
@@ -8,18 +8,20 @@ from benchmark.base import Benchmark
 
 class ParallelNSACompressionBenchmark(Benchmark):
     DEFAULT_DTYPES = [torch.bfloat16, torch.float16]
-    # 形状: (B, T, H, HQ, D)
+    # 形状: (B, T, H, HQ, D) — 参考 FLA benchmarks/ops/registry.py _nsa_default_shapes
     DEFAULT_SHAPES = [
-        # T 扫描 — 长序列到超长序列 (B=1, H=4, HQ=64, D=64)
-        (1, 8192, 4, 64, 64),
-        (1, 16384, 4, 64, 64),
-        (1, 32768, 4, 64, 64),
-        (1, 65536, 4, 64, 64),
-        # D 对比 — 宽/窄 head (B=1, T=16K, H=4, HQ=64)
-        (1, 16384, 4, 64, 64),
-        (1, 16384, 4, 64, 128),
-        # 多序列场景 (B=2, T=16K, H=4, HQ=64, D=64)
-        (2, 16384, 4, 64, 64),
+        # Small H regime
+        (1, 16384, 4, 64, 64),  # H4_S16K
+        # Main NSA workload
+        (1, 8192, 16, 256, 64),  # H16_S8K
+        (1, 16384, 16, 256, 64),  # H16_S16K
+        (1, 65536, 16, 256, 64),  # H16_S64K
+        # Large H
+        (1, 16384, 32, 512, 64),  # H32_S16K
+        # Head dimension
+        (1, 16384, 16, 256, 128),  # H16_D128
+        # 多序列
+        (4, 8192, 16, 256, 64),  # B4_H16_S8K
     ]
     DEFAULT_SHAPE_DESC = "B, T, H, HQ, D"
 

--- a/src/flaggems_vllm/ops/FLA/__init__.py
+++ b/src/flaggems_vllm/ops/FLA/__init__.py
@@ -11,6 +11,8 @@ from flaggems_vllm.ops.FLA.index import (
     prepare_chunk_offsets,
     prepare_token_indices,
 )
+from flaggems_vllm.ops.FLA.parallel_nsa import parallel_nsa
+from flaggems_vllm.ops.FLA.parallel_nsa_compression import parallel_nsa_compression
 from flaggems_vllm.ops.FLA.triton_ops_helper import autotune_cache_kwargs, exp, log
 
 __all__ = [
@@ -21,6 +23,8 @@ __all__ = [
     "fused_recurrent_gated_delta_rule_fwd",
     "log",
     "parallel_attn_bwd_preprocess",
+    "parallel_nsa",
+    "parallel_nsa_compression",
     "prepare_chunk_indices",
     "prepare_chunk_offsets",
     "prepare_token_indices",

--- a/src/flaggems_vllm/ops/FLA/mean_pooling.py
+++ b/src/flaggems_vllm/ops/FLA/mean_pooling.py
@@ -1,0 +1,212 @@
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import torch
+import triton
+import triton.language as tl
+
+from flaggems_vllm.ops.FLA.index import prepare_chunk_indices
+from flaggems_vllm.ops.FLA.triton_ops_helper import autotune_cache_kwargs
+from flaggems_vllm.ops.FLA.utils import input_guard
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({'BD': BD}, num_warps=num_warps)
+        for BD in [16, 32, 64, 128]
+        for num_warps in [1, 2, 4, 8]
+    ],
+    key=['BT'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def mean_pooling_fwd_kernel(
+    x,
+    o,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_d, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_tg = i_t
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = i_b * NT + i_t
+        bos, eos = i_b * T, i_b * T + T
+
+    p_x = tl.make_block_ptr(x + (bos * H + i_h) * D, (T, D), (H*D, 1), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
+    p_o = tl.make_block_ptr(o + (i_tg * H + i_h) * D, (D,), (1,), (i_d * BD,), (BD,), (0,))
+    # [BT, BD]
+    b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
+    # [BD]
+    b_o = tl.sum(b_x, axis=0) / min(BT, T - i_t * BT)
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({'BD': BD}, num_warps=num_warps)
+        for BD in [16, 32, 64, 128]
+        for num_warps in [1, 2, 4, 8]
+    ],
+    key=['BT'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def mean_pooling_bwd_kernel(
+    do,
+    dx,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_d, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_tg = i_t
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = i_b * NT + i_t
+        bos, eos = i_b * T, i_b * T + T
+
+    p_dx = tl.make_block_ptr(dx + (bos * H + i_h) * D, (T, D), (H*D, 1), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
+    p_do = tl.make_block_ptr(do + (i_tg * H + i_h) * D, (D,), (1,), (i_d * BD,), (BD,), (0,))
+    # [BD]
+    b_do = tl.load(p_do, boundary_check=(0,)).to(tl.float32)
+    # [BT, BD]
+    b_dx = b_do / tl.full((BT,), min(BT, T - i_t * BT), dtype=tl.float32)[:, None]
+    tl.store(p_dx, b_dx.to(p_dx.dtype.element_ty), boundary_check=(0, 1))
+
+
+def mean_pooling_fwd(
+    x: torch.Tensor,
+    chunk_size: int,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+) -> torch.Tensor:
+    B, T, H, D = x.shape
+    BT = chunk_size
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    o = x.new_empty(B, NT, H, D)
+
+    def grid(meta):
+        return (triton.cdiv(D, meta['BD']), NT, B * H)
+
+    mean_pooling_fwd_kernel[grid](
+        x,
+        o,
+        cu_seqlens,
+        chunk_indices,
+        T=T,
+        H=H,
+        D=D,
+        BT=BT,
+    )
+    return o
+
+
+def mean_pooling_bwd(
+    do: torch.Tensor,
+    batch_size: int,
+    seq_len: int,
+    chunk_size: int,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+) -> torch.Tensor:
+    B, T, H, D = batch_size, seq_len, *do.shape[-2:]
+    BT = chunk_size
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    dx = do.new_empty(B, T, H, D)
+
+    def grid(meta):
+        return (triton.cdiv(D, meta['BD']), NT, B * H)
+
+    mean_pooling_bwd_kernel[grid](
+        do,
+        dx,
+        cu_seqlens,
+        chunk_indices,
+        T=T,
+        H=H,
+        D=D,
+        BT=BT,
+    )
+    return dx
+
+
+class MeanPoolingFunction(torch.autograd.Function):
+
+    @staticmethod
+    @input_guard
+    def forward(ctx, x, chunk_size, cu_seqlens=None):
+        o = mean_pooling_fwd(x, chunk_size, cu_seqlens)
+        ctx.batch_size = x.shape[0]
+        ctx.seq_len = x.shape[1]
+        ctx.chunk_size = chunk_size
+        ctx.cu_seqlens = cu_seqlens
+        return o
+
+    @staticmethod
+    @input_guard
+    def backward(ctx, do):
+        batch_size = ctx.batch_size
+        seq_len = ctx.seq_len
+        chunk_size = ctx.chunk_size
+        cu_seqlens = ctx.cu_seqlens
+        dx = mean_pooling_bwd(do, batch_size, seq_len, chunk_size, cu_seqlens)
+        return dx, None, None
+
+
+def mean_pooling(
+    x: torch.Tensor,
+    chunk_size: int,
+    cu_seqlens: torch.LongTensor | None = None,
+) -> torch.Tensor:
+    r"""
+    Average-pool ``x`` along the sequence dimension with the given ``chunk_size``.
+
+    Args:
+        x: Input tensor of shape ``[B, T, H, D]``.
+        chunk_size: Size of each pooling chunk.
+        cu_seqlens: Optional cumulative sequence lengths for variable-length sequences.
+
+    Returns:
+        Pooled tensor of shape ``[B, NT, H, D]`` where ``NT = ceil(T / chunk_size)``.
+    """
+    return MeanPoolingFunction.apply(x, chunk_size, cu_seqlens)

--- a/src/flaggems_vllm/ops/FLA/mean_pooling.py
+++ b/src/flaggems_vllm/ops/FLA/mean_pooling.py
@@ -14,19 +14,21 @@ from flaggems_vllm.ops.FLA.triton_ops_helper import autotune_cache_kwargs
 from flaggems_vllm.ops.FLA.utils import input_guard
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
 @triton.autotune(
     configs=[
-        triton.Config({'BD': BD}, num_warps=num_warps)
+        triton.Config({"BD": BD}, num_warps=num_warps)
         for BD in [16, 32, 64, 128]
         for num_warps in [1, 2, 4, 8]
     ],
-    key=['BT'],
+    key=["BT"],
     **autotune_cache_kwargs,
 )
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=["T"])
 def mean_pooling_fwd_kernel(
     x,
     o,
@@ -43,8 +45,12 @@ def mean_pooling_fwd_kernel(
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
     else:
@@ -52,8 +58,17 @@ def mean_pooling_fwd_kernel(
         i_tg = i_b * NT + i_t
         bos, eos = i_b * T, i_b * T + T
 
-    p_x = tl.make_block_ptr(x + (bos * H + i_h) * D, (T, D), (H*D, 1), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
-    p_o = tl.make_block_ptr(o + (i_tg * H + i_h) * D, (D,), (1,), (i_d * BD,), (BD,), (0,))
+    p_x = tl.make_block_ptr(
+        x + (bos * H + i_h) * D,
+        (T, D),
+        (H * D, 1),
+        (i_t * BT, i_d * BD),
+        (BT, BD),
+        (1, 0),
+    )
+    p_o = tl.make_block_ptr(
+        o + (i_tg * H + i_h) * D, (D,), (1,), (i_d * BD,), (BD,), (0,)
+    )
     # [BT, BD]
     b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
     # [BD]
@@ -61,19 +76,21 @@ def mean_pooling_fwd_kernel(
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
 @triton.autotune(
     configs=[
-        triton.Config({'BD': BD}, num_warps=num_warps)
+        triton.Config({"BD": BD}, num_warps=num_warps)
         for BD in [16, 32, 64, 128]
         for num_warps in [1, 2, 4, 8]
     ],
-    key=['BT'],
+    key=["BT"],
     **autotune_cache_kwargs,
 )
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=["T"])
 def mean_pooling_bwd_kernel(
     do,
     dx,
@@ -90,8 +107,12 @@ def mean_pooling_bwd_kernel(
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
     else:
@@ -99,8 +120,17 @@ def mean_pooling_bwd_kernel(
         i_tg = i_b * NT + i_t
         bos, eos = i_b * T, i_b * T + T
 
-    p_dx = tl.make_block_ptr(dx + (bos * H + i_h) * D, (T, D), (H*D, 1), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
-    p_do = tl.make_block_ptr(do + (i_tg * H + i_h) * D, (D,), (1,), (i_d * BD,), (BD,), (0,))
+    p_dx = tl.make_block_ptr(
+        dx + (bos * H + i_h) * D,
+        (T, D),
+        (H * D, 1),
+        (i_t * BT, i_d * BD),
+        (BT, BD),
+        (1, 0),
+    )
+    p_do = tl.make_block_ptr(
+        do + (i_tg * H + i_h) * D, (D,), (1,), (i_d * BD,), (BD,), (0,)
+    )
     # [BD]
     b_do = tl.load(p_do, boundary_check=(0,)).to(tl.float32)
     # [BT, BD]
@@ -123,7 +153,7 @@ def mean_pooling_fwd(
     o = x.new_empty(B, NT, H, D)
 
     def grid(meta):
-        return (triton.cdiv(D, meta['BD']), NT, B * H)
+        return (triton.cdiv(D, meta["BD"]), NT, B * H)
 
     mean_pooling_fwd_kernel[grid](
         x,
@@ -155,7 +185,7 @@ def mean_pooling_bwd(
     dx = do.new_empty(B, T, H, D)
 
     def grid(meta):
-        return (triton.cdiv(D, meta['BD']), NT, B * H)
+        return (triton.cdiv(D, meta["BD"]), NT, B * H)
 
     mean_pooling_bwd_kernel[grid](
         do,

--- a/src/flaggems_vllm/ops/FLA/parallel_nsa.py
+++ b/src/flaggems_vllm/ops/FLA/parallel_nsa.py
@@ -1,0 +1,1067 @@
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import os
+import warnings
+
+import torch
+import triton
+import triton.language as tl
+
+from flaggems_vllm.ops.FLA.bwd_preprocess import parallel_attn_bwd_preprocess
+from flaggems_vllm.ops.FLA.index import (
+    prepare_chunk_indices,
+    prepare_chunk_offsets,
+    prepare_lens,
+    prepare_token_indices,
+)
+from flaggems_vllm.ops.FLA.mean_pooling import mean_pooling
+from flaggems_vllm.ops.FLA.parallel_nsa_compression import (
+    parallel_nsa_compression,
+)
+from flaggems_vllm.ops.FLA.triton_ops_helper import autotune_cache_kwargs, exp, log
+from flaggems_vllm.ops.FLA.utils import _bitonic_merge, check_shared_mem, input_guard
+
+try:
+    HAS_TLE = False
+    import triton.experimental.tle.language as tle  # noqa: F401
+    HAS_TLE = True
+except ImportError:
+    tle = None
+    HAS_TLE = False
+
+try:
+    from flash_attn import flash_attn_func, flash_attn_varlen_func
+except ImportError:
+    warnings.warn(
+        "Flash Attention is not installed. Please install it via `pip install flash-attn --no-build-isolation`",
+        category=ImportWarning,
+    )
+    flash_attn_func = None
+    flash_attn_varlen_func = None
+
+
+# ===========================================================================
+# Top-K selection kernel
+# ===========================================================================
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps)
+        for num_warps in [1, 2, 4]
+    ],
+    key=['BS', 'BK'],
+    **autotune_cache_kwargs,
+)
+@triton.jit
+def parallel_nsa_kernel_topk(
+    q,
+    k,
+    lse,
+    scale,
+    block_indices,
+    cu_seqlens,
+    token_indices,
+    chunk_offsets,
+    T,
+    H: tl.constexpr,
+    HQ: tl.constexpr,
+    G: tl.constexpr,
+    K: tl.constexpr,
+    S: tl.constexpr,
+    BC: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(token_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        boc = tl.load(chunk_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_b * T, i_b * T + T
+        boc = i_b * tl.cdiv(T, BS)
+
+    p_q = tl.make_block_ptr(q + (bos + i_t) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+
+    # the Q block is kept in the shared memory throughout the whole kernel
+    # [G, BK]
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = (b_q * scale).to(b_q.dtype)
+
+    # the number of compression representations in total
+    TC = tl.cdiv(T, BS)
+    # the number of compression representations required to iterate over
+    # incomplete compression blocks are not included
+    NC = (i_t + 1) // BS
+    ################################
+    # 1. lse computation
+    ################################
+    if lse is not None:
+        b_lse = tl.load(lse + (bos + i_t) * HQ + i_h * G + tl.arange(0, G))
+    else:
+        # max scores for the current block
+        b_m = tl.full([G], float('-inf'), dtype=tl.float32)
+        # lse = log(acc) + m
+        b_acc = tl.zeros([G], dtype=tl.float32)
+        for i_c in range(0, NC, BC):
+            o_c = i_c + tl.arange(0, BC)
+
+            p_k = tl.make_block_ptr(k + (boc * H + i_h) * K, (K, TC), (1, H * K), (0, i_c), (BK, BC), (0, 1))
+            # [BK, BC]
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+
+            # [G, BC]
+            b_s = tl.dot(b_q, b_k)
+            b_s = tl.where((o_c < NC)[None, :], b_s, float('-inf'))
+
+            # [G]
+            b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
+            b_r = exp(b_mp - b_m)
+            # [G, BC]
+            b_p = exp(b_s - b_m[:, None])
+            # [G]
+            b_acc = b_acc * b_r + tl.sum(b_p, 1)
+
+            b_mp = b_m
+        if NC == 0:
+            b_lse = tl.zeros([G], dtype=tl.float32)
+        else:
+            b_lse = b_m + log(b_acc)
+
+    ################################
+    # 2. topk selection
+    ################################
+    # [BC]
+    b_i = tl.full([BC], -1, dtype=tl.float32)
+    o_i = tl.zeros([BC], dtype=tl.int32)
+    m_i = tl.arange(0, BC) < BC // 2
+
+    IC = i_t // BS
+    for i_c in range(0, tl.cdiv(i_t + 1, BS), BC):
+        o_c = i_c + tl.arange(0, BC)
+
+        p_k = tl.make_block_ptr(k + (boc * H + i_h) * K, (K, TC), (1, H * K), (0, i_c), (BK, BC), (0, 1))
+        # [BK, BC]
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        # [G, BC]
+        b_s = tl.dot(b_q, b_k)
+        b_s = tl.where(o_c < IC, b_s, float('-inf'))
+        # [G, BC]
+        # the 1st and the last 2 blocks are always selected
+        b_p = tl.where((o_c == 0) | ((o_c == IC - 1) | (o_c == IC)), 1., exp(b_s - b_lse[:, None]))
+        # the importance scores of the current block
+        # [BC]
+        b_i, b_ip = tl.sum(b_p, 0), b_i
+        # blocks with index < 0 will be skipped
+        o_i, o_ip = tl.where(o_c <= IC, o_c, -1), o_i
+
+        n_dims: tl.constexpr = tl.standard._log2(b_i.shape[0])
+        for i in tl.static_range(1, n_dims):
+            b_i, o_i = _bitonic_merge(b_i, o_i.to(tl.int32), i, 2, n_dims)
+
+        if i_c != 0:
+            b_i, o_i = _bitonic_merge(b_i, o_i.to(tl.int32), n_dims, False, n_dims)
+            b_i_new = b_ip * m_i + b_i * (1 - m_i)
+            o_i_new = o_ip * m_i + o_i * (1 - m_i)
+            b_i, o_i = _bitonic_merge(b_i_new, o_i_new.to(tl.int32), n_dims, True, n_dims)
+        else:
+            b_i, o_i = _bitonic_merge(b_i, o_i.to(tl.int32), n_dims, True, n_dims)
+
+    m_top = tl.arange(0, BC // S) == 0
+    b_top = tl.sum(m_top[:, None] * tl.reshape(o_i, [BC // S, S]), 0)
+
+    p_b = tl.make_block_ptr(block_indices + (bos + i_t) * H * S, (H * S,), (1,), (i_h * S,), (S,), (0,))
+    tl.store(p_b, b_top.to(p_b.dtype.element_ty))
+
+
+# ===========================================================================
+# Forward kernel
+# ===========================================================================
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+    'USE_BLOCK_COUNTS': lambda args: isinstance(args['block_counts'], torch.Tensor),
+})
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps)
+        for num_warps in [1, 2, 4]
+    ],
+    key=['BS', 'BK', 'BV'],
+    **autotune_cache_kwargs,
+)
+@triton.jit
+def parallel_nsa_fwd_kernel(
+    q,
+    k,
+    v,
+    o,
+    lse,
+    scale,
+    block_indices,
+    block_counts,
+    cu_seqlens,
+    token_indices,
+    T,
+    H: tl.constexpr,
+    HQ: tl.constexpr,
+    G: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    S: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_BLOCK_COUNTS: tl.constexpr,
+):
+    i_t, i_v, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(token_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    k += (bos * H + i_h) * K
+    v += (bos * H + i_h) * V
+    block_indices += (bos + i_t) * H * S + i_h * S
+
+    if USE_BLOCK_COUNTS:
+        NS = tl.load(block_counts + (bos + i_t) * H + i_h)
+    else:
+        NS = S
+
+    p_q = tl.make_block_ptr(q + (bos + i_t) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+    # the Q block is kept in the shared memory throughout the whole kernel
+    # [G, BK]
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = (b_q * scale).to(b_q.dtype)
+
+    p_o = tl.make_block_ptr(o + (bos + i_t) * HQ * V, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0))
+    p_lse = lse + (bos + i_t) * HQ + i_h * G + tl.arange(0, G)
+    # [G, BV]
+    b_o = tl.zeros([G, BV], dtype=tl.float32)
+
+    b_m = tl.full([G], float('-inf'), dtype=tl.float32)
+    b_acc = tl.zeros([G], dtype=tl.float32)
+    for i in range(NS):
+        i_s = tl.load(block_indices + i).to(tl.int32) * BS
+        if i_s <= i_t and i_s >= 0:
+            p_k = tl.make_block_ptr(k, (K, T), (1, H * K), (0, i_s), (BK, BS), (0, 1))
+            p_v = tl.make_block_ptr(v, (T, V), (H * V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
+            # [BK, BS]
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            # [G, BS] — compute QK^T scores
+            b_s = tl.dot(b_q, b_k)
+            # b_k registers are now free — will be reused for later loads
+            b_s = tl.where((i_t >= (i_s + tl.arange(0, BS)))[None, :], b_s, float('-inf'))
+
+            # [G]
+            b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
+            b_r = exp(b_mp - b_m)
+            # [G, BS] — b_s registers reused for softmax output b_p
+            b_p = exp(b_s - b_m[:, None])
+            # [G]
+            b_acc = b_acc * b_r + tl.sum(b_p, 1)
+
+            # [BS, BV] — load V tile AFTER score computation
+            # so b_k registers are freed and peak register usage is reduced
+            b_v = tl.load(p_v, boundary_check=(0, 1))
+            # [G, BV]
+            b_o = b_o * b_r[:, None] + tl.dot(b_p.to(b_q.dtype), b_v)
+
+            b_mp = b_m
+    b_o = b_o / b_acc[:, None]
+    b_m += log(b_acc)
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_lse, b_m.to(p_lse.dtype.element_ty))
+
+
+# ===========================================================================
+# TLE-optimized forward kernel (Triton Language Extensions)
+# ===========================================================================
+
+if HAS_TLE:
+
+    @triton.heuristics({
+        'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+        'USE_BLOCK_COUNTS': lambda args: isinstance(args['block_counts'], torch.Tensor),
+    })
+    @triton.autotune(
+        configs=[
+            triton.Config({}, num_warps=num_warps)
+            for num_warps in [1, 2, 4]
+        ],
+        key=['BS', 'BK', 'BV'],
+        **autotune_cache_kwargs,
+    )
+    @triton.jit
+    def parallel_nsa_fwd_kernel_tle(
+        q,
+        k,
+        v,
+        o,
+        lse,
+        scale,
+        block_indices,
+        block_counts,
+        cu_seqlens,
+        token_indices,
+        T,
+        H: tl.constexpr,
+        HQ: tl.constexpr,
+        G: tl.constexpr,
+        K: tl.constexpr,
+        V: tl.constexpr,
+        S: tl.constexpr,
+        BS: tl.constexpr,
+        BK: tl.constexpr,
+        BV: tl.constexpr,
+        IS_VARLEN: tl.constexpr,
+        USE_BLOCK_COUNTS: tl.constexpr,
+    ):
+        i_t, i_v, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+        i_b, i_h = i_bh // H, i_bh % H
+
+        if IS_VARLEN:
+            i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(token_indices + i_t * 2 + 1).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+            T = eos - bos
+        else:
+            bos, eos = i_b * T, i_b * T + T
+
+        k += (bos * H + i_h) * K
+        v += (bos * H + i_h) * V
+        block_indices += (bos + i_t) * H * S + i_h * S
+
+        if USE_BLOCK_COUNTS:
+            NS = tl.load(block_counts + (bos + i_t) * H + i_h)
+        else:
+            NS = S
+
+        p_q = tl.make_block_ptr(q + (bos + i_t) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+        # [G, BK]
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = (b_q * scale).to(b_q.dtype)
+
+        p_o = tl.make_block_ptr(o + (bos + i_t) * HQ * V, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0))
+        p_lse = lse + (bos + i_t) * HQ + i_h * G + tl.arange(0, G)
+        # [G, BV]
+        b_o = tl.zeros([G, BV], dtype=tl.float32)
+
+        b_m = tl.full([G], float('-inf'), dtype=tl.float32)
+        b_acc = tl.zeros([G], dtype=tl.float32)
+
+        # Precompute indices for async K/V loads via tle.load(is_async=True).
+        offs_k = tl.arange(0, BK)
+        offs_s = tl.arange(0, BS)
+        offs_v = tl.arange(0, BV)
+        k_base = k  # already offset to (bos*H + i_h)*K
+        v_base = v  # already offset to (bos*H + i_h)*V
+        v_start = i_v * BV
+
+        for i in range(NS):
+            i_s = tl.load(block_indices + i).to(tl.int32) * BS
+            if i_s <= i_t and i_s >= 0:
+                # Async K load via regular pointer arithmetic
+                k_ptrs = k_base + offs_k[:, None] + (i_s + offs_s[None, :]) * H * K
+                k_mask = (offs_k[:, None] < K) & ((i_s + offs_s[None, :]) < T)
+                b_k = tle.load(k_ptrs, mask=k_mask, other=0.0, is_async=True)
+
+                # Compute QK^T scores
+                b_s = tl.dot(b_q, b_k.to(b_q.dtype))
+                b_s = tl.where((i_t >= (i_s + tl.arange(0, BS)))[None, :], b_s, float('-inf'))
+
+                # [G]
+                b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
+                b_r = exp(b_mp - b_m)
+                # [G, BS] — b_s registers reused for softmax output b_p
+                b_p = exp(b_s - b_m[:, None])
+                # [G]
+                b_acc = b_acc * b_r + tl.sum(b_p, 1)
+
+                # Async V load AFTER score computation
+                v_ptrs = v_base + (i_s + offs_s[:, None]) * H * V + (v_start + offs_v[None, :])
+                v_mask = ((i_s + offs_s[:, None]) < T) & ((v_start + offs_v[None, :]) < V)
+                b_v = tle.load(v_ptrs, mask=v_mask, other=0.0, is_async=True)
+
+                # [G, BV]
+                b_o = b_o * b_r[:, None] + tl.dot(b_p.to(b_q.dtype), b_v)
+
+                b_mp = b_m
+        b_o = b_o / b_acc[:, None]
+        b_m += log(b_acc)
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_lse, b_m.to(p_lse.dtype.element_ty))
+
+
+# ===========================================================================
+# Block mask kernel
+# ===========================================================================
+
+
+@triton.heuristics({
+    'USE_BLOCK_COUNTS': lambda args: isinstance(args['block_counts'], torch.Tensor),
+})
+@triton.jit(do_not_specialize=['T'])
+def parallel_nsa_kernel_mask(
+    block_indices,
+    block_counts,
+    block_mask,
+    T,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    BS: tl.constexpr,
+    NS: tl.constexpr,
+    USE_BLOCK_COUNTS: tl.constexpr,
+):
+    i_t, i_b, i_hs = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_h, i_s = i_hs // S, i_hs % S
+
+    b_i = tl.load(block_indices + i_b * T * H * S + i_t * H * S + i_h * S + i_s)
+    if USE_BLOCK_COUNTS:
+        b_m = b_i * BS <= i_t and i_s < tl.load(block_counts + i_b * T * H + i_t * H + i_h)
+    else:
+        b_m = b_i * BS <= i_t
+
+    if b_i < NS and b_i >= 0:
+        tl.store(block_mask + i_b * T * H * NS + i_t * H * NS + i_h * NS + b_i, b_m.to(block_mask.dtype.element_ty))
+
+
+# ===========================================================================
+# Backward kernel: dQ
+# ===========================================================================
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+    'USE_BLOCK_COUNTS': lambda args: isinstance(args['block_counts'], torch.Tensor),
+})
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps)
+        for num_warps in [1, 2, 4]
+    ],
+    key=['BS', 'BK', 'BV'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def parallel_nsa_bwd_kernel_dq(
+    q,
+    k,
+    v,
+    lse,
+    delta,
+    do,
+    dq,
+    scale,
+    block_indices,
+    block_counts,
+    cu_seqlens,
+    token_indices,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    HQ: tl.constexpr,
+    G: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    S: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_BLOCK_COUNTS: tl.constexpr,
+):
+    i_t, i_v, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    all = B * T
+    if IS_VARLEN:
+        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(token_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    q += (bos + i_t) * HQ * K
+    do += (bos + i_t) * HQ * V
+    lse += (bos + i_t) * HQ
+    delta += (bos + i_t) * HQ
+    dq += (i_v * all + bos + i_t) * HQ * K
+    block_indices += (bos + i_t) * H * S + i_h * S
+
+    if USE_BLOCK_COUNTS:
+        NS = tl.load(block_counts + (bos + i_t) * H + i_h)
+    else:
+        NS = S
+
+    k += (bos * H + i_h) * K
+    v += (bos * H + i_h) * V
+
+    p_q = tl.make_block_ptr(q, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+    p_dq = tl.make_block_ptr(dq, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+
+    # [G, BK]
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = (b_q * scale).to(b_q.dtype)
+
+    p_do = tl.make_block_ptr(do, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0))
+    p_lse = lse + i_h * G + tl.arange(0, G)
+    p_delta = delta + i_h * G + tl.arange(0, G)
+
+    # [G, BV]
+    b_do = tl.load(p_do, boundary_check=(0, 1))
+    # [G]
+    b_lse = tl.load(p_lse)
+    b_delta = tl.load(p_delta)
+
+    # [G, BK]
+    b_dq = tl.zeros([G, BK], dtype=tl.float32)
+    for i in range(NS):
+        i_s = tl.load(block_indices + i).to(tl.int32) * BS
+        if i_s <= i_t and i_s >= 0:
+            p_k = tl.make_block_ptr(k, (K, T), (1, H * K), (0, i_s), (BK, BS), (0, 1))
+            p_v = tl.make_block_ptr(v, (V, T), (1, H * V), (i_v * BV, i_s), (BV, BS), (0, 1))
+            # [BK, BS]
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            # [BV, BS]
+            b_v = tl.load(p_v, boundary_check=(0, 1))
+
+            # [G, BS]
+            b_s = tl.dot(b_q, b_k)
+            b_p = exp(b_s - b_lse[:, None])
+            b_p = tl.where((i_t >= (i_s + tl.arange(0, BS)))[None, :], b_p, 0)
+
+            # [G, BV] @ [BV, BS] -> [G, BS]
+            b_dp = tl.dot(b_do, b_v)
+            b_ds = b_p * (b_dp.to(tl.float32) - b_delta[:, None])
+            # [G, BS] @ [BS, BK] -> [G, BK]
+            b_dq += tl.dot(b_ds.to(b_k.dtype), tl.trans(b_k))
+    b_dq *= scale
+
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+
+
+# ===========================================================================
+# Backward kernel: dK / dV
+# ===========================================================================
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps)
+        for num_warps in [1, 2, 4]
+    ],
+    key=['BS', 'BK', 'BV'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def parallel_nsa_bwd_kernel_dkv(
+    q,
+    k,
+    v,
+    lse,
+    delta,
+    do,
+    dk,
+    dv,
+    block_mask,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    HQ: tl.constexpr,
+    G: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    M: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_s, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    all = B * T
+    if IS_VARLEN:
+        i_n, i_s = tl.load(chunk_indices + i_s * 2).to(tl.int32), tl.load(chunk_indices + i_s * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_s * BS, 0), (BS, BK), (1, 0))
+    p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H * V, 1), (i_s * BS, i_v * BV), (BS, BV), (1, 0))
+    p_dk = tl.make_block_ptr(dk + (i_v * all * H + bos * H + i_h) * K, (T, K), (H * K, 1), (i_s * BS, 0), (BS, BK), (1, 0))
+    p_dv = tl.make_block_ptr(dv + (bos * H + i_h) * V, (T, V), (H * V, 1), (i_s * BS, i_v * BV), (BS, BV), (1, 0))
+
+    # [BS, BK]
+    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_dk = tl.zeros([BS, BK], dtype=tl.float32)
+    # [BS, BV]
+    b_v = tl.load(p_v, boundary_check=(0, 1))
+    b_dv = tl.zeros([BS, BV], dtype=tl.float32)
+
+    for i in range(i_s * BS, T):
+        b_m = tl.load(block_mask + (bos + i) * H * M + i_h * M + i_s)
+        if b_m:
+            p_q = tl.make_block_ptr(q + (bos + i) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+            # [G, BK]
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_q = (b_q * scale).to(b_q.dtype)
+
+            p_do = tl.make_block_ptr(do + (bos + i) * HQ * V, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0))
+            p_lse = lse + (bos + i) * HQ + i_h * G + tl.arange(0, G)
+            p_delta = delta + (bos + i) * HQ + i_h * G + tl.arange(0, G)
+            # [G, BV]
+            b_do = tl.load(p_do, boundary_check=(0, 1))
+            # [G]
+            b_lse = tl.load(p_lse)
+            b_delta = tl.load(p_delta)
+            # [BS, G]
+            b_s = tl.dot(b_k, tl.trans(b_q))
+            b_p = exp(b_s - b_lse[None, :])
+            b_p = tl.where((i >= (i_s * BS + tl.arange(0, BS)))[:, None], b_p, 0)
+            # [BS, G] @ [G, BV] -> [BS, BV]
+            b_dv += tl.dot(b_p.to(b_do.dtype), b_do)
+            # [BS, BV] @ [BV, G] -> [BS, G]
+            b_dp = tl.dot(b_v, tl.trans(b_do))
+            # [BS, G]
+            b_ds = b_p * (b_dp - b_delta[None, :])
+            # [BS, G] @ [G, BK] -> [BS, BK]
+            b_dk += tl.dot(b_ds.to(b_q.dtype), b_q)
+
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+
+
+# ===========================================================================
+# Python-level wrapper functions
+# ===========================================================================
+
+
+def parallel_nsa_topk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    lse: torch.Tensor,
+    block_counts: torch.LongTensor | int,
+    block_size: int = 64,
+    scale: float = None,
+    cu_seqlens: torch.LongTensor | None = None,
+) -> torch.LongTensor:
+    B, T, HQ, K = q.shape
+    H = k.shape[2]
+    G = HQ // H
+    # the number of selected blocks for each token
+    S = block_counts if isinstance(block_counts, int) else block_counts.max().item()
+    S = triton.next_power_of_2(S)
+    # here we set BC = BS, but beware that they can be chosen separately if required
+    BC = BS = block_size
+    BK = max(triton.next_power_of_2(K), 16)
+    assert BC >= 2 * S, f"BC ({BC}) must be greater than or equal to 2 * S ({S})"
+
+    block_indices = torch.zeros(B, T, H, S, dtype=torch.int32, device=q.device)
+    token_indices = prepare_token_indices(cu_seqlens) if cu_seqlens is not None else None
+    chunk_offsets = prepare_chunk_offsets(cu_seqlens, BS) if cu_seqlens is not None else None
+    grid = (T, B * H)
+    # the 1st and the last 2 blocks are always selected
+    parallel_nsa_kernel_topk[grid](
+        q=q,
+        k=k,
+        lse=lse,
+        scale=scale,
+        block_indices=block_indices,
+        cu_seqlens=cu_seqlens,
+        token_indices=token_indices,
+        chunk_offsets=chunk_offsets,
+        T=T,
+        H=H,
+        HQ=HQ,
+        G=G,
+        K=K,
+        S=S,
+        BC=BC,
+        BS=BS,
+        BK=BK,
+    )
+    return block_indices
+
+
+def parallel_nsa_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    block_indices: torch.LongTensor,
+    block_counts: torch.LongTensor | int,
+    block_size: int,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    token_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K, V, S = *k.shape, v.shape[-1], block_indices.shape[-1]
+    HQ = q.shape[2]
+    G = HQ // H
+    BS = block_size
+    if check_shared_mem('hopper', q.device.index):
+        BK = min(256, triton.next_power_of_2(K))
+        BV = min(256, triton.next_power_of_2(V))
+    else:
+        BK = min(128, triton.next_power_of_2(K))
+        BV = min(128, triton.next_power_of_2(V))
+    NK = triton.cdiv(K, BK)
+    NV = triton.cdiv(V, BV)
+    assert NK == 1, "The key dimension can not be larger than 256"
+
+    grid = (T, NV, B * H)
+    o = torch.empty(B, T, HQ, V, dtype=v.dtype, device=q.device)
+    lse = torch.empty(B, T, HQ, dtype=torch.float, device=q.device)
+
+    # Dispatch to TLE-optimized kernel when available.
+    _use_tle = HAS_TLE and os.environ.get('FLA_NSA_TLE', '1') != '0'
+    if _use_tle:
+        kernel = parallel_nsa_fwd_kernel_tle
+    else:
+        kernel = parallel_nsa_fwd_kernel
+
+    kernel[grid](
+        q=q,
+        k=k,
+        v=v,
+        o=o,
+        lse=lse,
+        scale=scale,
+        block_indices=block_indices,
+        block_counts=block_counts,
+        cu_seqlens=cu_seqlens,
+        token_indices=token_indices,
+        T=T,
+        H=H,
+        HQ=HQ,
+        G=G,
+        K=K,
+        V=V,
+        S=S,
+        BS=BS,
+        BK=BK,
+        BV=BV,
+    )
+    return o, lse
+
+
+def parallel_nsa_block_mask(
+    block_indices: torch.LongTensor,
+    block_counts: torch.LongTensor | int,
+    cu_seqlens: torch.LongTensor,
+    block_size: int,
+):
+    B, T, H, S = block_indices.shape
+    BS = block_size
+    if cu_seqlens is not None:
+        NS = triton.cdiv(prepare_lens(cu_seqlens).max().item(), BS)
+    else:
+        NS = triton.cdiv(T, BS)
+    block_mask = torch.zeros(B, T, H, NS, dtype=torch.bool, device=block_indices.device)
+
+    parallel_nsa_kernel_mask[(T, B, H * S)](
+        block_indices=block_indices,
+        block_counts=block_counts,
+        block_mask=block_mask,
+        T=T,
+        H=H,
+        S=S,
+        BS=BS,
+        NS=NS,
+    )
+    return block_mask
+
+
+def parallel_nsa_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    o: torch.Tensor,
+    lse: torch.Tensor,
+    do: torch.Tensor,
+    block_indices: torch.Tensor,
+    block_counts: torch.LongTensor | int,
+    block_size: int = 64,
+    scale: float = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    token_indices: torch.LongTensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K, V, S = *k.shape, v.shape[-1], block_indices.shape[-1]
+    HQ = q.shape[2]
+    G = HQ // H
+    BS = block_size
+    BK = max(triton.next_power_of_2(K), 16)
+    BV = min(128, max(triton.next_power_of_2(v.shape[-1]), 16))
+    NV = triton.cdiv(V, BV)
+
+    delta = parallel_attn_bwd_preprocess(o, do)
+
+    dq = torch.empty(NV, *q.shape, dtype=q.dtype if NV == 1 else torch.float, device=q.device)
+    grid = (T, NV, B * H)
+    parallel_nsa_bwd_kernel_dq[grid](
+        q=q,
+        k=k,
+        v=v,
+        lse=lse,
+        delta=delta,
+        do=do,
+        dq=dq,
+        block_indices=block_indices,
+        block_counts=block_counts,
+        cu_seqlens=cu_seqlens,
+        token_indices=token_indices,
+        scale=scale,
+        T=T,
+        B=B,
+        H=H,
+        HQ=HQ,
+        G=G,
+        K=K,
+        V=V,
+        S=S,
+        BS=BS,
+        BK=BK,
+        BV=BV,
+    )
+    dq = dq.sum(0)
+
+    if cu_seqlens is not None:
+        if chunk_indices is None:
+            chunk_indices = prepare_chunk_indices(cu_seqlens, BS)
+        NS = len(chunk_indices)
+    else:
+        NS = triton.cdiv(T, BS)
+
+    block_mask = parallel_nsa_block_mask(block_indices, block_counts, cu_seqlens, block_size)
+    dk = torch.empty(NV, *k.shape, dtype=k.dtype if NV == 1 else torch.float, device=q.device)
+    dv = torch.empty(v.shape, dtype=v.dtype, device=q.device)
+
+    grid = (NV, NS, B * H)
+    parallel_nsa_bwd_kernel_dkv[grid](
+        q=q,
+        k=k,
+        v=v,
+        lse=lse,
+        delta=delta,
+        do=do,
+        dk=dk,
+        dv=dv,
+        block_mask=block_mask,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        B=B,
+        H=H,
+        HQ=HQ,
+        G=G,
+        K=K,
+        V=V,
+        M=block_mask.shape[-1],
+        BS=BS,
+        BK=BK,
+        BV=BV,
+    )
+    dk = dk.sum(0)
+    return dq, dk, dv
+
+
+# ===========================================================================
+# Autograd Function
+# ===========================================================================
+
+
+class ParallelNSAFunction(torch.autograd.Function):
+
+    @staticmethod
+    @input_guard
+    def forward(ctx, q, k, v, block_indices, block_counts, block_size, scale, cu_seqlens):
+        ctx.dtype = q.dtype
+
+        token_indices = prepare_token_indices(cu_seqlens) if cu_seqlens is not None else None
+
+        o, lse = parallel_nsa_fwd(
+            q=q,
+            k=k,
+            v=v,
+            block_indices=block_indices,
+            block_counts=block_counts,
+            block_size=block_size,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            token_indices=token_indices,
+        )
+        ctx.save_for_backward(q, k, v, o, lse)
+        ctx.block_indices = block_indices
+        ctx.block_counts = block_counts
+        ctx.cu_seqlens = cu_seqlens
+        ctx.token_indices = token_indices
+        ctx.block_size = block_size
+        ctx.scale = scale
+        return o.to(q.dtype)
+
+    @staticmethod
+    @input_guard
+    def backward(ctx, do):
+        q, k, v, o, lse = ctx.saved_tensors
+        dq, dk, dv = parallel_nsa_bwd(
+            q=q,
+            k=k,
+            v=v,
+            o=o,
+            lse=lse,
+            do=do,
+            block_indices=ctx.block_indices,
+            block_counts=ctx.block_counts,
+            block_size=ctx.block_size,
+            scale=ctx.scale,
+            cu_seqlens=ctx.cu_seqlens,
+            token_indices=ctx.token_indices,
+        )
+        return dq.to(q), dk.to(k), dv.to(v), None, None, None, None, None
+
+
+def parallel_nsa(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g_cmp: torch.Tensor | None = None,
+    g_slc: torch.Tensor | None = None,
+    g_swa: torch.Tensor | None = None,
+    block_indices: torch.LongTensor | None = None,
+    block_counts: torch.LongTensor | int = 16,
+    block_size: int = 64,
+    window_size: int = 0,
+    scale: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+) -> torch.Tensor:
+    r"""
+    Native Sparse Attention (NSA) — parallel implementation.
+
+    Args:
+        q (torch.Tensor):
+            queries of shape ``[B, T, HQ, K]``.
+        k (torch.Tensor):
+            keys of shape ``[B, T, H, K]``.
+            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H)
+            must be a power of 2 and >= 16.
+        v (torch.Tensor):
+            values of shape ``[B, T, H, V]``.
+        g_cmp (torch.Tensor):
+            Gate score for compressed attention of shape ``[B, T, HQ]``. If provided,
+            ``block_indices`` will be computed automatically.
+        g_slc (torch.Tensor):
+            Gate score for selected attention of shape ``[B, T, HQ]``.
+        g_swa (torch.Tensor):
+            Gate score for sliding window attention of shape ``[B, T, HQ]``.
+        block_indices (torch.LongTensor):
+            Pre-computed block indices of shape ``[B, T, H, S]``.
+            If ``g_cmp`` is provided, this is computed automatically.
+        block_counts (int or torch.LongTensor):
+            Number of selected blocks for each query. If a tensor, shape ``[B, T, H]``.
+            Default: 16.
+        block_size (int):
+            Size of each selected block. Default: 64.
+        window_size (int):
+            Sliding window size. 0 means no sliding attention. Default: 0.
+        scale (float):
+            Scale factor. If ``None``, defaults to ``K ** -0.5``.
+        cu_seqlens (torch.LongTensor):
+            Cumulative sequence lengths for variable-length sequences.
+
+    Returns:
+        torch.Tensor of shape ``[B, T, HQ, V]``.
+    """
+    assert block_counts is not None, "block counts must be provided for selection"
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    if cu_seqlens is not None and q.shape[0] != 1:
+        raise ValueError(
+            f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`. "
+            f"Please flatten variable-length inputs before processing.",
+        )
+    assert q.shape[2] % (k.shape[2] * 16) == 0, "Group size must be a multiple of 16 in NSA"
+
+    k_cmp = mean_pooling(k, block_size, cu_seqlens)
+    v_cmp = mean_pooling(v, block_size, cu_seqlens)
+    o_cmp, lse_cmp = None, None
+    if g_cmp is not None:
+        o_cmp, lse_cmp = parallel_nsa_compression(
+            q=q,
+            k=k_cmp,
+            v=v_cmp,
+            block_size=block_size,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+        )
+        if block_indices is not None:
+            warnings.warn("`block_indices` will be ignored when `g_cmp` is provided")
+        block_indices = parallel_nsa_topk(
+            q=q,
+            k=k_cmp,
+            lse=lse_cmp,
+            block_counts=block_counts,
+            block_size=block_size,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+        )
+    o = o_slc = ParallelNSAFunction.apply(q, k, v, block_indices, block_counts, block_size, scale, cu_seqlens)
+    if g_slc is not None:
+        o = o_slc * g_slc.unsqueeze(-1)
+    if o_cmp is not None:
+        o = torch.addcmul(o, o_cmp, g_cmp.unsqueeze(-1))
+    if window_size > 0:
+        try:
+            from flash_attn import flash_attn_func, flash_attn_varlen_func
+        except ImportError:
+            raise ImportError(
+                "Flash Attention is required for sliding window attention. "
+                "Install it via `pip install flash-attn --no-build-isolation`"
+            )
+        if cu_seqlens is not None:
+            max_seqlen = q.shape[1]
+            o_swa = flash_attn_varlen_func(
+                q.squeeze(0), k.squeeze(0), v.squeeze(0),
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+                causal=True,
+                window_size=(window_size - 1, 0),
+            ).unsqueeze(0)
+        else:
+            o_swa = flash_attn_func(
+                q, k, v,
+                causal=True,
+                window_size=(window_size - 1, 0),
+            )
+        o = torch.addcmul(o, o_swa, g_swa.unsqueeze(-1))
+    return o

--- a/src/flaggems_vllm/ops/FLA/parallel_nsa.py
+++ b/src/flaggems_vllm/ops/FLA/parallel_nsa.py
@@ -20,15 +20,14 @@ from flaggems_vllm.ops.FLA.index import (
     prepare_token_indices,
 )
 from flaggems_vllm.ops.FLA.mean_pooling import mean_pooling
-from flaggems_vllm.ops.FLA.parallel_nsa_compression import (
-    parallel_nsa_compression,
-)
+from flaggems_vllm.ops.FLA.parallel_nsa_compression import parallel_nsa_compression
 from flaggems_vllm.ops.FLA.triton_ops_helper import autotune_cache_kwargs, exp, log
 from flaggems_vllm.ops.FLA.utils import _bitonic_merge, check_shared_mem, input_guard
 
 try:
     HAS_TLE = False
     import triton.experimental.tle.language as tle  # noqa: F401
+
     HAS_TLE = True
 except ImportError:
     tle = None
@@ -50,15 +49,14 @@ except ImportError:
 # ===========================================================================
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
 @triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=num_warps)
-        for num_warps in [1, 2, 4]
-    ],
-    key=['BS', 'BK'],
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4]],
+    key=["BS", "BK"],
     **autotune_cache_kwargs,
 )
 @triton.jit
@@ -86,15 +84,21 @@ def parallel_nsa_kernel_topk(
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(token_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(
+            token_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
         T = eos - bos
         boc = tl.load(chunk_offsets + i_n).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
         boc = i_b * tl.cdiv(T, BS)
 
-    p_q = tl.make_block_ptr(q + (bos + i_t) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+    p_q = tl.make_block_ptr(
+        q + (bos + i_t) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0)
+    )
 
     # the Q block is kept in the shared memory throughout the whole kernel
     # [G, BK]
@@ -113,19 +117,21 @@ def parallel_nsa_kernel_topk(
         b_lse = tl.load(lse + (bos + i_t) * HQ + i_h * G + tl.arange(0, G))
     else:
         # max scores for the current block
-        b_m = tl.full([G], float('-inf'), dtype=tl.float32)
+        b_m = tl.full([G], float("-inf"), dtype=tl.float32)
         # lse = log(acc) + m
         b_acc = tl.zeros([G], dtype=tl.float32)
         for i_c in range(0, NC, BC):
             o_c = i_c + tl.arange(0, BC)
 
-            p_k = tl.make_block_ptr(k + (boc * H + i_h) * K, (K, TC), (1, H * K), (0, i_c), (BK, BC), (0, 1))
+            p_k = tl.make_block_ptr(
+                k + (boc * H + i_h) * K, (K, TC), (1, H * K), (0, i_c), (BK, BC), (0, 1)
+            )
             # [BK, BC]
             b_k = tl.load(p_k, boundary_check=(0, 1))
 
             # [G, BC]
             b_s = tl.dot(b_q, b_k)
-            b_s = tl.where((o_c < NC)[None, :], b_s, float('-inf'))
+            b_s = tl.where((o_c < NC)[None, :], b_s, float("-inf"))
 
             # [G]
             b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
@@ -153,15 +159,19 @@ def parallel_nsa_kernel_topk(
     for i_c in range(0, tl.cdiv(i_t + 1, BS), BC):
         o_c = i_c + tl.arange(0, BC)
 
-        p_k = tl.make_block_ptr(k + (boc * H + i_h) * K, (K, TC), (1, H * K), (0, i_c), (BK, BC), (0, 1))
+        p_k = tl.make_block_ptr(
+            k + (boc * H + i_h) * K, (K, TC), (1, H * K), (0, i_c), (BK, BC), (0, 1)
+        )
         # [BK, BC]
         b_k = tl.load(p_k, boundary_check=(0, 1))
         # [G, BC]
         b_s = tl.dot(b_q, b_k)
-        b_s = tl.where(o_c < IC, b_s, float('-inf'))
+        b_s = tl.where(o_c < IC, b_s, float("-inf"))
         # [G, BC]
         # the 1st and the last 2 blocks are always selected
-        b_p = tl.where((o_c == 0) | ((o_c == IC - 1) | (o_c == IC)), 1., exp(b_s - b_lse[:, None]))
+        b_p = tl.where(
+            (o_c == 0) | ((o_c == IC - 1) | (o_c == IC)), 1.0, exp(b_s - b_lse[:, None])
+        )
         # the importance scores of the current block
         # [BC]
         b_i, b_ip = tl.sum(b_p, 0), b_i
@@ -176,14 +186,18 @@ def parallel_nsa_kernel_topk(
             b_i, o_i = _bitonic_merge(b_i, o_i.to(tl.int32), n_dims, False, n_dims)
             b_i_new = b_ip * m_i + b_i * (1 - m_i)
             o_i_new = o_ip * m_i + o_i * (1 - m_i)
-            b_i, o_i = _bitonic_merge(b_i_new, o_i_new.to(tl.int32), n_dims, True, n_dims)
+            b_i, o_i = _bitonic_merge(
+                b_i_new, o_i_new.to(tl.int32), n_dims, True, n_dims
+            )
         else:
             b_i, o_i = _bitonic_merge(b_i, o_i.to(tl.int32), n_dims, True, n_dims)
 
     m_top = tl.arange(0, BC // S) == 0
     b_top = tl.sum(m_top[:, None] * tl.reshape(o_i, [BC // S, S]), 0)
 
-    p_b = tl.make_block_ptr(block_indices + (bos + i_t) * H * S, (H * S,), (1,), (i_h * S,), (S,), (0,))
+    p_b = tl.make_block_ptr(
+        block_indices + (bos + i_t) * H * S, (H * S,), (1,), (i_h * S,), (S,), (0,)
+    )
     tl.store(p_b, b_top.to(p_b.dtype.element_ty))
 
 
@@ -192,16 +206,15 @@ def parallel_nsa_kernel_topk(
 # ===========================================================================
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-    'USE_BLOCK_COUNTS': lambda args: isinstance(args['block_counts'], torch.Tensor),
-})
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "USE_BLOCK_COUNTS": lambda args: isinstance(args["block_counts"], torch.Tensor),
+    }
+)
 @triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=num_warps)
-        for num_warps in [1, 2, 4]
-    ],
-    key=['BS', 'BK', 'BV'],
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4]],
+    key=["BS", "BK", "BV"],
     **autotune_cache_kwargs,
 )
 @triton.jit
@@ -233,8 +246,12 @@ def parallel_nsa_fwd_kernel(
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(token_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(
+            token_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -248,30 +265,38 @@ def parallel_nsa_fwd_kernel(
     else:
         NS = S
 
-    p_q = tl.make_block_ptr(q + (bos + i_t) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+    p_q = tl.make_block_ptr(
+        q + (bos + i_t) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0)
+    )
     # the Q block is kept in the shared memory throughout the whole kernel
     # [G, BK]
     b_q = tl.load(p_q, boundary_check=(0, 1))
     b_q = (b_q * scale).to(b_q.dtype)
 
-    p_o = tl.make_block_ptr(o + (bos + i_t) * HQ * V, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0))
+    p_o = tl.make_block_ptr(
+        o + (bos + i_t) * HQ * V, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0)
+    )
     p_lse = lse + (bos + i_t) * HQ + i_h * G + tl.arange(0, G)
     # [G, BV]
     b_o = tl.zeros([G, BV], dtype=tl.float32)
 
-    b_m = tl.full([G], float('-inf'), dtype=tl.float32)
+    b_m = tl.full([G], float("-inf"), dtype=tl.float32)
     b_acc = tl.zeros([G], dtype=tl.float32)
     for i in range(NS):
         i_s = tl.load(block_indices + i).to(tl.int32) * BS
         if i_s <= i_t and i_s >= 0:
             p_k = tl.make_block_ptr(k, (K, T), (1, H * K), (0, i_s), (BK, BS), (0, 1))
-            p_v = tl.make_block_ptr(v, (T, V), (H * V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
+            p_v = tl.make_block_ptr(
+                v, (T, V), (H * V, 1), (i_s, i_v * BV), (BS, BV), (1, 0)
+            )
             # [BK, BS]
             b_k = tl.load(p_k, boundary_check=(0, 1))
             # [G, BS] — compute QK^T scores
             b_s = tl.dot(b_q, b_k)
             # b_k registers are now free — will be reused for later loads
-            b_s = tl.where((i_t >= (i_s + tl.arange(0, BS)))[None, :], b_s, float('-inf'))
+            b_s = tl.where(
+                (i_t >= (i_s + tl.arange(0, BS)))[None, :], b_s, float("-inf")
+            )
 
             # [G]
             b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
@@ -300,16 +325,17 @@ def parallel_nsa_fwd_kernel(
 
 if HAS_TLE:
 
-    @triton.heuristics({
-        'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-        'USE_BLOCK_COUNTS': lambda args: isinstance(args['block_counts'], torch.Tensor),
-    })
+    @triton.heuristics(
+        {
+            "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+            "USE_BLOCK_COUNTS": lambda args: isinstance(
+                args["block_counts"], torch.Tensor
+            ),
+        }
+    )
     @triton.autotune(
-        configs=[
-            triton.Config({}, num_warps=num_warps)
-            for num_warps in [1, 2, 4]
-        ],
-        key=['BS', 'BK', 'BV'],
+        configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4]],
+        key=["BS", "BK", "BV"],
         **autotune_cache_kwargs,
     )
     @triton.jit
@@ -341,8 +367,12 @@ if HAS_TLE:
         i_b, i_h = i_bh // H, i_bh % H
 
         if IS_VARLEN:
-            i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(token_indices + i_t * 2 + 1).to(tl.int32)
-            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+            i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(
+                token_indices + i_t * 2 + 1
+            ).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+                cu_seqlens + i_n + 1
+            ).to(tl.int32)
             T = eos - bos
         else:
             bos, eos = i_b * T, i_b * T + T
@@ -356,17 +386,26 @@ if HAS_TLE:
         else:
             NS = S
 
-        p_q = tl.make_block_ptr(q + (bos + i_t) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+        p_q = tl.make_block_ptr(
+            q + (bos + i_t) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0)
+        )
         # [G, BK]
         b_q = tl.load(p_q, boundary_check=(0, 1))
         b_q = (b_q * scale).to(b_q.dtype)
 
-        p_o = tl.make_block_ptr(o + (bos + i_t) * HQ * V, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0))
+        p_o = tl.make_block_ptr(
+            o + (bos + i_t) * HQ * V,
+            (HQ, V),
+            (V, 1),
+            (i_h * G, i_v * BV),
+            (G, BV),
+            (1, 0),
+        )
         p_lse = lse + (bos + i_t) * HQ + i_h * G + tl.arange(0, G)
         # [G, BV]
         b_o = tl.zeros([G, BV], dtype=tl.float32)
 
-        b_m = tl.full([G], float('-inf'), dtype=tl.float32)
+        b_m = tl.full([G], float("-inf"), dtype=tl.float32)
         b_acc = tl.zeros([G], dtype=tl.float32)
 
         # Precompute indices for async K/V loads via tle.load(is_async=True).
@@ -387,7 +426,9 @@ if HAS_TLE:
 
                 # Compute QK^T scores
                 b_s = tl.dot(b_q, b_k.to(b_q.dtype))
-                b_s = tl.where((i_t >= (i_s + tl.arange(0, BS)))[None, :], b_s, float('-inf'))
+                b_s = tl.where(
+                    (i_t >= (i_s + tl.arange(0, BS)))[None, :], b_s, float("-inf")
+                )
 
                 # [G]
                 b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
@@ -398,8 +439,14 @@ if HAS_TLE:
                 b_acc = b_acc * b_r + tl.sum(b_p, 1)
 
                 # Async V load AFTER score computation
-                v_ptrs = v_base + (i_s + offs_s[:, None]) * H * V + (v_start + offs_v[None, :])
-                v_mask = ((i_s + offs_s[:, None]) < T) & ((v_start + offs_v[None, :]) < V)
+                v_ptrs = (
+                    v_base
+                    + (i_s + offs_s[:, None]) * H * V
+                    + (v_start + offs_v[None, :])
+                )
+                v_mask = ((i_s + offs_s[:, None]) < T) & (
+                    (v_start + offs_v[None, :]) < V
+                )
                 b_v = tle.load(v_ptrs, mask=v_mask, other=0.0, is_async=True)
 
                 # [G, BV]
@@ -417,10 +464,12 @@ if HAS_TLE:
 # ===========================================================================
 
 
-@triton.heuristics({
-    'USE_BLOCK_COUNTS': lambda args: isinstance(args['block_counts'], torch.Tensor),
-})
-@triton.jit(do_not_specialize=['T'])
+@triton.heuristics(
+    {
+        "USE_BLOCK_COUNTS": lambda args: isinstance(args["block_counts"], torch.Tensor),
+    }
+)
+@triton.jit(do_not_specialize=["T"])
 def parallel_nsa_kernel_mask(
     block_indices,
     block_counts,
@@ -437,12 +486,17 @@ def parallel_nsa_kernel_mask(
 
     b_i = tl.load(block_indices + i_b * T * H * S + i_t * H * S + i_h * S + i_s)
     if USE_BLOCK_COUNTS:
-        b_m = b_i * BS <= i_t and i_s < tl.load(block_counts + i_b * T * H + i_t * H + i_h)
+        b_m = b_i * BS <= i_t and i_s < tl.load(
+            block_counts + i_b * T * H + i_t * H + i_h
+        )
     else:
         b_m = b_i * BS <= i_t
 
     if b_i < NS and b_i >= 0:
-        tl.store(block_mask + i_b * T * H * NS + i_t * H * NS + i_h * NS + b_i, b_m.to(block_mask.dtype.element_ty))
+        tl.store(
+            block_mask + i_b * T * H * NS + i_t * H * NS + i_h * NS + b_i,
+            b_m.to(block_mask.dtype.element_ty),
+        )
 
 
 # ===========================================================================
@@ -450,19 +504,18 @@ def parallel_nsa_kernel_mask(
 # ===========================================================================
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-    'USE_BLOCK_COUNTS': lambda args: isinstance(args['block_counts'], torch.Tensor),
-})
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "USE_BLOCK_COUNTS": lambda args: isinstance(args["block_counts"], torch.Tensor),
+    }
+)
 @triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=num_warps)
-        for num_warps in [1, 2, 4]
-    ],
-    key=['BS', 'BK', 'BV'],
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4]],
+    key=["BS", "BK", "BV"],
     **autotune_cache_kwargs,
 )
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=["T"])
 def parallel_nsa_bwd_kernel_dq(
     q,
     k,
@@ -495,8 +548,12 @@ def parallel_nsa_bwd_kernel_dq(
 
     all = B * T
     if IS_VARLEN:
-        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(token_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(
+            token_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -539,7 +596,9 @@ def parallel_nsa_bwd_kernel_dq(
         i_s = tl.load(block_indices + i).to(tl.int32) * BS
         if i_s <= i_t and i_s >= 0:
             p_k = tl.make_block_ptr(k, (K, T), (1, H * K), (0, i_s), (BK, BS), (0, 1))
-            p_v = tl.make_block_ptr(v, (V, T), (1, H * V), (i_v * BV, i_s), (BV, BS), (0, 1))
+            p_v = tl.make_block_ptr(
+                v, (V, T), (1, H * V), (i_v * BV, i_s), (BV, BS), (0, 1)
+            )
             # [BK, BS]
             b_k = tl.load(p_k, boundary_check=(0, 1))
             # [BV, BS]
@@ -565,18 +624,17 @@ def parallel_nsa_bwd_kernel_dq(
 # ===========================================================================
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
 @triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=num_warps)
-        for num_warps in [1, 2, 4]
-    ],
-    key=['BS', 'BK', 'BV'],
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4]],
+    key=["BS", "BK", "BV"],
     **autotune_cache_kwargs,
 )
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=["T"])
 def parallel_nsa_bwd_kernel_dkv(
     q,
     k,
@@ -608,16 +666,43 @@ def parallel_nsa_bwd_kernel_dkv(
 
     all = B * T
     if IS_VARLEN:
-        i_n, i_s = tl.load(chunk_indices + i_s * 2).to(tl.int32), tl.load(chunk_indices + i_s * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_s = tl.load(chunk_indices + i_s * 2).to(tl.int32), tl.load(
+            chunk_indices + i_s * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_s * BS, 0), (BS, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H * V, 1), (i_s * BS, i_v * BV), (BS, BV), (1, 0))
-    p_dk = tl.make_block_ptr(dk + (i_v * all * H + bos * H + i_h) * K, (T, K), (H * K, 1), (i_s * BS, 0), (BS, BK), (1, 0))
-    p_dv = tl.make_block_ptr(dv + (bos * H + i_h) * V, (T, V), (H * V, 1), (i_s * BS, i_v * BV), (BS, BV), (1, 0))
+    p_k = tl.make_block_ptr(
+        k + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_s * BS, 0), (BS, BK), (1, 0)
+    )
+    p_v = tl.make_block_ptr(
+        v + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_s * BS, i_v * BV),
+        (BS, BV),
+        (1, 0),
+    )
+    p_dk = tl.make_block_ptr(
+        dk + (i_v * all * H + bos * H + i_h) * K,
+        (T, K),
+        (H * K, 1),
+        (i_s * BS, 0),
+        (BS, BK),
+        (1, 0),
+    )
+    p_dv = tl.make_block_ptr(
+        dv + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_s * BS, i_v * BV),
+        (BS, BV),
+        (1, 0),
+    )
 
     # [BS, BK]
     b_k = tl.load(p_k, boundary_check=(0, 1))
@@ -629,12 +714,21 @@ def parallel_nsa_bwd_kernel_dkv(
     for i in range(i_s * BS, T):
         b_m = tl.load(block_mask + (bos + i) * H * M + i_h * M + i_s)
         if b_m:
-            p_q = tl.make_block_ptr(q + (bos + i) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+            p_q = tl.make_block_ptr(
+                q + (bos + i) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0)
+            )
             # [G, BK]
             b_q = tl.load(p_q, boundary_check=(0, 1))
             b_q = (b_q * scale).to(b_q.dtype)
 
-            p_do = tl.make_block_ptr(do + (bos + i) * HQ * V, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0))
+            p_do = tl.make_block_ptr(
+                do + (bos + i) * HQ * V,
+                (HQ, V),
+                (V, 1),
+                (i_h * G, i_v * BV),
+                (G, BV),
+                (1, 0),
+            )
             p_lse = lse + (bos + i) * HQ + i_h * G + tl.arange(0, G)
             p_delta = delta + (bos + i) * HQ + i_h * G + tl.arange(0, G)
             # [G, BV]
@@ -685,8 +779,12 @@ def parallel_nsa_topk(
     assert BC >= 2 * S, f"BC ({BC}) must be greater than or equal to 2 * S ({S})"
 
     block_indices = torch.zeros(B, T, H, S, dtype=torch.int32, device=q.device)
-    token_indices = prepare_token_indices(cu_seqlens) if cu_seqlens is not None else None
-    chunk_offsets = prepare_chunk_offsets(cu_seqlens, BS) if cu_seqlens is not None else None
+    token_indices = (
+        prepare_token_indices(cu_seqlens) if cu_seqlens is not None else None
+    )
+    chunk_offsets = (
+        prepare_chunk_offsets(cu_seqlens, BS) if cu_seqlens is not None else None
+    )
     grid = (T, B * H)
     # the 1st and the last 2 blocks are always selected
     parallel_nsa_kernel_topk[grid](
@@ -726,7 +824,7 @@ def parallel_nsa_fwd(
     HQ = q.shape[2]
     G = HQ // H
     BS = block_size
-    if check_shared_mem('hopper', q.device.index):
+    if check_shared_mem("hopper", q.device.index):
         BK = min(256, triton.next_power_of_2(K))
         BV = min(256, triton.next_power_of_2(V))
     else:
@@ -741,7 +839,7 @@ def parallel_nsa_fwd(
     lse = torch.empty(B, T, HQ, dtype=torch.float, device=q.device)
 
     # Dispatch to TLE-optimized kernel when available.
-    _use_tle = HAS_TLE and os.environ.get('FLA_NSA_TLE', '1') != '0'
+    _use_tle = HAS_TLE and os.environ.get("FLA_NSA_TLE", "1") != "0"
     if _use_tle:
         kernel = parallel_nsa_fwd_kernel_tle
     else:
@@ -824,7 +922,9 @@ def parallel_nsa_bwd(
 
     delta = parallel_attn_bwd_preprocess(o, do)
 
-    dq = torch.empty(NV, *q.shape, dtype=q.dtype if NV == 1 else torch.float, device=q.device)
+    dq = torch.empty(
+        NV, *q.shape, dtype=q.dtype if NV == 1 else torch.float, device=q.device
+    )
     grid = (T, NV, B * H)
     parallel_nsa_bwd_kernel_dq[grid](
         q=q,
@@ -860,8 +960,12 @@ def parallel_nsa_bwd(
     else:
         NS = triton.cdiv(T, BS)
 
-    block_mask = parallel_nsa_block_mask(block_indices, block_counts, cu_seqlens, block_size)
-    dk = torch.empty(NV, *k.shape, dtype=k.dtype if NV == 1 else torch.float, device=q.device)
+    block_mask = parallel_nsa_block_mask(
+        block_indices, block_counts, cu_seqlens, block_size
+    )
+    dk = torch.empty(
+        NV, *k.shape, dtype=k.dtype if NV == 1 else torch.float, device=q.device
+    )
     dv = torch.empty(v.shape, dtype=v.dtype, device=q.device)
 
     grid = (NV, NS, B * H)
@@ -903,10 +1007,14 @@ class ParallelNSAFunction(torch.autograd.Function):
 
     @staticmethod
     @input_guard
-    def forward(ctx, q, k, v, block_indices, block_counts, block_size, scale, cu_seqlens):
+    def forward(
+        ctx, q, k, v, block_indices, block_counts, block_size, scale, cu_seqlens
+    ):
         ctx.dtype = q.dtype
 
-        token_indices = prepare_token_indices(cu_seqlens) if cu_seqlens is not None else None
+        token_indices = (
+            prepare_token_indices(cu_seqlens) if cu_seqlens is not None else None
+        )
 
         o, lse = parallel_nsa_fwd(
             q=q,
@@ -1008,7 +1116,9 @@ def parallel_nsa(
             f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`. "
             f"Please flatten variable-length inputs before processing.",
         )
-    assert q.shape[2] % (k.shape[2] * 16) == 0, "Group size must be a multiple of 16 in NSA"
+    assert (
+        q.shape[2] % (k.shape[2] * 16) == 0
+    ), "Group size must be a multiple of 16 in NSA"
 
     k_cmp = mean_pooling(k, block_size, cu_seqlens)
     v_cmp = mean_pooling(v, block_size, cu_seqlens)
@@ -1033,7 +1143,9 @@ def parallel_nsa(
             scale=scale,
             cu_seqlens=cu_seqlens,
         )
-    o = o_slc = ParallelNSAFunction.apply(q, k, v, block_indices, block_counts, block_size, scale, cu_seqlens)
+    o = o_slc = ParallelNSAFunction.apply(
+        q, k, v, block_indices, block_counts, block_size, scale, cu_seqlens
+    )
     if g_slc is not None:
         o = o_slc * g_slc.unsqueeze(-1)
     if o_cmp is not None:
@@ -1049,7 +1161,9 @@ def parallel_nsa(
         if cu_seqlens is not None:
             max_seqlen = q.shape[1]
             o_swa = flash_attn_varlen_func(
-                q.squeeze(0), k.squeeze(0), v.squeeze(0),
+                q.squeeze(0),
+                k.squeeze(0),
+                v.squeeze(0),
                 cu_seqlens_q=cu_seqlens,
                 cu_seqlens_k=cu_seqlens,
                 max_seqlen_q=max_seqlen,
@@ -1059,7 +1173,9 @@ def parallel_nsa(
             ).unsqueeze(0)
         else:
             o_swa = flash_attn_func(
-                q, k, v,
+                q,
+                k,
+                v,
                 causal=True,
                 window_size=(window_size - 1, 0),
             )

--- a/src/flaggems_vllm/ops/FLA/parallel_nsa_compression.py
+++ b/src/flaggems_vllm/ops/FLA/parallel_nsa_compression.py
@@ -9,15 +9,13 @@ import torch
 import triton
 import triton.language as tl
 
-from flaggems_vllm.ops.FLA import (
-    autotune_cache_kwargs,
-    exp,
-    log,
-    parallel_attn_bwd_preprocess,
+from flaggems_vllm.ops.FLA.bwd_preprocess import parallel_attn_bwd_preprocess
+from flaggems_vllm.ops.FLA.index import (
     prepare_chunk_indices,
     prepare_chunk_offsets,
     prepare_token_indices,
 )
+from flaggems_vllm.ops.FLA.triton_ops_helper import autotune_cache_kwargs, exp, log
 from flaggems_vllm.ops.FLA.utils import check_shared_mem, input_guard
 
 # ===========================================================================

--- a/src/flaggems_vllm/ops/FLA/utils.py
+++ b/src/flaggems_vllm/ops/FLA/utils.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import torch
 import triton
+import triton.language as tl
 
 from flaggems_vllm import runtime
 from flaggems_vllm.utils.device_info import get_device_capability
@@ -146,3 +147,84 @@ def check_shared_mem(arch: str = "none", tensor_idx: int = 0) -> bool:
         return False
     # Use the AMPERE threshold used in the original project as heuristic
     return max_shared >= 166_000
+
+
+# ===========================================================================
+# Bitonic sort utilities (used by NSA top-k selection kernel)
+# ===========================================================================
+
+
+@triton.jit
+def _log2(x):
+    """Compute log2 of a compile-time constant integer."""
+    return x.bit_length() - 1
+
+
+@triton.jit
+def _compare_and_swap(x, ids, flip, i: tl.constexpr, n_dims: tl.constexpr):
+    n_outer: tl.constexpr = x.numel >> n_dims
+    shape: tl.constexpr = [n_outer * 2**i, 2, 2 ** (n_dims - i - 1)]
+    y = tl.reshape(x, shape)
+    # slice left/right with 'stride' 2**(n_dims - i - 1)
+    mask = tl.arange(0, 2)[None, :, None]
+    left = tl.broadcast_to(tl.sum(y * (1 - mask), 1)[:, None, :], shape).to(y.dtype)
+    right = tl.broadcast_to(tl.sum(y * mask, 1)[:, None, :], shape).to(y.dtype)
+    left = tl.reshape(left, x.shape)
+    right = tl.reshape(right, x.shape)
+    # idx
+    y_idx = tl.reshape(ids, shape)
+    left_idx = tl.broadcast_to(tl.sum(y_idx * (1 - mask), 1)[:, None, :], shape)
+    right_idx = tl.broadcast_to(tl.sum(y_idx * mask, 1)[:, None, :], shape)
+    left_idx = tl.reshape(left_idx, x.shape).to(y_idx.dtype)
+    right_idx = tl.reshape(right_idx, x.shape).to(y_idx.dtype)
+    # actual compare-and-swap
+    idtype = tl.core.get_int_dtype(bitwidth=x.dtype.primitive_bitwidth, signed=True)
+    ileft = left.to(idtype, bitcast=True)
+    iright = right.to(idtype, bitcast=True)
+    ix = x.to(idtype, bitcast=True)
+
+    cond = (left > right) != flip
+    ret = ix ^ tl.where(cond, ileft ^ iright, tl.zeros_like(ix))
+    new_ids = ids ^ tl.where(cond, left_idx ^ right_idx, tl.zeros_like(ids))
+    return ret.to(x.dtype, bitcast=True), new_ids
+
+
+@triton.jit
+def _bitonic_merge(
+    x, ids, stage: tl.constexpr, order: tl.constexpr, n_dims: tl.constexpr
+):
+    n_outer: tl.constexpr = x.numel >> n_dims
+    tl.static_assert(stage <= n_dims)
+    # flip denotes whether to re-arrange sub-sequences of elements in ascending or
+    # descending order.
+    # if flip = 00000000... then all elements will be re-arranged ascendingly at this stage
+    # if flip = 00110011... then all the elements will be re-arranged alternatingly (with
+    # a stride of 2) at this stage
+    if order == 2:
+        shape: tl.constexpr = [n_outer * 2 ** (n_dims - 1 - stage), 2, 2**stage]
+        flip = tl.reshape(
+            tl.broadcast_to(tl.arange(0, 2)[None, :, None], shape), x.shape
+        )
+    else:
+        flip = order
+    # perform `stage` rounds of `compare-and-swap`
+    for i in tl.static_range(stage):
+        x, ids = _compare_and_swap(x, ids, flip, i + (n_dims - stage), n_dims)
+    return x, ids
+
+
+@triton.jit
+def argsort(
+    x, ids, dim: tl.constexpr = None, descending: tl.constexpr = tl.core.CONSTEXPR_0
+):
+    # handle default dimension or check that it is the most minor dim
+    _dim: tl.constexpr = len(x.shape) - 1 if dim is None else dim
+    tl.static_assert(
+        _dim == len(x.shape) - 1, "only minor dimension is currently supported"
+    )
+    # iteratively run bitonic merge-sort steps
+    n_dims: tl.constexpr = _log2(x.shape[_dim])
+
+    for i in tl.static_range(1, n_dims + 1):
+        x, ids = _bitonic_merge(x, ids, i, 2 if i < n_dims else descending, n_dims)
+    return x, ids

--- a/src/flaggems_vllm/ops/__init__.py
+++ b/src/flaggems_vllm/ops/__init__.py
@@ -70,7 +70,10 @@ from flaggems_vllm.ops.mul import mul, mul_
 from flaggems_vllm.ops.mv import mv
 from flaggems_vllm.ops.outer import outer
 from flaggems_vllm.ops.pack_seq import pack_seq_triton
-from flaggems_vllm.ops.parallel_nsa_compression import parallel_nsa_compression
+from flaggems_vllm.ops.FLA import (
+    parallel_nsa,
+    parallel_nsa_compression,
+)
 from flaggems_vllm.ops.per_token_group_quant_fp8 import (
     SUPPORTED_FP8_DTYPE,
     per_token_group_quant_fp8,
@@ -155,6 +158,7 @@ __all__ = [
     "mv",
     "outer",
     "outplace_fused_experts",
+    "parallel_nsa",
     "parallel_nsa_compression",
     "pack_seq_triton",
     "per_token_group_quant_fp8",

--- a/tests/test_parallel_nsa.py
+++ b/tests/test_parallel_nsa.py
@@ -47,7 +47,7 @@ def naive_nsa(
     Returns:
         o: outputs of shape ``[B, T, HQ, V]``.
     """
-    if 'head_first' in kwargs:
+    if "head_first" in kwargs:
         raise DeprecationWarning("head_first has been removed.")
     if scale is None:
         scale = k.shape[-1] ** -0.5
@@ -55,7 +55,9 @@ def naive_nsa(
     dtype = q.dtype
     G = q.shape[2] // k.shape[2]
     BS = block_size
-    k, v, block_indices = (repeat(x, 'b t h d -> b t (h g) d', g=G) for x in (k, v, block_indices))
+    k, v, block_indices = (
+        repeat(x, "b t h d -> b t (h g) d", g=G) for x in (k, v, block_indices)
+    )
     q, k, v = map(lambda x: x.float(), (q, k, v))
 
     o = torch.zeros_like(v)
@@ -63,16 +65,22 @@ def naive_nsa(
     if cu_seqlens is None:
         varlen = False
         B, T = q.shape[:2]
-        cu_seqlens = torch.cat([
-            block_indices.new_tensor(range(0, B * T, T)), block_indices.new_tensor([B * T]),
-        ])
+        cu_seqlens = torch.cat(
+            [
+                block_indices.new_tensor(range(0, B * T, T)),
+                block_indices.new_tensor([B * T]),
+            ]
+        )
 
     for i in range(len(cu_seqlens) - 1):
         if not varlen:
             q_b, k_b, v_b, i_b = q[i], k[i], v[i], block_indices[i]
         else:
             T = cu_seqlens[i + 1] - cu_seqlens[i]
-            q_b, k_b, v_b, i_b = map(lambda x: x[0][cu_seqlens[i]:cu_seqlens[i + 1]], (q, k, v, block_indices))
+            q_b, k_b, v_b, i_b = map(
+                lambda x: x[0][cu_seqlens[i] : cu_seqlens[i + 1]],
+                (q, k, v, block_indices),
+            )
 
         i_b = i_b.unsqueeze(-1) * BS + i_b.new_tensor(range(BS))
         i_b = i_b.view(T, block_indices.shape[2], -1).transpose(1, 2)
@@ -80,14 +88,20 @@ def naive_nsa(
             q_i = q_b[i_q] * scale
             i_i = i_b[i_q]
             k_i, v_i = map(
-                lambda x: x.gather(0, i_i.clamp(0, T - 1).unsqueeze(-1).expand(*i_i.shape, x.shape[-1])),
+                lambda x: x.gather(
+                    0, i_i.clamp(0, T - 1).unsqueeze(-1).expand(*i_i.shape, x.shape[-1])
+                ),
                 (k_b, v_b),
             )
-            attn = torch.einsum('h d, n h d -> n h', q_i, k_i).masked_fill(i_i > i_q, float('-inf')).softmax(0)
+            attn = (
+                torch.einsum("h d, n h d -> n h", q_i, k_i)
+                .masked_fill(i_i > i_q, float("-inf"))
+                .softmax(0)
+            )
             if not varlen:
-                o[i, i_q] = torch.einsum('n h, n h v -> h v', attn, v_i)
+                o[i, i_q] = torch.einsum("n h, n h v -> h v", attn, v_i)
             else:
-                o[0][cu_seqlens[i] + i_q] = torch.einsum('n h, n h v -> h v', attn, v_i)
+                o[0][cu_seqlens[i] + i_q] = torch.einsum("n h, n h v -> h v", attn, v_i)
 
     return o.to(dtype)
 
@@ -130,9 +144,11 @@ def assert_close(prefix, ref, tri, ratio, warning=False, err_atol=1e-6):
 
 @pytest.mark.parallel_nsa
 @pytest.mark.parametrize(
-    ('B', 'T', 'H', 'HQ', 'D', 'S', 'block_size', 'scale', 'dtype'),
+    ("B", "T", "H", "HQ", "D", "S", "block_size", "scale", "dtype"),
     [
-        pytest.param(*test, id="B{}-T{}-H{}-HQ{}-D{}-S{}-block_size{}-scale{}-{}".format(*test))
+        pytest.param(
+            *test, id="B{}-T{}-H{}-HQ{}-D{}-S{}-block_size{}-scale{}-{}".format(*test)
+        )
         for test in [
             (1, 63, 1, 16, 64, 16, 32, 1.0, torch.float16),
             (3, 111, 1, 32, 100, 16, 32, 1.0, torch.float16),
@@ -155,7 +171,7 @@ def test_parallel(
 ):
     """Compare FlagGems-vllm parallel_nsa with the naive reference (forward + backward)."""
     torch.manual_seed(42)
-    os.environ['TRITON_F32_DEFAULT'] = 'ieee'
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
 
     device = flaggems_vllm.device
 
@@ -169,17 +185,21 @@ def test_parallel(
         for t in range(T):
             for h in range(H):
                 i_i = torch.randperm(max(1, triton.cdiv(t, block_size)))[:S]
-                block_indices[b, t, h, :len(i_i)] = i_i
+                block_indices[b, t, h, : len(i_i)] = i_i
     block_indices = block_indices.sort(-1)[0]
 
-    ref = naive_nsa(q=q, k=k, v=v, block_indices=block_indices, block_size=block_size, scale=scale)
+    ref = naive_nsa(
+        q=q, k=k, v=v, block_indices=block_indices, block_size=block_size, scale=scale
+    )
     ref.backward(do)
     ref_dq, q.grad = q.grad.clone(), None
     ref_dk, k.grad = k.grad.clone(), None
     ref_dv, v.grad = v.grad.clone(), None
 
     tri = flaggems_vllm.parallel_nsa(
-        q=q, k=k, v=v,
+        q=q,
+        k=k,
+        v=v,
         block_indices=block_indices,
         block_counts=S,
         block_size=block_size,
@@ -198,9 +218,11 @@ def test_parallel(
 
 @pytest.mark.parallel_nsa
 @pytest.mark.parametrize(
-    ('H', 'HQ', 'D', 'S', 'block_size', 'cu_seqlens', 'dtype'),
+    ("H", "HQ", "D", "S", "block_size", "cu_seqlens", "dtype"),
     [
-        pytest.param(*test, id="H{}-HQ{}-D{}-S{}-block_size{}-cu_seqlens{}-{}".format(*test))
+        pytest.param(
+            *test, id="H{}-HQ{}-D{}-S{}-block_size{}-cu_seqlens{}-{}".format(*test)
+        )
         for test in [
             (1, 16, 64, 16, 32, [0, 15], torch.float16),
             (2, 32, 64, 16, 32, [0, 256, 500, 1000], torch.float16),
@@ -219,7 +241,7 @@ def test_parallel_varlen(
 ):
     """Compare FlagGems-vllm parallel_nsa with naive reference for variable-length sequences."""
     torch.manual_seed(42)
-    os.environ['TRITON_F32_DEFAULT'] = 'ieee'
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
 
     device = flaggems_vllm.device
 
@@ -238,7 +260,7 @@ def test_parallel_varlen(
         _, t = seq_indices[i]
         for h in range(H):
             i_i = torch.randperm(max(1, triton.cdiv(t, block_size)))[:S]
-            block_indices[0, i, h, :len(i_i)] = i_i
+            block_indices[0, i, h, : len(i_i)] = i_i
     block_indices = block_indices.sort(-1)[0]
 
     ref = naive_nsa(
@@ -268,7 +290,7 @@ def test_parallel_varlen(
     tri_dk, k.grad = k.grad.clone(), None
     tri_dv, v.grad = v.grad.clone(), None
 
-    assert_close('o', ref, tri, 0.004)
-    assert_close('dq', ref_dq, tri_dq, 0.005)
-    assert_close('dk', ref_dk, tri_dk, 0.005)
-    assert_close('dv', ref_dv, tri_dv, 0.005)
+    assert_close("o", ref, tri, 0.004)
+    assert_close("dq", ref_dq, tri_dq, 0.005)
+    assert_close("dk", ref_dk, tri_dk, 0.005)
+    assert_close("dv", ref_dv, tri_dv, 0.005)

--- a/tests/test_parallel_nsa.py
+++ b/tests/test_parallel_nsa.py
@@ -1,0 +1,274 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+
+import pytest
+import torch
+import triton
+from einops import repeat
+
+import flaggems_vllm
+from flaggems_vllm.ops.FLA.index import prepare_token_indices
+
+logger = logging.getLogger(__name__)
+
+
+# ===========================================================================
+# Naive reference implementation (from flash-linear-attention)
+# ===========================================================================
+
+
+def naive_nsa(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    block_indices: torch.LongTensor,
+    block_size: int = 64,
+    scale: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    **kwargs,
+) -> torch.Tensor:
+    r"""
+    Naive PyTorch reference for NSA selected-sparse attention.
+
+    Args:
+        q: queries of shape ``[B, T, HQ, K]``.
+        k: keys of shape ``[B, T, H, K]``.
+        v: values of shape ``[B, T, H, V]``.
+        block_indices: block indices of shape ``[B, T, H, S]``.
+        block_size: selected block size. Default: 64.
+        scale: scale factor. If None, defaults to ``K ** -0.5``.
+        cu_seqlens: cumulative sequence lengths for variable-length sequences.
+
+    Returns:
+        o: outputs of shape ``[B, T, HQ, V]``.
+    """
+    if 'head_first' in kwargs:
+        raise DeprecationWarning("head_first has been removed.")
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    dtype = q.dtype
+    G = q.shape[2] // k.shape[2]
+    BS = block_size
+    k, v, block_indices = (repeat(x, 'b t h d -> b t (h g) d', g=G) for x in (k, v, block_indices))
+    q, k, v = map(lambda x: x.float(), (q, k, v))
+
+    o = torch.zeros_like(v)
+    varlen = True
+    if cu_seqlens is None:
+        varlen = False
+        B, T = q.shape[:2]
+        cu_seqlens = torch.cat([
+            block_indices.new_tensor(range(0, B * T, T)), block_indices.new_tensor([B * T]),
+        ])
+
+    for i in range(len(cu_seqlens) - 1):
+        if not varlen:
+            q_b, k_b, v_b, i_b = q[i], k[i], v[i], block_indices[i]
+        else:
+            T = cu_seqlens[i + 1] - cu_seqlens[i]
+            q_b, k_b, v_b, i_b = map(lambda x: x[0][cu_seqlens[i]:cu_seqlens[i + 1]], (q, k, v, block_indices))
+
+        i_b = i_b.unsqueeze(-1) * BS + i_b.new_tensor(range(BS))
+        i_b = i_b.view(T, block_indices.shape[2], -1).transpose(1, 2)
+        for i_q in range(T):
+            q_i = q_b[i_q] * scale
+            i_i = i_b[i_q]
+            k_i, v_i = map(
+                lambda x: x.gather(0, i_i.clamp(0, T - 1).unsqueeze(-1).expand(*i_i.shape, x.shape[-1])),
+                (k_b, v_b),
+            )
+            attn = torch.einsum('h d, n h d -> n h', q_i, k_i).masked_fill(i_i > i_q, float('-inf')).softmax(0)
+            if not varlen:
+                o[i, i_q] = torch.einsum('n h, n h v -> h v', attn, v_i)
+            else:
+                o[0][cu_seqlens[i] + i_q] = torch.einsum('n h, n h v -> h v', attn, v_i)
+
+    return o.to(dtype)
+
+
+# ===========================================================================
+# Testing utilities (from fla.utils._testing)
+# ===========================================================================
+
+
+def get_abs_err(x, y):
+    return (x.detach() - y.detach()).flatten().abs().max().item()
+
+
+def get_err_ratio(x, y):
+    err = (x.detach() - y.detach()).flatten().square().mean().sqrt().item()
+    base = (x.detach()).flatten().square().mean().sqrt().item()
+    return err / (base + 1e-8)
+
+
+def assert_close(prefix, ref, tri, ratio, warning=False, err_atol=1e-6):
+    abs_atol = get_abs_err(ref, tri)
+    error_rate = get_err_ratio(ref, tri)
+    msg = f"{prefix:>16} diff: {abs_atol:.6f} ratio: {error_rate:.6f}"
+    logger.info(msg)
+    if abs_atol <= err_atol:
+        return
+    assert not torch.isnan(ref).any(), f"{prefix}: NaN detected in ref"
+    assert not torch.isnan(tri).any(), f"{prefix}: NaN detected in tri"
+    if warning:
+        if error_rate > ratio:
+            logger.warning(msg)
+    else:
+        assert error_rate < ratio, msg
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+@pytest.mark.parallel_nsa
+@pytest.mark.parametrize(
+    ('B', 'T', 'H', 'HQ', 'D', 'S', 'block_size', 'scale', 'dtype'),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-HQ{}-D{}-S{}-block_size{}-scale{}-{}".format(*test))
+        for test in [
+            (1, 63, 1, 16, 64, 16, 32, 1.0, torch.float16),
+            (3, 111, 1, 32, 100, 16, 32, 1.0, torch.float16),
+            (3, 1024, 2, 32, 60, 16, 32, 0.1, torch.float16),
+            (3, 1024, 2, 32, 128, 16, 32, 0.1, torch.float16),
+            (4, 2048, 2, 32, 64, 16, 32, 0.1, torch.float16),
+        ]
+    ],
+)
+def test_parallel(
+    B: int,
+    T: int,
+    H: int,
+    HQ: int,
+    D: int,
+    S: int,
+    block_size: int,
+    scale: float,
+    dtype: torch.dtype,
+):
+    """Compare FlagGems-vllm parallel_nsa with the naive reference (forward + backward)."""
+    torch.manual_seed(42)
+    os.environ['TRITON_F32_DEFAULT'] = 'ieee'
+
+    device = flaggems_vllm.device
+
+    q = torch.randn((B, T, HQ, D), dtype=dtype, device=device).requires_grad_(True)
+    k = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+    v = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+    do = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
+
+    block_indices = torch.full((B, T, H, S), T, dtype=torch.long, device=device)
+    for b in range(B):
+        for t in range(T):
+            for h in range(H):
+                i_i = torch.randperm(max(1, triton.cdiv(t, block_size)))[:S]
+                block_indices[b, t, h, :len(i_i)] = i_i
+    block_indices = block_indices.sort(-1)[0]
+
+    ref = naive_nsa(q=q, k=k, v=v, block_indices=block_indices, block_size=block_size, scale=scale)
+    ref.backward(do)
+    ref_dq, q.grad = q.grad.clone(), None
+    ref_dk, k.grad = k.grad.clone(), None
+    ref_dv, v.grad = v.grad.clone(), None
+
+    tri = flaggems_vllm.parallel_nsa(
+        q=q, k=k, v=v,
+        block_indices=block_indices,
+        block_counts=S,
+        block_size=block_size,
+        scale=scale,
+    )
+    tri.backward(do)
+    tri_dq, q.grad = q.grad.clone(), None
+    tri_dk, k.grad = k.grad.clone(), None
+    tri_dv, v.grad = v.grad.clone(), None
+
+    assert_close(" o", ref, tri, 0.005)
+    assert_close("dq", ref_dq, tri_dq, 0.005)
+    assert_close("dk", ref_dk, tri_dk, 0.005)
+    assert_close("dv", ref_dv, tri_dv, 0.005)
+
+
+@pytest.mark.parallel_nsa
+@pytest.mark.parametrize(
+    ('H', 'HQ', 'D', 'S', 'block_size', 'cu_seqlens', 'dtype'),
+    [
+        pytest.param(*test, id="H{}-HQ{}-D{}-S{}-block_size{}-cu_seqlens{}-{}".format(*test))
+        for test in [
+            (1, 16, 64, 16, 32, [0, 15], torch.float16),
+            (2, 32, 64, 16, 32, [0, 256, 500, 1000], torch.float16),
+            (2, 32, 100, 16, 32, [0, 15, 100, 300, 1200, 2000], torch.float16),
+        ]
+    ],
+)
+def test_parallel_varlen(
+    H: int,
+    HQ: int,
+    D: int,
+    S: int,
+    block_size: int,
+    cu_seqlens: list[int],
+    dtype: torch.dtype,
+):
+    """Compare FlagGems-vllm parallel_nsa with naive reference for variable-length sequences."""
+    torch.manual_seed(42)
+    os.environ['TRITON_F32_DEFAULT'] = 'ieee'
+
+    device = flaggems_vllm.device
+
+    T = cu_seqlens[-1]
+    cu_seqlens_t = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+
+    q = torch.randn((1, T, HQ, D), dtype=dtype, device=device).requires_grad_()
+    k = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    v = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    do = torch.randn((1, T, HQ, D), dtype=dtype, device=device)
+
+    block_indices = torch.full((1, T, H, S), T, dtype=torch.long, device=device)
+    seq_indices = prepare_token_indices(cu_seqlens_t).tolist()
+
+    for i in range(T):
+        _, t = seq_indices[i]
+        for h in range(H):
+            i_i = torch.randperm(max(1, triton.cdiv(t, block_size)))[:S]
+            block_indices[0, i, h, :len(i_i)] = i_i
+    block_indices = block_indices.sort(-1)[0]
+
+    ref = naive_nsa(
+        q=q,
+        k=k,
+        v=v,
+        block_indices=block_indices,
+        block_size=block_size,
+        cu_seqlens=cu_seqlens_t,
+    )
+    ref.backward(do)
+    ref_dq, q.grad = q.grad.clone(), None
+    ref_dk, k.grad = k.grad.clone(), None
+    ref_dv, v.grad = v.grad.clone(), None
+
+    tri = flaggems_vllm.parallel_nsa(
+        q=q,
+        k=k,
+        v=v,
+        block_indices=block_indices,
+        block_counts=S,
+        block_size=block_size,
+        cu_seqlens=cu_seqlens_t,
+    )
+    tri.backward(do)
+    tri_dq, q.grad = q.grad.clone(), None
+    tri_dk, k.grad = k.grad.clone(), None
+    tri_dv, v.grad = v.grad.clone(), None
+
+    assert_close('o', ref, tri, 0.004)
+    assert_close('dq', ref_dq, tri_dq, 0.005)
+    assert_close('dk', ref_dk, tri_dk, 0.005)
+    assert_close('dv', ref_dv, tri_dv, 0.005)


### PR DESCRIPTION
### PR Category
Operator | OP Test  Benchmark

### Type of Change
New Feature | Performance Optimization 

### Description
Add parallel_nsa op with tests and benchmark
* Triton kernels: top-k selection, forward (with TLE async load variant), backward (dQ/dKV), and block mask
* Supporting ops: mean_pooling, bitonic sort utilities
* Public API: parallel_nsa() with gated compression/selection/sliding-window attention fusion
* Functional tests (forward/backward accuracy vs naive PyTorch reference, variable-length support)
* Performance benchmarks (7 representative shapes from the FLA registry)

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<img width="1267" height="496" alt="image" src="https://github.com/user-attachments/assets/43aaffe6-9190-42d2-8977-2efc6b152591" />
