### PR TITLE
fix gla

### DIFF
--- a/benchmark/test_FLA/test_chunk_gla_perf.py
+++ b/benchmark/test_FLA/test_chunk_gla_perf.py
@@ -1,6 +1,3 @@
-import importlib.util
-from pathlib import Path
-
 import pytest
 import torch
 import torch.nn.functional as F
@@ -10,7 +7,7 @@ import flaggems_vllm
 from benchmark.conftest import Config
 from flaggems_vllm.ops.FLA.chunk_gla import chunk_gla as gems_chunk_gla
 
-# Try importing fla chunk_gla from installed package only.
+# optional FLA reference
 _HAS_FLA_CHUNK = False
 _fla_chunk_gla = None
 
@@ -22,138 +19,58 @@ except Exception:
     _HAS_FLA_CHUNK = False
 
 
-def _torch_naive_recurrent_gla(
-    q,
-    k,
-    v,
-    g,
-    scale=None,
-    initial_state=None,
-    output_final_state=False,
-    state_v_first=False,
-    cu_seqlens=None,
-    cu_seqlens_cpu=None,
-):
-    del cu_seqlens_cpu
-
-    if state_v_first:
-        raise ValueError("state_v_first=True is not supported in torch naive baseline")
-    if cu_seqlens is not None:
-        raise ValueError("cu_seqlens is not supported in torch naive baseline")
-
-    dtype = q.dtype
-    qf = q.float()
-    kf = k.float()
-    vf = v.float()
-    gf = g.float()
-
-    B, T, H, K = qf.shape
-    V = vf.shape[-1]
-    if scale is None:
-        scale = K**-0.5
-
-    if initial_state is None:
-        h = torch.zeros((B, H, K, V), device=q.device, dtype=torch.float32)
-    else:
-        h = initial_state.float().clone()
-
-    out = torch.zeros((B, T, H, V), device=q.device, dtype=torch.float32)
-    for t in range(T):
-        qt = qf[:, t] * float(scale)
-        kt = kf[:, t]
-        vt = vf[:, t]
-        gt = gf[:, t].exp()
-        h = h * gt[..., None] + kt[..., None] * vt[..., None, :]
-        out[:, t] = (qt[..., None] * h).sum(-2)
-
-    final_state = h if output_final_state else None
-    return out.to(dtype), final_state
-
-
-def _fla_chunk_wrapper(
-    q,
-    k,
-    v,
-    g,
-    scale=None,
-    initial_state=None,
-    output_final_state=False,
-    state_v_first=False,
-    cu_seqlens=None,
-    cu_seqlens_cpu=None,
-):
-    del cu_seqlens_cpu
+def _fla_chunk_wrapper(q, k, v, g, **kwargs):
     if not _HAS_FLA_CHUNK:
         raise RuntimeError("fla chunk_gla is unavailable")
+
     return _fla_chunk_gla(
         q=q,
         k=k,
         v=v,
         g=g,
-        scale=scale,
-        initial_state=initial_state,
-        output_final_state=output_final_state,
-        state_v_first=state_v_first,
-        cu_seqlens=cu_seqlens,
+        scale=kwargs.get("scale", None),
+        initial_state=kwargs.get("initial_state", None),
+        output_final_state=kwargs.get("output_final_state", False),
+        state_v_first=kwargs.get("state_v_first", False),
+        cu_seqlens=kwargs.get("cu_seqlens", None),
     )
 
 
-def _load_test_reference_impl():
-    repo_root = Path(__file__).resolve().parents[2]
-    test_file = repo_root / "benchmark" / "test_FLA" / "test_chunk_gla_perf.py"
-    spec = importlib.util.spec_from_file_location("_chunk_gla_test_ref", str(test_file))
-    if spec is None or spec.loader is None:
-        raise RuntimeError("Failed to load benchmark/test_FLA/test_chunk_gla_perf.py")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+def _precompile():
+    """
+    Force:
+    1. Triton JIT compile
+    2. autotune cache population
+    3. CUDA context stabilization
+    """
+    print("[precompile] warming up kernels & autotune cache ...")
 
