### PR TITLE
Optimize GDN recompute_w_u with TLE

### DIFF
--- a/benchmark/core_shapes.yaml
+++ b/benchmark/core_shapes.yaml
@@ -457,3 +457,10 @@ ReshapeAndCacheFlashBenchmark:
     - [21, 4, 80, 16, 10000]
     - [42, 8, 64, 8, 1024]
     - [42, 8, 80, 16, 10000]
+
+chunk_gated_delta_rule_fwd:
+  shapes:
+    - [2, 16384, 16, 128, 128]
+    - [4, 2048, 16, 128, 128]
+    - [4, 4096, 64, 128, 128]
+  shape_desc: "B, T, H, K, V"

--- a/benchmark/test_FLA/test_chunk_gated_delta_rule_fwd.py
+++ b/benchmark/test_FLA/test_chunk_gated_delta_rule_fwd.py
@@ -4,6 +4,7 @@ import torch.nn.functional as F
 
 import flaggems_vllm
 from benchmark.base import Benchmark
+from flaggems_vllm.utils.triton_version_utils import has_triton_tle
 
 
 class ChunkGatedDeltaRuleFwdBenchmark(Benchmark):
@@ -56,6 +57,7 @@ class ChunkGatedDeltaRuleFwdBenchmark(Benchmark):
 
 @pytest.mark.chunk_gated_delta_rule_fwd
 @pytest.mark.xfail(
+    not has_triton_tle(3, 6, 0),
     reason="Triton 3.6.0 compilation error on Hopper: 'ttng.warp_group_dot' op pipeliner issue"
 )
 def test_perf_chunk_gated_delta_rule_fwd():

--- a/benchmark/test_FLA/test_chunk_gated_delta_rule_fwd.py
+++ b/benchmark/test_FLA/test_chunk_gated_delta_rule_fwd.py
@@ -1,46 +1,82 @@
+import os
+from contextlib import contextmanager
+
 import pytest
 import torch
-import torch.nn.functional as F
 
 import flaggems_vllm
 from benchmark.base import Benchmark
 from flaggems_vllm.utils.triton_version_utils import has_triton_tle
 
 
+RECOMPUTE_TLE_ENV = "FLAGGEMS_CHUNK_GDR_RECOMPUTE_TLE"
+FULL_TLE_ENV = "FLAGGEMS_CHUNK_GATED_DELTA_RULE_TLE"
+
+
+@contextmanager
+def _set_gdn_tle(*, full_tle: bool, recompute_tle: bool):
+    old_full = os.environ.get(FULL_TLE_ENV)
+    old_recompute = os.environ.get(RECOMPUTE_TLE_ENV)
+    os.environ[FULL_TLE_ENV] = "1" if full_tle else "0"
+    os.environ[RECOMPUTE_TLE_ENV] = "1" if recompute_tle else "0"
+    try:
+        yield
+    finally:
+        if old_full is None:
+            os.environ.pop(FULL_TLE_ENV, None)
+        else:
+            os.environ[FULL_TLE_ENV] = old_full
+        if old_recompute is None:
+            os.environ.pop(RECOMPUTE_TLE_ENV, None)
+        else:
+            os.environ[RECOMPUTE_TLE_ENV] = old_recompute
+
+
+def _gdn_fwd_with_tle(full_tle: bool, recompute_tle: bool, *args):
+    with _set_gdn_tle(full_tle=full_tle, recompute_tle=recompute_tle):
+        return flaggems_vllm.chunk_gated_delta_rule_fwd(*args)
+
+
+def _native_gdn_fwd(*args):
+    return _gdn_fwd_with_tle(False, False, *args)
+
+
+def _optimized_gdn_fwd(*args):
+    return _gdn_fwd_with_tle(True, True, *args)
+
+
 class ChunkGatedDeltaRuleFwdBenchmark(Benchmark):
     DEFAULT_DTYPES = [torch.bfloat16, torch.float16]
