### PR TITLE
ci: check FlagTree TLE support in setup

### DIFF
--- a/tools/select_tests.py
+++ b/tools/select_tests.py
@@ -29,6 +29,7 @@ ENV_SMOKE_TRIGGER_FILES = {
 ENV_SMOKE_TESTS = [
     "tests/test_add_rms_norm.py",
     "tests/test_bincount.py",
+    "tests/test_flash_mla.py",
     "tests/test_silu_and_mul.py",
 ]
 

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -18,7 +18,7 @@ VLLM_VERSION="${VLLM_VERSION:-0.20.2}"
 TORCH_BACKEND="${TORCH_BACKEND:-auto}"
 
 FLAGOS_PYPI="${FLAGOS_PYPI:-https://resource.flagos.net/repository/flagos-pypi-hosted/simple}"
-FLAGTREE_VERSION="${FLAGTREE_VERSION:-0.6.0rc1}"
+FLAGTREE_VERSION="${FLAGTREE_VERSION:-0.6.0}"
 
 # Whether to replace Triton with FlagTree.
 # For temporary container validation, you can run:
@@ -201,28 +201,40 @@ print(" vllm:", vllm.__version__)
 PY
 ok
 
+# ── Install FlagGems-vllm before Triton replacement ──────────
+printf "Installing FlagGems-vllm editable ..."
+uv pip install -q \
+  --no-build-isolation \
+  -e ".[test]" \
+  --constraint "${CONSTRAINTS_FILE}" \
+  --default-index "${MIRROR}" \
+  || fail
+ok
+
 # ── Remove Triton and install FlagTree ───────────────────────
 if [ "${USE_FLAGTREE}" = "1" ]; then
   printf "Removing Triton packages ..."
-  TRITON_PKGS="$(uv pip list 2>/dev/null | awk 'tolower($1) ~ /^triton/ {print $1}' || true)"
-
-  if [ -n "${TRITON_PKGS}" ]; then
-    echo "${TRITON_PKGS}" | xargs -r uv pip uninstall -q || true
-  fi
+  TRITON_UNINSTALL_ATTEMPTS=0
+  while python -m pip show triton >/dev/null 2>&1; do
+    python -m pip uninstall -y triton >/dev/null || fail
+    TRITON_UNINSTALL_ATTEMPTS=$((TRITON_UNINSTALL_ATTEMPTS + 1))
+    if [ "${TRITON_UNINSTALL_ATTEMPTS}" -ge 10 ]; then
+      fail
+    fi
+  done
   ok
 
   printf "Installing FlagTree==${FLAGTREE_VERSION} ..."
-  uv pip install -q \
+  python -m pip install -q \
     "flagtree===${FLAGTREE_VERSION}" \
-    --index "${FLAGOS_PYPI}" \
-    --default-index "${MIRROR}" \
+    --index-url "${FLAGOS_PYPI}" \
     || fail
   ok
 
   # Do not force `import triton` by default here.
   # Some FlagTree wheels may try to load vendor plugins during import.
   printf "Checking FlagTree package ..."
-  uv pip show flagtree >/tmp/flagtree_show.log || fail
+  python -m pip show flagtree >/tmp/flagtree_show.log || fail
   cat /tmp/flagtree_show.log
   ok
 
@@ -240,16 +252,6 @@ PY
 else
   warn "Skipping FlagTree installation; keeping Triton installed by vLLM/PyTorch"
 fi
-
-# ── Install FlagGems-vllm ────────────────────────────────────
-printf "Installing FlagGems-vllm editable ..."
-uv pip install -q \
-  --no-build-isolation \
-  -e ".[test]" \
-  --constraint "${CONSTRAINTS_FILE}" \
-  --default-index "${MIRROR}" \
-  || fail
-ok
 
 # ── Verify installation ──────────────────────────────────────
 printf "Verifying imports ..."

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -266,6 +266,30 @@ print(" flaggems_vllm device:", getattr(flaggems_vllm, "device", "unknown"))
 PY
 ok
 
+if [ "${USE_FLAGTREE}" = "1" ]; then
+  printf "Checking FlagTree TLE support ..."
+  python - <<'PY' || fail
+from flaggems_vllm.utils.triton_version_utils import has_triton_tle
+
+if has_triton_tle(3, 6, 0):
+    try:
+        import triton.experimental.tle.language as tle  # noqa: F401
+
+        HAS_TLE_FLASH_MLA = True
+    except ImportError:
+        tle = None
+        HAS_TLE_FLASH_MLA = False
+else:
+    tle = None
+    HAS_TLE_FLASH_MLA = False
+
+print(" HAS_TLE_FLASH_MLA:", HAS_TLE_FLASH_MLA)
+if not HAS_TLE_FLASH_MLA:
+    raise SystemExit("FlagTree TLE support is unavailable")
+PY
+  ok
+fi
+
 # ── Optional Triton import check ─────────────────────────────
 if [ "${STRICT_TRITON_IMPORT}" = "1" ]; then
   printf "Strictly verifying Triton import ..."


### PR DESCRIPTION
### PR Category
CI/CD

### Type of Change
New Feature

### Description
This PR adds a setup-time validation for FlagTree TLE support.

Changes include:
- Check FlagTree/TLE availability after installing `flaggems_vllm` in `tools/setup.sh`.
- Use `flaggems_vllm.utils.triton_version_utils.has_triton_tle(3, 6, 0)` to match the runtime feature check used by FlagGems-vllm.
- Fail setup early if `triton.experimental.tle.language` is unavailable when FlagTree is enabled.

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
N/A. This is a CI/setup validation change and does not affect runtime performance.