-
-def _check_torch_reference_consistency():
-    module = _load_test_reference_impl()
-    if hasattr(module, "_HAS_FLA_NAIVE"):
-        module._HAS_FLA_NAIVE = False
-    if not hasattr(module, "_reference_chunk_gla"):
-        print("[consistency] skip: _reference_chunk_gla not found")
-        return
-    dtype = torch.bfloat16
     device = flaggems_vllm.device
-    B, T, H, D = 1, 16, 2, 32
+    dtype = torch.float16
 
-    torch.manual_seed(0)
+    B, T, H, D = 1, 512, 8, 64
+
     q = torch.randn(B, T, H, D, device=device, dtype=dtype)
     k = torch.randn(B, T, H, D, device=device, dtype=dtype)
     v = torch.randn(B, T, H, D, device=device, dtype=dtype)
     g = F.logsigmoid(torch.randn(B, T, H, D, device=device, dtype=dtype))
-    h0 = torch.randn(B, H, D, D, device=device, dtype=torch.float32)
-    scale = D**-0.5
 
-    out_a, ht_a = _torch_naive_recurrent_gla(
-        q=q,
-        k=k,
-        v=v,
-        g=g,
-        scale=scale,
-        initial_state=h0,
-        output_final_state=True,
-    )
-    out_b, ht_b = module._reference_chunk_gla(
-        q=q,
-        k=k,
-        v=v,
-        g=g,
-        scale=scale,
-        initial_state=h0,
-        output_final_state=True,
-        state_v_first=False,
-        cu_seqlens=None,
-    )
+    kwargs = {
+        "scale": D**-0.5,
+        "initial_state": None,
+        "output_final_state": False,
+        "state_v_first": False,
+        "cu_seqlens": None,
+        "cu_seqlens_cpu": None,
+    }
 
-    torch.testing.assert_close(out_a, out_b, atol=1e-6, rtol=1e-6)
-    torch.testing.assert_close(ht_a, ht_b, atol=1e-6, rtol=1e-6)
-    print(
-        "[consistency] torch naive == tests/test_FLA/test_chunk_gla.py reference: PASS"
-    )
+    # run multiple times to fully warm autotune
+    for _ in range(5):
+        if _HAS_FLA_CHUNK:
+            _fla_chunk_wrapper(q, k, v, g, **kwargs)
+        gems_chunk_gla(q, k, v, g, **kwargs)
+
+    torch.cuda.synchronize()
 
 
 def _bench_ms(fn):
@@ -165,25 +82,16 @@ def _bench_ms(fn):
             return_mode="median",
         )
 
-    for _ in range(Config.warm_up):
-        fn()
-    torch.cuda.synchronize()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
-    for _ in range(Config.repetition):
-        fn()
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / Config.repetition
 
-
-def _build_inputs(B, T, H, D, dtype):
+def _build_inputs(B, T, H, D, dtype, requires_grad=False):
     device = flaggems_vllm.device
-    q = torch.randn(B, T, H, D, device=device, dtype=dtype)
-    k = torch.randn(B, T, H, D, device=device, dtype=dtype)
-    v = torch.randn(B, T, H, D, device=device, dtype=dtype)
-    g = F.logsigmoid(torch.randn(B, T, H, D, device=device, dtype=dtype))
+    q = torch.randn(B, T, H, D, device=device, dtype=dtype, requires_grad=requires_grad)
+    k = torch.randn(B, T, H, D, device=device, dtype=dtype, requires_grad=requires_grad)
+    v = torch.randn(B, T, H, D, device=device, dtype=dtype, requires_grad=requires_grad)
+    g_logit = torch.randn(
+        B, T, H, D, device=device, dtype=dtype, requires_grad=requires_grad
+    )
+
     kwargs = {
         "scale": D**-0.5,
         "initial_state": None,
@@ -192,69 +100,174 @@ def _build_inputs(B, T, H, D, dtype):
         "cu_seqlens": None,
         "cu_seqlens_cpu": None,
     }