-    DEFAULT_SHAPES = [(64,), (128,), (256,), (512,), (1024,)]
-    DEFAULT_SHAPE_DESC = "T"
+    DEFAULT_METRICS = ["latency_base", "latency", "speedup"]
+    DEFAULT_SHAPES = [
+        (2, 16384, 16, 128, 128),
+        (4, 2048, 16, 128, 128),
+        (4, 4096, 64, 128, 128),
+    ]
+    DEFAULT_SHAPE_DESC = "B, T, H, K, V"
 
     def set_more_shapes(self):
-        return [
-            (64,),
-            (128,),
-            (256,),
-            (512,),
-            (1024,),
-        ]
+        return self.DEFAULT_SHAPES
 
     def set_shapes(self, shape_file_path=None):
         self.shapes = self.DEFAULT_SHAPES
         self.shape_desc = self.DEFAULT_SHAPE_DESC
 
     def get_input_iter(self, cur_dtype):
-        for shape in self.shapes:
-            T = shape[0]
-            yield self._build_inputs(T, cur_dtype)
+        for B, T, H, K, V in self.shapes:
+            yield self._build_inputs(B, T, H, K, V, cur_dtype)
 
-    def _build_inputs(self, T: int, dtype: torch.dtype):
+    def _build_inputs(self, B: int, T: int, H: int, K: int, V: int, dtype: torch.dtype):
         device = flaggems_vllm.device
-        B, H, K, V = 1, 4, 64, 64
 
-        q = torch.randn(B, T, H, K, device=device, dtype=dtype)
-        k = torch.randn(B, T, H, K, device=device, dtype=dtype)
+        q = torch.randn(B, T, H, K, device=device, dtype=dtype) / (K**0.5)
+        k = torch.randn(B, T, H, K, device=device, dtype=dtype) / (K**0.5)
         v = torch.randn(B, T, H, V, device=device, dtype=dtype)
-        g = F.logsigmoid(torch.randn(B, T, H, device=device, dtype=dtype))
+        g = (-torch.rand(B, T, H, device=device, dtype=torch.float32) * 0.1).to(
+            dtype
+        )
         beta = torch.rand(B, T, H, device=device, dtype=dtype).sigmoid()
         scale = K**-0.5
-        initial_state = torch.zeros(B, H, K, V, device=device, dtype=dtype)
 
         return (
             q,
@@ -49,7 +85,7 @@ class ChunkGatedDeltaRuleFwdBenchmark(Benchmark):
             g,
             beta,
             scale,
-            initial_state,
+            None,
             True,
             None,
         )
@@ -63,7 +99,7 @@ class ChunkGatedDeltaRuleFwdBenchmark(Benchmark):
 def test_perf_chunk_gated_delta_rule_fwd():
     bench = ChunkGatedDeltaRuleFwdBenchmark(
         op_name="chunk_gated_delta_rule_fwd",
-        torch_op=flaggems_vllm.chunk_gated_delta_rule_fwd,
+        torch_op=_native_gdn_fwd,
     )
-    bench.set_gems(flaggems_vllm.chunk_gated_delta_rule_fwd)
+    bench.set_gems(_optimized_gdn_fwd)
     bench.run()

--- a/benchmark/test_FLA/test_chunk_gated_delta_rule_fwd.py
+++ b/benchmark/test_FLA/test_chunk_gated_delta_rule_fwd.py
@@ -8,7 +8,6 @@ import flaggems_vllm
 from benchmark.base import Benchmark
 from flaggems_vllm.utils.triton_version_utils import has_triton_tle
 
-
 RECOMPUTE_TLE_ENV = "FLAGGEMS_CHUNK_GDR_RECOMPUTE_TLE"
 FULL_TLE_ENV = "FLAGGEMS_CHUNK_GATED_DELTA_RULE_TLE"
 
@@ -72,9 +71,7 @@ class ChunkGatedDeltaRuleFwdBenchmark(Benchmark):
         q = torch.randn(B, T, H, K, device=device, dtype=dtype) / (K**0.5)
         k = torch.randn(B, T, H, K, device=device, dtype=dtype) / (K**0.5)
         v = torch.randn(B, T, H, V, device=device, dtype=dtype)
