### PR TITLE
fix --ref cpu

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import fcntl
 import json
 import logging
 import os
@@ -74,12 +75,10 @@ def pytest_addoption(parser):
     try:
         parser.addoption(
             "--collect-marks",
-            action="store_true",
-            help="Collect the tests with marker information without executing them",
+            default=None,
+            help="Collect the tests with marker information and write to the specified file",
         )
     except ValueError:
-        # Mixed test+benchmark pytest runs may already register this option in
-        # benchmark/conftest.py. Reuse the existing option in that case.
         pass
 
 
@@ -179,34 +178,43 @@ def get_reason(report):
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_logreport(report):
+    result = TEST_RESULTS.setdefault(
+        report.nodeid, {"params": None, "result": None, "opname": None}
+    )
     if report.when == "setup":
         if report.outcome == "skipped":
             reason = get_reason(report)
-            TEST_RESULTS[report.nodeid]["result"] = "skipped"
-            TEST_RESULTS[report.nodeid]["reason"] = reason
+            result["result"] = "skipped"
+            result["reason"] = reason
     elif report.when == "call":
-        TEST_RESULTS[report.nodeid]["result"] = report.outcome
+        result["result"] = report.outcome
         if report.outcome in ["skipped", "failed"]:
             reason = get_reason(report)
-            TEST_RESULTS[report.nodeid]["reason"] = reason
+            result["reason"] = reason
         else:
-            TEST_RESULTS[report.nodeid]["reason"] = None
+            result["reason"] = None
 
 
 def pytest_terminal_summary(terminalreporter):
     data = TEST_RESULTS
-    if os.path.exists(REPORT_FILE):
-        with open(REPORT_FILE, "r") as json_file:
-            existing_data = json.load(json_file)
-        existing_data.update(TEST_RESULTS)
-        data = existing_data
-
-    with open(REPORT_FILE, "w") as json_file:
+    with open(REPORT_FILE, "a+") as json_file:
+        fcntl.flock(json_file, fcntl.LOCK_EX)
+        json_file.seek(0)
+        content = json_file.read()
+        if content:
+            existing_data = json.loads(content)
+            existing_data.update(TEST_RESULTS)
+            data = existing_data
+        json_file.seek(0)
+        json_file.truncate()
         json.dump(data, json_file, indent=2, default=str)
+        json_file.flush()
+        os.fsync(json_file.fileno())
 
 
 def pytest_collection_modifyitems(session, config, items):
-    if config.getoption("--collect-marks"):
+    collect_marks_file = config.getoption("--collect-marks")
+    if collect_marks_file:
         report = []
         for item in items:
             data = {}
@@ -229,7 +237,8 @@ def pytest_collection_modifyitems(session, config, items):
             data["marks"] = op_marks
             report.append(data)
 
-        print(yaml.dump(report, indent=2))
+        with open(collect_marks_file, "w") as f:
+            yaml.dump(report, f, indent=2)
 
         # Skip all tests
         items.clear()


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
Bug Fix 

### Description
I update test config for --ref cpu support.
Changes made:
1. Added locked JSON result writing with fcntl.
2. Made test result logging more robust with TEST_RESULTS.setdefault(...).
3. Changed --collect-marks to accept an output file path instead of acting as a boolean flag.
4. Made collected marker info write to that file instead of printing to stdout.

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
N/A