-    return q, k, v, g, kwargs
+    if requires_grad:
+        return q, k, v, g_logit, kwargs
+    else:
+        g = F.logsigmoid(g_logit)
+        return q, k, v, g, kwargs
 
 
+# ---------------------------
+# fwd+bwd benchmark helper
+# ---------------------------
+def _bench_fwd_bwd_ms(fn, q, k, v, g_logit, kwargs):
+    """Measure forward + backward pass time for a chunk_gla function.
+
+    ``g_logit`` is the pre-logsigmoid raw tensor (a leaf).  F.logsigmoid is
+    called *inside* the timed closure so each backward iteration gets a fresh
+    computation graph.
+    """
+
+    params = [q, k, v, g_logit]
+
+    def _fwd_bwd():
+        for p in params:
+            if p.grad is not None:
+                p.grad.zero_()
+        g = F.logsigmoid(g_logit)
+        out = fn(q, k, v, g, **kwargs)
+        if isinstance(out, tuple):
+            out = out[0]
+        loss = out.sum()
+        loss.backward()
+
+    if Config.mode.value == "kernel":
+        return triton.testing.do_bench(
+            _fwd_bwd,
+            warmup=Config.warm_up,
+            rep=Config.repetition,
+            return_mode="median",
+        )
+
+
+_SHAPES = [
+    # (1, 4096, 32, 512),
+    # (2, 2048, 16, 512),
+    (1, 8192, 96, 128),
+    (2, 16384, 16, 128),
+    (4, 2048, 16, 128),
+    (4, 4096, 64, 128),
+    (8, 2048, 32, 256),
+    (2, 2048, 16, 512),
+    (4, 1024, 8, 512),
+    (8, 1024, 8, 64),
+]
+
+_DTYPES = [
+    torch.bfloat16,
+    # torch.float32,
+    # torch.float16,
+]
+
+
+def _print_header(title, subtitle):
+    print(f"\n{'=' * 70}")
+    print(f"  {title}")
+    print(f"  {subtitle}")
+    print(
+        f"  mode={Config.mode.value}  warmup={Config.warm_up}  iter={Config.repetition}"
+    )
+    print(f"{'=' * 70}")
+
+    if _HAS_FLA_CHUNK:
+        print(
+            f"{'B':>3} {'T':>6} {'H':>4} {'D':>4} {'dtype':>8} "
+            f"{'fla(ms)':>10} {'gems(ms)':>10} {'gems/fla':>10}"
+        )
+    else:
+        print(f"{'B':>3} {'T':>6} {'H':>4} {'D':>4} {'dtype':>8} " f"{'gems(ms)':>10}")
+
+
+def _print_row(B, T, H, D, dtype, ms_fla, ms_gems):
+    dtype_str = str(dtype).split(".")[-1]
+    if _HAS_FLA_CHUNK:
+        speedup = ms_fla / ms_gems if ms_gems > 0 else float("inf")
+        print(
+            f"{B:>3} {T:>6} {H:>4} {D:>4} {dtype_str:>8} "
+            f"{ms_fla:>10.3f} {ms_gems:>10.3f} {speedup:>10.2f}x"
+        )
+    else:
+        print(f"{B:>3} {T:>6} {H:>4} {D:>4} {dtype_str:>8} " f"{ms_gems:>10.3f}")
+
+
+# ---------------------------
+# unified benchmark (fwd then fwd+bwd)
+# ---------------------------
 @pytest.mark.skipif(
-    flaggems_vllm.device != "cuda", reason="benchmark requires CUDA device"
+    flaggems_vllm.device != "cuda",
+    reason="benchmark requires CUDA device",
 )
 @pytest.mark.chunk_gla
 def test_perf_chunk_gla():