-        g = (-torch.rand(B, T, H, device=device, dtype=torch.float32) * 0.1).to(
-            dtype
-        )
+        g = (-torch.rand(B, T, H, device=device, dtype=torch.float32) * 0.1).to(dtype)
         beta = torch.rand(B, T, H, device=device, dtype=dtype).sigmoid()
         scale = K**-0.5
 
@@ -94,7 +91,7 @@ class ChunkGatedDeltaRuleFwdBenchmark(Benchmark):
 @pytest.mark.chunk_gated_delta_rule_fwd
 @pytest.mark.xfail(
     not has_triton_tle(3, 6, 0),
-    reason="Triton 3.6.0 compilation error on Hopper: 'ttng.warp_group_dot' op pipeliner issue"
+    reason="Triton 3.6.0 compilation error on Hopper: 'ttng.warp_group_dot' op pipeliner issue",
 )
 def test_perf_chunk_gated_delta_rule_fwd():
     bench = ChunkGatedDeltaRuleFwdBenchmark(

--- a/src/flaggems_vllm/ops/FLA/chunk.py
+++ b/src/flaggems_vllm/ops/FLA/chunk.py
@@ -78,6 +78,53 @@ def chunk_gated_delta_rule_fwd(
     chunk_size = _chunk_size_for_sequence(q.shape[1], cu_seqlens is not None)
     maybe_set_tle_recompute_allocator(q.device, cu_seqlens)
 
+    if initial_state is None and output_final_state:
+        try:
+            from flaggems_vllm.ops.chunk_gated_delta_rule import (
+                _can_use_tle_chunk_gated_delta_rule,
+                _tle_chunk_gated_delta_rule_fwd,
+            )
+
+            if _can_use_tle_chunk_gated_delta_rule(
+                q=q,
+                k=k,
+                v=v,
+                beta=beta,
+                g=g,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+                cu_seqlens=cu_seqlens,
+            ):
+                g_tle, A_tle = chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
+                    g=g,
+                    k=k,
+                    beta=beta,
+                    cu_seqlens=cu_seqlens,
+                    chunk_size=chunk_size,
+                    output_dtype=k.dtype,
+                    use_g_in_kkt=False,
+                )
+                o, final_state = _tle_chunk_gated_delta_rule_fwd(
+                    q=q,
+                    k=k,
+                    v=v,
+                    g_cumsum=g_tle,
+                    beta=beta,
+                    a=A_tle,
+                    scale=float(scale),
+                )
+                g, A = chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
+                    g=g,
+                    k=k,
+                    beta=beta,
+                    cu_seqlens=cu_seqlens,
+                    chunk_size=chunk_size,
+                    output_dtype=k.dtype,
+                )
+                return g, o, A, final_state, None, None, None
+        except ImportError:
+            pass
+
     g, A = chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
         g=g,
         k=k,

--- a/src/flaggems_vllm/ops/FLA/chunk.py
+++ b/src/flaggems_vllm/ops/FLA/chunk.py
@@ -18,7 +18,10 @@ from flaggems_vllm.ops.FLA.fused_cumsum_kkt_solve_tril import (
     chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril,
 )
 from flaggems_vllm.ops.FLA.utils import SUPPRESS_LEVEL