-    _check_torch_reference_consistency()
 
-    shapes = [
-        # small / correctness-friendly
-        (2, 512, 8, 64),
-        (4, 1024, 8, 64),
-        # small batch + medium / long context
-        (1, 2048, 8, 64),
-        (1, 4096, 16, 64),
-    ]
-    dtypes = [
-        torch.float32,
-        torch.float16,
-        torch.bfloat16,
-    ]
+    # ============================================================
+    # Part 1: forward only
+    # ============================================================
+    _print_header(
+        "chunk_gla benchmark — FWD ONLY",
+        "provider: fla_chunk vs flaggems_chunk",
+    )
 
-    print("\n[chunk_gla 3-way benchmark]")
-    print(f"mode={Config.mode.value} warmup={Config.warm_up} iter={Config.repetition}")
-    if _HAS_FLA_CHUNK:
-        print("provider: torch_naive vs fla_chunk vs flaggems_chunk")
-        print(
-            f"{'B':>3} {'T':>6} {'H':>4} {'D':>4} {'dtype':>8} "
-            f"{'torch(ms)':>12} {'fla(ms)':>10} {'gems(ms)':>10} "
-            f"{'gems/torch':>11} {'gems/fla':>10}"
-        )
-    else:
-        print("provider: torch_naive vs flaggems_chunk (fla_chunk unavailable)")
-        print(
-            f"{'B':>3} {'T':>6} {'H':>4} {'D':>4} {'dtype':>8} "
-            f"{'torch(ms)':>12} {'gems(ms)':>10} {'gems/torch':>11}"
-        )
+    _precompile()
+    torch.cuda.synchronize()
 
-    for dtype in dtypes:
-        print("精度：", dtype)
-        for B, T, H, D in shapes:
+    for dtype in _DTYPES:
+        print("\ndtype:", dtype)
+        for B, T, H, D in _SHAPES:
             q, k, v, g, kwargs = _build_inputs(B, T, H, D, dtype)
 
-            ms_torch = _bench_ms(
-                lambda: _torch_naive_recurrent_gla(q, k, v, g, **kwargs)
-            )
             ms_fla = None
             if _HAS_FLA_CHUNK:
                 ms_fla = _bench_ms(lambda: _fla_chunk_wrapper(q, k, v, g, **kwargs))
             ms_gems = _bench_ms(lambda: gems_chunk_gla(q, k, v, g, **kwargs))
+            _print_row(B, T, H, D, dtype, ms_fla, ms_gems)
 
-            speedup_vs_torch = ms_torch / ms_gems if ms_gems > 0 else float("inf")
-            if _HAS_FLA_CHUNK and ms_fla is not None:
-                speedup_vs_fla = ms_fla / ms_gems if ms_gems > 0 else float("inf")
-                print(
-                    f"{B:>3} {T:>6} {H:>4} {D:>4} {str(dtype).split('.')[-1]:>8} "
-                    f"{ms_torch:>12.3f} {ms_fla:>10.3f} {ms_gems:>10.3f} "
-                    f"{speedup_vs_torch:>11.2f}x {speedup_vs_fla:>10.2f}x"
-                )
-            else:
-                print(
-                    f"{B:>3} {T:>6} {H:>4} {D:>4} {str(dtype).split('.')[-1]:>8} "
-                    f"{ms_torch:>12.3f} {ms_gems:>10.3f} {speedup_vs_torch:>11.2f}x"
-                )
+    # ============================================================
+    # Part 2: forward + backward
+    # ============================================================
+    _print_header(
+        "chunk_gla benchmark — FWD + BWD",
+        "provider: fla_chunk vs flaggems_chunk  (forward + backward)",
+    )
+
+    # warmup: run fwd+bwd on a small shape so backward kernels compile
+    print("[precompile] warming up fwd+bwd kernels ...")
+    wq, wk, wv, wg_logit, wkwargs = _build_inputs(
+        1, 256, 4, 64, torch.float16, requires_grad=True
+    )
+    for _ in range(3):
+        if _HAS_FLA_CHUNK:
+            wg = F.logsigmoid(wg_logit)
+            out = _fla_chunk_wrapper(wq, wk, wv, wg, **wkwargs)
+            if isinstance(out, tuple):
+                out = out[0]
+            out.sum().backward()
+            for p in [wq, wk, wv, wg_logit]:
+                if p.grad is not None:
+                    p.grad.zero_()
+        wg = F.logsigmoid(wg_logit)
+        out = gems_chunk_gla(wq, wk, wv, wg, **wkwargs)
+        if isinstance(out, tuple):
+            out = out[0]
+        out.sum().backward()
+        for p in [wq, wk, wv, wg_logit]:
+            if p.grad is not None:
+                p.grad.zero_()
+    torch.cuda.synchronize()
+
+    for dtype in _DTYPES:
+        print("\ndtype:", dtype)
+        for B, T, H, D in _SHAPES:
+            q, k, v, g_logit, kwargs = _build_inputs(
+                B, T, H, D, dtype, requires_grad=True
+            )
+
+            ms_fla = None
+            if _HAS_FLA_CHUNK:
+                ms_fla = _bench_fwd_bwd_ms(_fla_chunk_wrapper, q, k, v, g_logit, kwargs)
+            ms_gems = _bench_fwd_bwd_ms(gems_chunk_gla, q, k, v, g_logit, kwargs)
+            _print_row(B, T, H, D, dtype, ms_fla, ms_gems)
+
+    print(f"\n{'=' * 70}")
+    print("  All done. ")
+    print(f"{'=' * 70}\n")

--- a/src/flaggems_vllm/ops/FLA/chunk_gla.py
+++ b/src/flaggems_vllm/ops/FLA/chunk_gla.py
@@ -4,10 +4,20 @@
 # LICENSE file in the root directory of this source tree.
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+import os
 
 import torch
 import triton
 import triton.language as tl
+
+try:
+    HAS_TLE = False
+    import triton.experimental.tle.language as tle  # noqa: F401
+
+    HAS_TLE = True
+except ImportError:
+    tle = None
+    HAS_TLE = False
 
 from flaggems_vllm.ops.FLA.chunk_h import chunk_bwd_dh, chunk_fwd_h
 from flaggems_vllm.ops.FLA.cumsum_gla import chunk_local_cumsum