-from flaggems_vllm.ops.FLA.wy_fast import recompute_w_u_fwd
+from flaggems_vllm.ops.FLA.wy_fast import (
+    maybe_set_tle_recompute_allocator,
+    recompute_w_u_fwd,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +76,7 @@ def chunk_gated_delta_rule_fwd(
             cu_seqlens = cu_seqlens.contiguous()
 
     chunk_size = _chunk_size_for_sequence(q.shape[1], cu_seqlens is not None)
+    maybe_set_tle_recompute_allocator(q.device, cu_seqlens)
 
     g, A = chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
         g=g,
@@ -82,6 +86,8 @@ def chunk_gated_delta_rule_fwd(
         chunk_size=chunk_size,
         output_dtype=k.dtype,
     )
+    block_v = 128 if v.shape[-1] == 128 else 64
+    pipe_stages = 5 if v.shape[-1] >= 256 else (3 if v.shape[-1] == 128 else 2)
     w, u = recompute_w_u_fwd(
         k=k,
         v=v,
@@ -89,6 +95,8 @@ def chunk_gated_delta_rule_fwd(
         A=A,
         g_cumsum=g,
         cu_seqlens=cu_seqlens,
+        block_v=block_v,
+        pipe_stages=pipe_stages,
     )
     if SUPPRESS_LEVEL < 3 and can_use_fused_tail_vblock(
         q=q,

--- a/src/flaggems_vllm/ops/FLA/wy_fast.py
+++ b/src/flaggems_vllm/ops/FLA/wy_fast.py
@@ -5,12 +5,50 @@
 
 # ruff: noqa: E501
 
+import os
+
 import torch
 import triton
 import triton.language as tl
 
 from flaggems_vllm.ops.FLA.index import prepare_chunk_indices
 from flaggems_vllm.utils import libentry, libtuner
+from flaggems_vllm.utils.triton_version_utils import has_triton_tle
+
+if has_triton_tle(3, 6, 0):
+    try:
+        import triton.experimental.tle.language as tle
+
+        HAS_TLE_RECOMPUTE_W_U = True
+    except ImportError:
+        tle = None
+        HAS_TLE_RECOMPUTE_W_U = False
+else:
+    tle = None
+    HAS_TLE_RECOMPUTE_W_U = False
+
+
+def _use_tle_recompute_w_u(cu_seqlens: torch.Tensor | None) -> bool:
+    value = os.environ.get("FLAGGEMS_CHUNK_GDR_RECOMPUTE_TLE", "1").lower()
+    return (
+        HAS_TLE_RECOMPUTE_W_U
+        and cu_seqlens is None
+        and value not in {"0", "false", "off", "no"}
+    )
+
+
+def maybe_set_tle_recompute_allocator(
+    device: torch.device, cu_seqlens: torch.Tensor | None
+) -> None:
+    if not (HAS_TLE_RECOMPUTE_W_U and cu_seqlens is None):
+        return
+
+    def alloc_fn(size: int, align: int, stream):
+        _ = align
+        _ = stream
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
 
 
 @libentry()
@@ -119,6 +157,103 @@ def recompute_w_u_fwd_kernel(
         tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
 
 
+if HAS_TLE_RECOMPUTE_W_U:
+
+    @libentry()
+    @libtuner(
+        configs=[
+            triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+            for num_warps in [2, 4]
+            for num_stages in [2, 3]
+        ],
+        key=["H", "K", "V", "BT", "BK", "BV", "PIPE_STAGES"],
+    )
+    @triton.jit(do_not_specialize=["T"])
+    def recompute_w_u_fwd_tle_kernel(
+        k,
+        v,
+        beta,
+        w,
+        u,
+        A,
+        g,
+        T,
+        H: tl.constexpr,
+        Hg: tl.constexpr,
+        K: tl.constexpr,
+        V: tl.constexpr,
+        BT: tl.constexpr,
+        BK: tl.constexpr,
+        BV: tl.constexpr,
+        PIPE_STAGES: tl.constexpr,
+    ):
+        i_t, i_bh = tl.program_id(0), tl.program_id(1)
+        i_b, i_h = i_bh // H, i_bh % H
+        bos = i_b * T
+
+        p_beta = tl.make_block_ptr(
+            beta + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+        )
+        p_g = tl.make_block_ptr(
+            g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+        )
+        p_A = tl.make_block_ptr(
+            A + (bos * H + i_h) * BT,
+            (T, BT),
+            (H * BT, 1),
+            (i_t * BT, 0),
+            (BT, BT),
+            (1, 0),
+        )
+        b_beta = tl.load(p_beta, boundary_check=(0,))
+        b_A = tl.load(p_A, boundary_check=(0, 1))
+        b_g = tl.exp(tl.load(p_g, boundary_check=(0,)).to(tl.float32))
+
+        for i_v in tl.range(0, tl.cdiv(V, BV), 1, num_stages=PIPE_STAGES):
+            p_v = tl.make_block_ptr(
+                v + (bos * H + i_h) * V,
+                (T, V),
+                (H * V, 1),
+                (i_t * BT, i_v * BV),
+                (BT, BV),
+                (1, 0),
+            )
+            p_u = tl.make_block_ptr(
+                u + (bos * H + i_h) * V,
+                (T, V),
+                (H * V, 1),
+                (i_t * BT, i_v * BV),
+                (BT, BV),
+                (1, 0),
+            )
+            b_v = tle.load(p_v, boundary_check=(0, 1), is_async=True)
+            b_vb = (b_v * b_beta[:, None]).to(b_v.dtype)
+            b_u = tl.dot(b_A, b_vb, allow_tf32=False)
+            tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
+
+        for i_k in tl.range(0, tl.cdiv(K, BK), 1, num_stages=PIPE_STAGES):
+            p_k = tl.make_block_ptr(
+                k + (bos * Hg + i_h // (H // Hg)) * K,
+                (T, K),
+                (Hg * K, 1),
+                (i_t * BT, i_k * BK),
+                (BT, BK),
+                (1, 0),
+            )
+            p_w = tl.make_block_ptr(
+                w + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT, i_k * BK),
+                (BT, BK),
+                (1, 0),
+            )
+            b_k = tle.load(p_k, boundary_check=(0, 1), is_async=True)
+            b_kb = (b_k * b_beta[:, None] * b_g[:, None]).to(b_k.dtype)
+            b_w = tl.dot(b_A, b_kb)
+            tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+
+
 def recompute_w_u_fwd(
     k: torch.Tensor,
     v: torch.Tensor,
@@ -126,6 +261,8 @@ def recompute_w_u_fwd(
     g_cumsum: torch.Tensor,
     A: torch.Tensor,
     cu_seqlens: torch.LongTensor | None,
+    block_v: int | None = None,
+    pipe_stages: int = 2,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, Hg, K, V = *k.shape, v.shape[-1]
     H = v.shape[-2]
@@ -136,9 +273,30 @@ def recompute_w_u_fwd(
     )
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     BK = 64
-    BV = 64
+    BV = block_v or 64
     u = torch.empty_like(v)
     w = k.new_empty(B, T, H, K)
+    if _use_tle_recompute_w_u(cu_seqlens):
+        recompute_w_u_fwd_tle_kernel[(NT, B * H)](
+            k=k,
+            v=v,
+            beta=beta,
+            w=w,
+            u=u,
+            A=A,
+            g=g_cumsum,
+            T=T,
+            H=H,
+            Hg=Hg,
+            K=K,
+            V=V,
+            BT=BT,
+            BK=BK,
+            BV=BV,
+            PIPE_STAGES=pipe_stages,
+        )
+        return w, u
+
     # Varlen kernels get the sequence from chunk_indices; i_b is unused in the
     # IS_VARLEN path, so H programs cover every chunk/head exactly once even
     # when the packed storage has B > 1.

--- a/src/flaggems_vllm/ops/FLA/wy_fast.py
+++ b/src/flaggems_vllm/ops/FLA/wy_fast.py
@@ -194,9 +194,7 @@ if HAS_TLE_RECOMPUTE_W_U:
         p_beta = tl.make_block_ptr(
             beta + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
         )
-        p_g = tl.make_block_ptr(
-            g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
-        )
+        p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
         p_A = tl.make_block_ptr(
             A + (bos * H + i_h) * BT,
             (T, BT),

--- a/tests/test_FLA/test_chunk_gated_delta_rule_fwd_recompute.py
+++ b/tests/test_FLA/test_chunk_gated_delta_rule_fwd_recompute.py
@@ -7,7 +7,6 @@ import torch
 import flaggems_vllm
 from flaggems_vllm.utils.triton_version_utils import has_triton_tle
 
-
 ASSERT_RATIO = 0.01
 RECOMPUTE_TLE_ENV = "FLAGGEMS_CHUNK_GDR_RECOMPUTE_TLE"
 FULL_TLE_ENV = "FLAGGEMS_CHUNK_GATED_DELTA_RULE_TLE"
@@ -95,13 +94,14 @@ def _assert_close(name: str, actual: torch.Tensor, expected: torch.Tensor) -> No
     assert not torch.isnan(expected).any(), f"{name}: NaN detected in baseline"
     ratio = _err_ratio(expected, actual)
     assert ratio < ASSERT_RATIO, (
-        f"{name} diff: abs={abs_err:.6f} ratio={ratio:.6f} "
-        f"limit={ASSERT_RATIO}"
+        f"{name} diff: abs={abs_err:.6f} ratio={ratio:.6f} " f"limit={ASSERT_RATIO}"
     )
 
 
 @pytest.mark.chunk_gated_delta_rule_fwd
-@pytest.mark.skipif(not _cuda_tle_available(), reason="GDN recompute TLE tests require CUDA/TLE")
+@pytest.mark.skipif(
+    not _cuda_tle_available(), reason="GDN recompute TLE tests require CUDA/TLE"
+)
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("shape", GDN_RECOMPUTE_TEST_SHAPES)
 @torch.inference_mode()
@@ -119,7 +119,9 @@ def test_chunk_gated_delta_rule_fwd_recompute_tle_matches_native(dtype, shape):
 
 
 @pytest.mark.chunk_gated_delta_rule_fwd
-@pytest.mark.skipif(not _cuda_tle_available(), reason="GDN fused TLE tests require CUDA/TLE")
+@pytest.mark.skipif(
+    not _cuda_tle_available(), reason="GDN fused TLE tests require CUDA/TLE"
+)
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("shape", GDN_FUSED_FWD_TEST_SHAPES)
 @torch.inference_mode()

--- a/tests/test_FLA/test_chunk_gated_delta_rule_fwd_recompute.py
+++ b/tests/test_FLA/test_chunk_gated_delta_rule_fwd_recompute.py
@@ -1,0 +1,136 @@
+import os
+from contextlib import contextmanager
+
+import pytest
+import torch
+
+import flaggems_vllm
+from flaggems_vllm.utils.triton_version_utils import has_triton_tle
+
+
+ASSERT_RATIO = 0.01
+RECOMPUTE_TLE_ENV = "FLAGGEMS_CHUNK_GDR_RECOMPUTE_TLE"
+FULL_TLE_ENV = "FLAGGEMS_CHUNK_GATED_DELTA_RULE_TLE"
+
+GDN_RECOMPUTE_TEST_SHAPES = [
+    (2, 16384, 16, 128, 128),
+    (4, 2048, 16, 128, 128),
+    (4, 4096, 64, 128, 128),
+    (8, 1024, 8, 64, 64),
+    (8, 2048, 32, 256, 256),
+]
+
+GDN_FUSED_FWD_TEST_SHAPES = [
+    (2, 16384, 16, 128, 128),
+    (4, 2048, 16, 128, 128),
+    (4, 4096, 64, 128, 128),
+]
+
+
+def _cuda_tle_available() -> bool:
+    return flaggems_vllm.device == "cuda" and has_triton_tle(3, 6, 0)
+
+
+@contextmanager
+def _set_gdn_tle(*, full_tle: bool, recompute_tle: bool):
+    old_full = os.environ.get(FULL_TLE_ENV)
+    old_recompute = os.environ.get(RECOMPUTE_TLE_ENV)
+    os.environ[FULL_TLE_ENV] = "1" if full_tle else "0"
+    os.environ[RECOMPUTE_TLE_ENV] = "1" if recompute_tle else "0"
+    try:
+        yield
+    finally:
+        if old_full is None:
+            os.environ.pop(FULL_TLE_ENV, None)
+        else:
+            os.environ[FULL_TLE_ENV] = old_full
+        if old_recompute is None:
+            os.environ.pop(RECOMPUTE_TLE_ENV, None)
+        else:
+            os.environ[RECOMPUTE_TLE_ENV] = old_recompute
+
+
+def _make_inputs(
+    B: int,
+    T: int,
+    H: int,
+    K: int,
+    V: int,
+    dtype: torch.dtype,
+    *,
+    use_initial_state: bool,
+):
+    device = flaggems_vllm.device
+    q = torch.randn(B, T, H, K, device=device, dtype=dtype) / (K**0.5)
+    k = torch.randn(B, T, H, K, device=device, dtype=dtype) / (K**0.5)
+    v = torch.randn(B, T, H, V, device=device, dtype=dtype)
+    g = (-torch.rand(B, T, H, device=device, dtype=torch.float32) * 0.1).to(dtype)
+    beta = torch.rand(B, T, H, device=device, dtype=dtype).sigmoid()
+    initial_state = (
+        torch.zeros(B, H, K, V, device=device, dtype=dtype)
+        if use_initial_state
+        else None
+    )
+    return q, k, v, g, beta, K**-0.5, initial_state, True, None
+
+
+def _call_fwd(args, *, full_tle: bool, recompute_tle: bool):
+    with _set_gdn_tle(full_tle=full_tle, recompute_tle=recompute_tle):
+        return flaggems_vllm.chunk_gated_delta_rule_fwd(*args)
+
+
+def _err_ratio(expected: torch.Tensor, actual: torch.Tensor) -> float:
+    err = (expected.float() - actual.float()).flatten().square().mean().sqrt().item()
+    base = expected.float().flatten().square().mean().sqrt().item()
+    return err / (base + 1e-8)
+
+
+def _assert_close(name: str, actual: torch.Tensor, expected: torch.Tensor) -> None:
+    actual = actual.float()
+    expected = expected.float()
+    abs_err = (actual - expected).abs().max().item()
+    if abs_err <= 1e-6:
+        return
+    assert not torch.isnan(actual).any(), f"{name}: NaN detected in actual"
+    assert not torch.isnan(expected).any(), f"{name}: NaN detected in baseline"
+    ratio = _err_ratio(expected, actual)
+    assert ratio < ASSERT_RATIO, (
+        f"{name} diff: abs={abs_err:.6f} ratio={ratio:.6f} "
+        f"limit={ASSERT_RATIO}"
+    )
+
+
+@pytest.mark.chunk_gated_delta_rule_fwd
+@pytest.mark.skipif(not _cuda_tle_available(), reason="GDN recompute TLE tests require CUDA/TLE")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("shape", GDN_RECOMPUTE_TEST_SHAPES)
+@torch.inference_mode()
+def test_chunk_gated_delta_rule_fwd_recompute_tle_matches_native(dtype, shape):
+    torch.manual_seed(42)
+    args = _make_inputs(*shape, dtype=dtype, use_initial_state=True)
+
+    baseline = _call_fwd(args, full_tle=False, recompute_tle=False)
+    actual = _call_fwd(args, full_tle=False, recompute_tle=True)
+
+    _assert_close("g", actual[0], baseline[0])
+    _assert_close("o", actual[1], baseline[1])
+    _assert_close("A", actual[2], baseline[2])
+    _assert_close("final_state", actual[3], baseline[3])
+
+
+@pytest.mark.chunk_gated_delta_rule_fwd
+@pytest.mark.skipif(not _cuda_tle_available(), reason="GDN fused TLE tests require CUDA/TLE")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("shape", GDN_FUSED_FWD_TEST_SHAPES)
+@torch.inference_mode()
+def test_chunk_gated_delta_rule_fwd_full_tle_matches_native(dtype, shape):
+    torch.manual_seed(42)
+    args = _make_inputs(*shape, dtype=dtype, use_initial_state=False)
+
+    baseline = _call_fwd(args, full_tle=False, recompute_tle=False)
+    actual = _call_fwd(args, full_tle=True, recompute_tle=True)
+
+    _assert_close("g", actual[0], baseline[0])
+    _assert_close("o", actual[1], baseline[1])
+    _assert_close("A", actual[2], baseline[2])
+    _assert_close("final_state", actual[3], baseline[3])


### PR DESCRIPTION
## Summary

This PR updates the GDN forward path by adding a guarded TLE fused-forward fast path to `chunk_gated_delta_rule_fwd`.

The benchmark has also been fixed to compare a real native baseline against the optimized path. The previous benchmark compared `chunk_gated_delta_rule_fwd` with itself, so it could not measure the optimization.

## Main Changes

- Add a TLE fused-forward fast path in `src/flaggems_vllm/ops/FLA/chunk.py`.
- Reuse the existing `_tle_chunk_gated_delta_rule_fwd` helper from the public GDN wrapper.
- Keep unsupported cases on the original fallback path.
- Preserve the raw `chunk_gated_delta_rule_fwd` return contract, including the returned `A`.
- Rewrite the benchmark to compare:
  - native path: `FLAGGEMS_CHUNK_GATED_DELTA_RULE_TLE=0`, `FLAGGEMS_CHUNK_GDR_RECOMPUTE_TLE=0`
  - optimized path: `FLAGGEMS_CHUNK_GATED_DELTA_RULE_TLE=1`, `FLAGGEMS_CHUNK_GDR_RECOMPUTE_TLE=1`
- Add correctness tests for both recompute TLE and full fused TLE forward.

## Fast Path Conditions

The fused-forward path is enabled only when all required conditions are satisfied:

- `initial_state is None`
- `output_final_state is True`
- CUDA device
- dtype is `float16` or `bfloat16`
- `cu_seqlens is None`
- `K == 128`
- `V == 128`
- `T` is divisible by the TLE block size

All other cases fall back to the original implementation.

## API Compatibility

The TLE fused-forward kernel needs the chunk-local matrix computed with:

```python
use_g_in_kkt=False
```

However, the raw `chunk_gated_delta_rule_fwd` API returns `A`, and the original fallback path returns `A` computed with the default KKT behavior.

To preserve API compatibility, the optimized path:

1. computes `A_tle` with `use_g_in_kkt=False` for `_tle_chunk_gated_delta_rule_fwd`;
2. recomputes the default `A` for the public return value.

This keeps `g`, `o`, `A`, and `final_state` consistent with the native path. The extra default `A` computation intentionally trades peak benchmark speed for correct raw API semantics.

## Correctness

Command:

```bash
PYTHONPATH=/share/project/tle/FlagTree/build/lib.linux-x86_64-cpython-312:src:$PYTHONPATH \
/root/miniconda3/envs/qrh/bin/python -m pytest -q -s \
  tests/test_FLA/test_chunk_gated_delta_rule_fwd_recompute.py \
  -m chunk_gated_delta_rule_fwd --tb=short
```

Result:

```text
16 passed, 16 warnings in 1.95s
```

The tests compare:

- `g`
- `o`
- `A`
- `final_state`

## Benchmark

### fp16

```text
B2_T16384_H16_D128: 1.609564 ms -> 1.378377 ms, 1.168x
B4_T2048_H16_D128:  0.449022 ms -> 0.355403 ms, 1.263x
B4_T4096_H64_D128:  2.636274 ms -> 2.333005 ms, 1.130x
```

### bf16

```text
B2_T16384_H16_D128: 1.618942 ms -> 1.373768 ms, 1.178x
B4_T2048_H16_D128:  0.452677 ms -> 0.358582 ms, 1.262x
B4_T4096_H64_D128:  2.642711 ms -> 2.333164 ms, 1.133x
```

## Notes

An output-only fused-forward variant can reach higher speedups because it does not need to return the raw API's default `A`. This PR keeps the API-compatible behavior, so the measured speedup is lower but safe for existing callers.

`B1_T8192_H96_D128` is not included in the benchmark table here because the native baseline path triggers a CUDA illegal memory access in `chunk_fwd_o` autotuning on the remote environment. The issue is in the baseline fallback path, not in the fused TLE forward path.