@@ -404,7 +414,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=["BT", "HV", "STATE_V_FIRST"],
+    key=["BT", "HV", "STATE_V_FIRST", "V"],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_fwd_kernel_o(
@@ -499,6 +509,207 @@ def chunk_gla_fwd_kernel_o(
     b_A = tl.where(m_s, b_A, 0.0).to(b_v.dtype)
     b_o += tl.dot(b_A, b_v)
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
+if HAS_TLE:
+
+    @triton.heuristics(
+        {
+            "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        }
+    )
+    @triton.autotune(
+        configs=[
+            triton.Config(
+                {"BK": BK, "BV": BV, "B_VCHUNK": B_VCHUNK},
+                num_warps=num_warps,
+                num_stages=num_stages,
+            )
+            for BK in [32, 64]
+            for BV in [64, 128]
+            for B_VCHUNK in [1, 2, 4]
+            for num_warps in [2, 4, 8]
+            for num_stages in [2, 3, 4]
+        ],
+        key=["BT", "HV", "STATE_V_FIRST", "V"],
+    )
+    @triton.jit(do_not_specialize=["T"])
+    def chunk_gla_fwd_kernel_o_tle(
+        q,
+        v,
+        g,
+        h,
+        o,
+        A,
+        cu_seqlens,
+        chunk_indices,
+        scale,
+        T,
+        H: tl.constexpr,
+        HV: tl.constexpr,
+        K: tl.constexpr,
+        V: tl.constexpr,
+        BT: tl.constexpr,
+        BK: tl.constexpr,
+        BV: tl.constexpr,
+        B_VCHUNK: tl.constexpr,
+        STATE_V_FIRST: tl.constexpr,
+        IS_VARLEN: tl.constexpr,
+    ):
+        i_vg, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+        i_v_base = i_vg * B_VCHUNK
+        i_b, i_hv = i_bh // HV, i_bh % HV
+        i_h = i_hv // (HV // H)
+        if IS_VARLEN:
+            i_tg = i_t.to(tl.int64)
+            i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+                chunk_indices + i_t * 2 + 1
+            ).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(
+                cu_seqlens + i_n + 1
+            ).to(tl.int64)
+            T = eos - bos
+            NT = tl.cdiv(T, BT)
+        else:
+            NT = tl.cdiv(T, BT)
+            i_tg = (i_b * NT + i_t).to(tl.int64)
+            bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
+
+        m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
+
+        q += (bos * H + i_h) * K
+        g += (bos * HV + i_hv) * K
+        v += (bos * HV + i_hv) * V
+        o += (bos * HV + i_hv) * V
+        h += (i_tg * HV + i_hv).to(tl.int64) * K * V
+        A += (bos * HV + i_hv) * BT
+
+        n_k_tiles = tl.cdiv(K, BK)
+
+        if B_VCHUNK <= 1:
+            i_v = i_v_base
+            b_o = tl.zeros([BT, BV], dtype=tl.float32)
+            for i_k in range(n_k_tiles):
+                p_q = tl.make_block_ptr(
+                    q, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+                )
+                p_g = tl.make_block_ptr(
+                    g, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+                )
+                if STATE_V_FIRST:
+                    p_h = tl.make_block_ptr(
+                        h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
+                    )
+                else:
+                    p_h = tl.make_block_ptr(
+                        h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
+                    )
+
+                b_q = tle.load(p_q, boundary_check=(0, 1), is_async=True)
+                b_g = tle.load(p_g, boundary_check=(0, 1), is_async=True).to(tl.float32)
+                b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
+                b_h = tle.load(p_h, boundary_check=(0, 1), is_async=True)
+
+                if STATE_V_FIRST:
+                    b_o += tl.dot(b_qg, tl.trans(b_h).to(b_qg.dtype))
+                else:
+                    b_o += tl.dot(b_qg, b_h.to(b_qg.dtype))
+
+            b_o *= scale
+            p_v = tl.make_block_ptr(
+                v, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+            )
+            p_o = tl.make_block_ptr(
+                o, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+            )
+            p_A = tl.make_block_ptr(
+                A, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+            )
+
+            b_v = tle.load(p_v, boundary_check=(0, 1), is_async=True)
+            b_A = tle.load(p_A, boundary_check=(0, 1), is_async=True)
+            b_A = tl.where(m_s, b_A, 0.0).to(b_v.dtype)
+            b_o += tl.dot(b_A, b_v)
+            tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+        else:
+            b_o_0 = tl.zeros([BT, BV], dtype=tl.float32)
+            b_o_1 = tl.zeros([BT, BV], dtype=tl.float32)
+            b_o_2 = tl.zeros([BT, BV], dtype=tl.float32)
+            b_o_3 = tl.zeros([BT, BV], dtype=tl.float32)
+
+            for i_k in range(n_k_tiles):
+                p_q = tl.make_block_ptr(
+                    q, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+                )
+                p_g = tl.make_block_ptr(
+                    g, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+                )
+
+                b_q = tle.load(p_q, boundary_check=(0, 1), is_async=True)
+                b_g = tle.load(p_g, boundary_check=(0, 1), is_async=True).to(tl.float32)
+                b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
+
+                for d in tl.static_range(B_VCHUNK):
+                    i_v = i_v_base + d
+
+                    if STATE_V_FIRST:
+                        p_h = tl.make_block_ptr(
+                            h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
+                        )
+                    else:
+                        p_h = tl.make_block_ptr(
+                            h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
+                        )
+
+                    b_h = tle.load(p_h, boundary_check=(0, 1), is_async=True)
+
+                    if STATE_V_FIRST:
+                        dot_res = tl.dot(b_qg, tl.trans(b_h).to(b_qg.dtype))
+                    else:
+                        dot_res = tl.dot(b_qg, b_h.to(b_qg.dtype))
+
+                    if d == 0:
+                        b_o_0 += dot_res
+                    elif d == 1:
+                        b_o_1 += dot_res
+                    elif d == 2:
+                        b_o_2 += dot_res
+                    elif d == 3:
+                        b_o_3 += dot_res
+
+            p_A = tl.make_block_ptr(
+                A, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+            )
+            b_A = tle.load(p_A, boundary_check=(0, 1), is_async=True)
+            b_A = tl.where(m_s, b_A, 0.0)
+
+            for d in tl.static_range(B_VCHUNK):
+                i_v = i_v_base + d
+
+                if d == 0:
+                    b_o_final = b_o_0
+                elif d == 1:
+                    b_o_final = b_o_1
+                elif d == 2:
+                    b_o_final = b_o_2
+                elif d == 3:
+                    b_o_final = b_o_3
+                else:
+                    b_o_final = b_o_0
+
+                b_o_final = b_o_final * scale
+
+                p_v = tl.make_block_ptr(
+                    v, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+                )
+                b_v = tle.load(p_v, boundary_check=(0, 1), is_async=True)
+                b_o_final += tl.dot(b_A.to(b_v.dtype), b_v)
+
+                p_o = tl.make_block_ptr(
+                    o, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+                )
+                tl.store(p_o, b_o_final.to(p_o.dtype.element_ty), boundary_check=(0, 1))
 
 
 @triton.heuristics(
@@ -642,7 +853,7 @@ def chunk_gla_bwd_kernel_intra(
         p_gkj += H * K
     tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
 
-    tl.debug_barrier()
+    # tl.debug_barrier()
     # [BC, BK]
     b_dk = tl.zeros([BC, BK], dtype=tl.float32)
 
@@ -816,7 +1027,7 @@ def chunk_gla_bwd_kernel_dA(
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=["BT", "STATE_V_FIRST"],
+    key=["BT", "K", "V", "STATE_V_FIRST"],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_bwd_kernel_dv(
@@ -952,7 +1163,7 @@ def chunk_gla_bwd_kernel_dv(
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=["BT", "STATE_V_FIRST"],
+    key=["BT", "K", "V", "STATE_V_FIRST"],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_gla_bwd_kernel_inter(
@@ -1222,7 +1433,17 @@ def chunk_gla_fwd_o_gk(
     def grid(meta):
         return (triton.cdiv(V, meta["BV"]), NT, B * HV)
 
-    chunk_gla_fwd_kernel_o[grid](
+    def grid_tle(meta):
+        return (triton.cdiv(V, meta["BV"] * meta.get("B_VCHUNK", 1)), NT, B * HV)
+
+    _use_tle = HAS_TLE and os.environ.get("FLA_GLA_TLE", "1") != "0"
+    if _use_tle:
+        kernel = chunk_gla_fwd_kernel_o_tle
+        grid_fn = grid_tle
+    else:
+        kernel = chunk_gla_fwd_kernel_o
+        grid_fn = grid
+    kernel[grid_fn](
         q=q,
         v=v,
         g=g,

--- a/src/flaggems_vllm/ops/FLA/utils.py
+++ b/src/flaggems_vllm/ops/FLA/utils.py
@@ -139,9 +139,9 @@ def check_shared_mem(arch: str = "none", tensor_idx: int = 0) -> bool:
         return False
 
     # property names differ across torch versions/drivers; try common ones
-    max_shared = getattr(props, "max_shared_memory_per_multiprocessor", None)
+    max_shared = getattr(props, "shared_memory_per_multiprocessor", None)
     if max_shared is None:
-        max_shared = getattr(props, "max_shared_memory", None)
+        max_shared = getattr(props, "max_shared_mem", None)
     if max_shared is None:
         # fallback conservative default
         return False


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
# Benchmark 
 ## Chunk GLA Benchmark — Forward

**Provider: FLA Chunk vs FlagGems Chunk (Forward)**  
**dtype: torch.bfloat16**

| B | T | H | D | dtype | fla(ms) | gems(ms) | gems/fla |
|---|---|---|---|---|---:|---:|---:|
| 1 | 4096 | 32 | 512 | bfloat16 | 2.441 | 2.068 | 1.18x |
| 2 | 2048 | 16 | 512 | bfloat16 | 1.243 | 1.054 | 1.18x |
| 1 | 8192 | 96 | 128 | bfloat16 | 2.491 | 1.957 | 1.27x |
| 2 | 16384 | 16 | 128 | bfloat16 | 1.893 | 1.541 | 1.23x |
| 4 | 2048 | 16 | 128 | bfloat16 | 0.454 | 0.365 | 1.24x |
| 4 | 4096 | 64 | 128 | bfloat16 | 3.312 | 2.600 | 1.27x |
| 8 | 2048 | 32 | 256 | bfloat16 | 3.711 | 3.046 | 1.22x |
| 2 | 2048 | 16 | 512 | bfloat16 | 1.244 | 1.053 | 1.18x |
| 4 | 1024 | 8 | 512 | bfloat16 | 0.653 | 0.550 | 1.19x |
| 8 | 1024 | 8 | 64 | bfloat16 | 0.288 | 0.241 | 1.20x |
 
## Chunk GLA Benchmark — Forward + Backward

**Provider: FLA Chunk vs FlagGems Chunk (Forward + Backward)**  
**dtype: torch.bfloat16**

| B | T | H | D | dtype | fla(ms) | gems(ms) | gems/fla |
|---|---|---|---|---|---:|---:|---:|
| 1 | 4096 | 32 | 512 | bfloat16 | 11.833 | 11.466 | 1.03x |
| 2 | 2048 | 16 | 512 | bfloat16 | 5.975 | 5.785 | 1.03x |
| 1 | 8192 | 96 | 128 | bfloat16 | 12.184 | 11.638 | 1.05x |
| 2 | 16384 | 16 | 128 | bfloat16 | 8.726 | 8.371 | 1.04x |
| 4 | 2048 | 16 | 128 | bfloat16 | 2.150 | 2.064 | 1.04x |
| 4 | 4096 | 64 | 128 | bfloat16 | 16.327 | 15.615 | 1.05x |
| 8 | 2048 | 32 | 256 | bfloat16 | 18.400 | 17.739 | 1.04x |
| 2 | 2048 | 16 | 512 | bfloat16 | 5.978 | 5.792 | 1.03x |
| 4 | 1024 | 8 | 512 | bfloat16 | 3.082 | 2.979 | 1.03x |
| 8 | 1024 | 8 | 64 | bfloat16 | 1.144 | 1.022 | 1.12x |

## Performance Summary

| Mode | Average Speedup (gems/fla) | Maximum Speedup | Minimum Speedup |
|---|---:|---:|---:|
| Forward | ~1.21x | 1.27x | 1.18x |
| Forward + Backward | ~1.04x | 1.12x | 1.03x |

### Observations

- Forward kernel achieves consistent performance improvement:
  - Speedup range: **1.18x ~ 1.27x**
  - Average improvement: **~21%**

- Forward + Backward overall improvement is smaller:
  - Speedup range: **1.03x ~ 1.12x**
  - Average improvement: **~4%**


```bash
pytest benchmark/test_FLA/test_chunk_gla_perf.py::test_perf_chunk_gla -s --level core --iter 200 --warmup 100 
