### PR TITLE
feat: port run_tests.py and reporting tools from FlagGems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ test = [
     "numpy>=1.26",
     "scipy>=1.14",
     "cupy-cuda12x",
+    "distro>=1.9.0",
 ]
 
 [project.urls]

--- a/tools/add_labels.py
+++ b/tools/add_labels.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -*- coding: utf-8 -*-
+"""
+Standalone script to add operator labels from operators.yaml into summary.json.
+
+Usage:
+    python add_labels.py <result_dir>
+
+Where <result_dir> is the output directory produced by run_tests.py containing
+summary.json. The script reads conf/operators.yaml relative to the project root,
+builds a mapping of op_id -> labels, and injects the "labels" field into each
+operator entry in summary.json.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).parent.parent
+
+
+def pinfo(msg):
+    print(f"\033[32m[INFO]\033[0m {msg}")
+
+
+def perror(msg):
+    print(f"\033[31m[ERROR]\033[0m {msg}")
+
+
+def load_op_labels():
+    """Load operator labels from conf/operators.yaml."""
+    op_labels = {}
+    op_inventory = ROOT / "conf" / "operators.yaml"
+    try:
+        with open(str(op_inventory), "r") as f:
+            data = yaml.safe_load(f)
+            catalog = data.get("ops", [])
+    except Exception as e:
+        perror(f"Failed to load operator inventory: {e}")
+        return op_labels
+
+    for op_entry in catalog:
+        op_id = op_entry.get("id", "")
+        labels = op_entry.get("labels", [])
+        op_labels[op_id] = labels
+
+    return op_labels
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Add operator labels from operators.yaml into summary.json"
+    )
+    parser.add_argument(
+        "result_dir",
+        help="Path to the result directory containing summary.json",
+    )
+    args = parser.parse_args()
+
+    result_dir = Path(args.result_dir)
+    summary_path = result_dir / "summary.json"
+
+    if not summary_path.exists():
+        perror(f"summary.json not found in {result_dir}")
+        sys.exit(1)
+
+    # Load summary
+    with summary_path.open("r") as f:
+        summary = json.load(f)
+
+    op_data = summary.get("result", {})
+    if not op_data:
+        perror("No 'result' field found in summary.json")
+        sys.exit(1)
+
+    # Load labels from operators.yaml
+    op_labels = load_op_labels()
+    if not op_labels:
+        perror("No labels loaded from operators.yaml")
+        sys.exit(1)
+
+    # Inject labels into each operator entry
+    updated = 0
+    for op_id, op_entry in op_data.items():
+        labels = op_labels.get(op_id, [])
+        op_entry["labels"] = labels
+        updated += 1
+
+    # Write back
+    with summary_path.open("w") as f:
+        json.dump(summary, f, indent=2)
+
+    pinfo(f"Updated {updated} operators with labels in {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/consts.py
+++ b/tools/consts.py
@@ -1,0 +1,28 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DTYPE_MAP = {
+    "torch.float16": "fp16",
+    "torch.float32": "fp32",
+    "torch.bfloat16": "bf16",
+    "torch.int16": "int16",
+    "torch.int32": "int32",
+    "torch.int8": "int8",
+    "torch.uint8": "uint8",
+    "torch.int64": "int64",
+    "torch.bool": "bool",
+    "torch.complex64": "cf64",
+    "torch.float8_e4m3fn": "float8_e4m3fn",
+    "torch.float8_e5m2": "float8_e5m2",
+}

--- a/tools/html_assets/script.js
+++ b/tools/html_assets/script.js
@@ -1,0 +1,63 @@
+function switchTab(containerId, idx) {
+  var container = document.getElementById(containerId);
+  var btns = container.querySelectorAll('.tab-btn');
+  var panels = container.querySelectorAll('.tab-panel');
+  for (var i = 0; i < btns.length; i++) {
+    btns[i].classList.remove('active');
+    panels[i].style.display = 'none';
+  }
+  btns[idx].classList.add('active');
+  panels[idx].style.display = '';
+}
+
+var originalOrder = [];
+(function() {
+  var table = document.getElementById('main-table');
+  if (!table) return;
+  var rows = table.tBodies[0].rows;
+  for (var i = 0; i < rows.length; i++) originalOrder.push(rows[i]);
+})();
+
+function getCellText(row, col) {
+  var cell = row.cells[col];
+  if (!cell) return '';
+  var summary = cell.querySelector('summary');
+  if (summary) return summary.textContent.trim();
+  return cell.textContent.trim();
+}
+
+function filterTable() {
+  var table = document.getElementById('main-table');
+  if (!table) return;
+  var selects = table.querySelectorAll('thead .filter-select');
+  var accVal = selects[0] ? selects[0].value : '';
+  var perfVal = selects[1] ? selects[1].value : '';
+  var rows = table.tBodies[0].rows;
+  var visible = 0;
+  for (var i = 0; i < rows.length; i++) {
+    var show = true;
+    if (accVal && getCellText(rows[i], 2) !== accVal) show = false;
+    if (perfVal && getCellText(rows[i], 4) !== perfVal) show = false;
+    rows[i].style.display = show ? '' : 'none';
+    if (show) visible++;
+  }
+  var el = document.getElementById('visible-count');
+  if (el) el.textContent = visible;
+}
+
+function sortTable(col, dir) {
+  var table = document.getElementById('main-table');
+  if (!table) return;
+  var tbody = table.tBodies[0];
+  var rows = Array.from(tbody.rows);
+  if (dir === 'reset') {
+    originalOrder.forEach(function(r) { tbody.appendChild(r); });
+    return;
+  }
+  rows.sort(function(a, b) {
+    var va = parseFloat(getCellText(a, col)) || 0;
+    var vb = parseFloat(getCellText(b, col)) || 0;
+    return dir === 'asc' ? va - vb : vb - va;
+  });
+  rows.forEach(function(r) { tbody.appendChild(r); });
+}

--- a/tools/html_assets/style.css
+++ b/tools/html_assets/style.css
@@ -1,0 +1,184 @@
+/*
+ Copyright 2026 FlagOS Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    margin: 20px;
+    color: #333;
+}
+h3 {
+    color: #2c3e50;
+    border-bottom: 2px solid #3498db;
+    padding-bottom: 6px;
+}
+h4 {
+    color: #34495e;
+}
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-bottom: 20px;
+    font-size: 14px;
+}
+thead th {
+    background-color: #3498db;
+    color: #fff;
+    padding: 8px 10px;
+    text-align: left;
+}
+tbody td {
+    padding: 6px 10px;
+    border-bottom: 1px solid #ddd;
+}
+tbody tr:nth-child(even) {
+    background-color: #f9f9f9;
+}
+tbody tr:hover {
+    background-color: #eaf2f8;
+}
+tt {
+    background-color: #ecf0f1;
+    padding: 2px 4px;
+    border-radius: 3px;
+}
+blockquote {
+    margin: 4px 0;
+    padding: 4px 8px;
+    border-left: 3px solid #e74c3c;
+    background-color: #fdf2f2;
+}
+details summary {
+    cursor: pointer;
+    color: #2980b9;
+    text-decoration: underline;
+}
+details summary:hover {
+    color: #1a5276;
+}
+pre.log-content {
+    max-height: 400px;
+    overflow: auto;
+    background-color: #2d2d2d;
+    color: #f8f8f2;
+    padding: 10px;
+    border-radius: 0 4px 4px 4px;
+    font-size: 12px;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    margin-top: 0;
+}
+.log-tabs {
+    margin-top: 6px;
+}
+.tab-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px;
+    border-bottom: 2px solid #3498db;
+}
+.tab-btn {
+    padding: 4px 10px;
+    border: 1px solid #ccc;
+    border-bottom: none;
+    background: #ecf0f1;
+    cursor: pointer;
+    font-size: 12px;
+    border-radius: 4px 4px 0 0;
+}
+.tab-btn.active {
+    background: #3498db;
+    color: #fff;
+    border-color: #3498db;
+}
+.tab-btn:hover:not(.active) {
+    background: #d5e8f7;
+}
+.tab-panel {
+    border: 1px solid #ccc;
+    border-top: none;
+}
+.table-stats {
+    padding: 8px 10px;
+    margin-bottom: 8px;
+    background-color: #eaf2f8;
+    border-radius: 4px;
+    font-size: 14px;
+    color: #2c3e50;
+}
+.table-stats span {
+    font-weight: bold;
+}
+.table-wrapper {
+    overflow-x: auto;
+    overflow-y: auto;
+    max-height: 85vh;
+    position: relative;
+}
+thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background-color: #3498db;
+}
+.sticky-col {
+    position: sticky;
+    background-color: inherit;
+    z-index: 2;
+}
+.sticky-col-0 {
+    left: 0;
+    min-width: 40px;
+}
+.sticky-col-1 {
+    left: 40px;
+    min-width: 120px;
+    border-right: 2px solid #bdc3c7;
+}
+thead .sticky-col {
+    z-index: 4;
+}
+thead .sticky-col-0 {
+    background-color: #3498db;
+}
+thead .sticky-col-1 {
+    background-color: #3498db;
+}
+tbody tr .sticky-col {
+    background-color: #fff;
+}
+tbody tr:nth-child(even) .sticky-col {
+    background-color: #f9f9f9;
+}
+tbody tr:hover .sticky-col {
+    background-color: #eaf2f8;
+}
+.filter-select {
+    width: 100%;
+    margin-top: 4px;
+    font-size: 12px;
+    padding: 2px;
+}
+.sort-btn {
+    border: none;
+    background: transparent;
+    color: #fff;
+    cursor: pointer;
+    font-size: 14px;
+    padding: 0 2px;
+}
+.sort-btn:hover {
+    color: #f1c40f;
+}

--- a/tools/psum_html
+++ b/tools/psum_html
@@ -1,0 +1,454 @@
+#!/usr/bin/env python
+
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import html as html_module
+import json
+import re
+import sys
+from pathlib import Path
+
+import consts
+
+DATA = {}
+DATA_DIR = None
+
+ASSETS_DIR = Path(__file__).resolve().parent / "html_assets"
+
+
+def wrap_html(lines):
+    """Wrap HTML content lines in a complete HTML document with styling."""
+    header = [
+        "<!DOCTYPE html>",
+        "<html>",
+        "<head>",
+        '<meta charset="utf-8">',
+        "<title>FlagGems-vllm Test Report</title>",
+    ]
+
+    css = (ASSETS_DIR / "style.css").read_text()
+    header.append(f"<style>\n{css}</style>")
+    header.extend(["</head>", "<body>"])
+    js = (ASSETS_DIR / "script.js").read_text()
+    footer = [
+        f"<script>\n{js}</script>",
+        "</body>",
+        "</html>",
+    ]
+    return header + lines + footer
+
+
+def read_log_files(op_name, prefix):
+    """Read log files for an operator with the given prefix (accuracy_ or performance_).
+
+    Returns a list of (filename, content) tuples, or None if no files found.
+    """
+    if DATA_DIR is None:
+        return None
+    op_dir = Path(DATA_DIR) / op_name
+    if not op_dir.is_dir():
+        return None
+    log_files = sorted(op_dir.glob(f"{prefix}*"))
+    if not log_files:
+        return None
+    results = []
+    for lf in log_files:
+        try:
+            content = lf.read_text(errors="replace").strip()
+            if content:
+                results.append((lf.name, content))
+        except Exception:
+            pass
+    if not results:
+        return None
+    return results
+
+
+def load_data(data_path):
+    try:
+        with data_path.open("r") as f:
+            data = json.load(f)
+        return data, True
+    except Exception as ex:
+        print(f"Failed to load data: {ex}")
+    return {}, False
+
+
+def parse_lines():
+    data = DATA.get("result", {})
+    lines = []
+    for op, item in data.items():
+        fields = []
+        accu = item["accuracy"]["status"]
+        accud = "/".join(
+            [
+                str(item["accuracy"]["passed"]),
+                str(item["accuracy"]["failed"]),
+                str(item["accuracy"]["skipped"]),
+            ]
+        )
+        fields.extend([op, accu, accud])
+
+        perf_data = item["performance"]["data"]
+        perf_status = item["performance"]["status"]
+        if perf_status == "NotFound":
+            fields.append("NotFound")
+            fields.extend(
+                [""] * (len(consts.DTYPE_MAP) + 2)
+            )  # OPAverageSpeedUp + dtypes + note
+
+        elif perf_status in ["Failed", "Skipped"]:
+            reason = item["performance"]["reason"]
+            reason = reason.split("\n")[0]
+            fields.append(perf_status)
+            fields.extend(
+                [""] * (len(consts.DTYPE_MAP) + 1)
+            )  # OPAverageSpeedUp + dtypes
+            fields.append(f'"{reason}"')
+
+        else:
+            fields.append(perf_status)
+            speedup_values = []
+            for dtype in list(consts.DTYPE_MAP.values()):
+                dobj = perf_data.get(dtype, {})
+                speedup = dobj.get("speedup", None)
+                if speedup:
+                    fields.append(f"{speedup:6.3f}")
+                    speedup_values.append(speedup)
+                else:
+                    fields.append("")
+            # Compute OPAverageSpeedUp
+            if speedup_values:
+                avg_speedup = sum(speedup_values) / len(speedup_values)
+                op_avg_field = f"{avg_speedup:6.3f}"
+            else:
+                op_avg_field = ""
+            # Insert OPAverageSpeedUp right after PerfRes (before dtype columns)
+            fields.insert(4, op_avg_field)
+            fields.append("")  # note
+
+        lines.append(_build_html_row_with_logs(op, fields))
+
+    return sorted(lines)
+
+
+def _build_html_row_with_logs(op, fields):
+    """Build an HTML table row with expandable log content in AccRes and PerfRes cells."""
+    # Column layout: 0=ID, 1=AccRes, 2=AccStat, 3=PerfRes, 4=OPAverageSpeedUp, ...
+    # (No. column is prepended later in parse_multi)
+    cells = []
+    for i, val in enumerate(fields):
+        if i == 1:  # AccRes column
+            log_files = read_log_files(op, "accuracy_")
+            if log_files:
+                cell = _render_log_tabs(val, log_files, f"acc-{op}")
+            else:
+                cell = html_module.escape(val)
+        elif i == 3:  # PerfRes column
+            log_files = read_log_files(op, "performance_")
+            if log_files:
+                cell = _render_log_tabs(val, log_files, f"perf-{op}")
+            else:
+                cell = html_module.escape(val)
+        else:
+            cell = html_module.escape(val)
+        cells.append(f"<td>{cell}</td>")
+    return "<tr>" + "".join(cells) + "</tr>"
+
+
+def _render_log_tabs(summary_text, log_files, uid):
+    """Render a <details> block with tabbed log file content.
+
+    Args:
+        summary_text: The text shown in the clickable summary.
+        log_files: List of (filename, content) tuples.
+        uid: Unique ID prefix for this tab group.
+    """
+    parts = []
+    parts.append(f"<details><summary>{html_module.escape(summary_text)}</summary>")
+    parts.append(f'<div class="log-tabs" id="tabs-{uid}">')
+
+    # Tab buttons
+    parts.append('<div class="tab-buttons">')
+    for idx, (fname, _) in enumerate(log_files):
+        active = " active" if idx == 0 else ""
+        parts.append(
+            f'<button class="tab-btn{active}" '
+            f"onclick=\"switchTab('tabs-{uid}', {idx})\">"
+            f"{html_module.escape(fname)}</button>"
+        )
+    parts.append("</div>")
+
+    # Tab panels
+    for idx, (fname, content) in enumerate(log_files):
+        display = "" if idx == 0 else ' style="display:none"'
+        escaped = html_module.escape(content)
+        parts.append(f'<div class="tab-panel"{display}>')
+        parts.append(f'<pre class="log-content">{escaped}</pre>')
+        parts.append("</div>")
+
+    parts.append("</div>")
+    parts.append("</details>")
+    return "".join(parts)
+
+
+def parse_env():
+    timestamp = DATA.get("timestamp", "?")
+    env = DATA.get("env", {})
+    arch = env.get("architecture", "?")
+    os = env.get("os_name") + " " + env.get("os_release")
+    pyver = env.get("python", "?")
+    torch_obj = env.get("torch", {})
+    torch_ver = torch_obj.get("version", "?")
+    flagtree_ver = env.get("flagtree", "?")
+    triton_ver = env.get("triton", {}).get("version", "?")
+    flaggems_ver = env.get("flaggems_vllm", {}).get("version", "?")
+    flaggems_vendor = env.get("flaggems_vllm", {}).get("vendor", "?")
+    flaggems_device = env.get("flaggems_vllm", {}).get("device", "?")
+
+    lines = []
+    lines.append("<h3>Test Environment</h3>")
+    lines.append("<table>")
+    lines.append("<thead><tr><th>Env</th><th>Setting</th></tr></thead>")
+    lines.append("<tbody>")
+    lines.append(f"<tr><td>Time</td><td><tt>{timestamp}</tt></td></tr>")
+    lines.append(f"<tr><td>Architecture</td><td><tt>{arch}</tt></td></tr>")
+    lines.append(f"<tr><td>OS</td><td><tt>{os}</tt></td></tr>")
+    lines.append(f"<tr><td>Python</td><td><tt>{pyver}</tt></td></tr>")
+    lines.append(f"<tr><td>Torch</td><td><tt>{torch_ver}</tt></td></tr>")
+    lines.append(f"<tr><td>FlagTree</td><td><tt>{flagtree_ver}</tt></td></tr>")
+    lines.append(f"<tr><td>Triton</td><td><tt>{triton_ver}</tt></td></tr>")
+    lines.append(f"<tr><td>FlagGems-vllm</td><td><tt>{flaggems_ver}</tt></td></tr>")
+    lines.append(f"<tr><td>Vendor</td><td><tt>{flaggems_vendor}</tt></td></tr>")
+    lines.append(f"<tr><td>Device</td><td><tt>{flaggems_device}</tt></td></tr>")
+    lines.append("</tbody>")
+    lines.append("</table>")
+
+    return lines
+
+
+def parse_single_accuracy_details(fmt, details, num, kind):
+    lines = []
+    if num == 0:
+        return lines
+
+    lines.append(f"#### {kind.title()} Cases")
+    lines.append("")
+
+    for reason, cases in details.get(kind, {}).items():
+        reason_strs = reason.split("\n")
+        lines.append("- **Reason**")
+        lines.append("")
+        for s in reason_strs:
+            lines.append(f"  > {s}")
+        lines.append("")
+        lines.append("  **Test cases**")
+        lines.append("")
+        for case in cases:
+            lines.append(f"  - `{case}`")
+        lines.append("")
+
+    return lines
+
+
+def parse_single_accuracy(fmt, op_data):
+    lines = []
+
+    lines.append("<h3>Accuracy Result</h3>")
+    lines.append("<h4>Summary</h4>")
+    lines.append("<table>")
+    lines.append("<thead><tr>")
+    lines.append("<th>Status</th><th>Duration (s)</th><th>Total</th>")
+    lines.append("<th>Passed</th><th>Skipped</th><th>Failed</th>")
+    lines.append("</tr></thead>")
+    lines.append("<tbody>")
+    lines.append(f"<tr><td>{op_data.get('status', '?')}</td>")
+    lines.append(f"<td>{op_data.get('duration', '?')}</td>")
+    lines.append(f"<td>{op_data.get('total', 0)}</td>")
+    lines.append(f"<td>{op_data.get('passed', 0)}</td>")
+    skipped = op_data.get("skipped", 0)
+    lines.append(f"<td>{skipped}</td>")
+    failed = op_data.get("failed", 0)
+    lines.append(f"<td>{failed}</td></tr>")
+    lines.append("</tbody>")
+    lines.append("</table>")
+
+    # Append failed and skipped cases if any
+    details = op_data.get("details", {})
+    f_lines = parse_single_accuracy_details(fmt, details, failed, "failed")
+    lines.extend(f_lines)
+    k_lines = parse_single_accuracy_details(fmt, details, skipped, "skipped")
+    lines.extend(k_lines)
+
+    return lines
+
+
+def parse_data():
+    lines = parse_lines()
+    header_fields = (
+        [
+            "No.",
+            "ID",
+            "AccRes",
+            "AccStat(pass/fail/skip)",
+            "PerfRes",
+            "OPAverageSpeedUp",
+        ]
+        + list(consts.DTYPE_MAP.values())
+        + ["Note"]
+    )
+
+    # Add sequence number to each sorted line
+    numbered_lines = []
+    for idx, line in enumerate(lines, 1):
+        seq = str(idx)
+        # Add sticky classes to No. and ID (first two) columns
+        row = line.replace(
+            "<tr>",
+            f'<tr><td class="sticky-col sticky-col-0">{seq}</td>',
+            1,
+        )
+        # Add sticky class to the original first <td> (now ID column)
+        row = row.replace("<td>", '<td class="sticky-col sticky-col-1">', 1)
+        numbered_lines.append(row)
+
+    return _build_styled_html_table(header_fields, numbered_lines)
+
+
+def _build_styled_html_table(header_fields, data_rows):
+    """Build the main HTML table with filter/sort controls and sticky columns."""
+    # Column indices (0-based): 0=No., 1=ID, 2=AccRes, 3=AccStat, 4=PerfRes, 5=OPAverageSpeedUp, ...
+    acc_col = 2
+    perf_col = 4
+    avg_col = 5
+
+    # Collect unique values for filter dropdowns from data rows
+    acc_values = set()
+    perf_values = set()
+    for row in data_rows:
+        cells = _extract_html_cells(row)
+        if len(cells) > acc_col:
+            val = _strip_html_tags(cells[acc_col])
+            if val:
+                acc_values.add(val)
+        if len(cells) > perf_col:
+            val = _strip_html_tags(cells[perf_col])
+            if val:
+                perf_values.add(val)
+
+    total = len(data_rows)
+    lines = [
+        f'<div class="table-stats">Total: <span id="total-count">{total}</span>'
+        f' | Showing: <span id="visible-count">{total}</span></div>',
+        '<div class="table-wrapper">',
+        '<table id="main-table">',
+        "<thead>",
+        "<tr>",
+    ]
+    for i, field in enumerate(header_fields):
+        cls = (
+            ' class="sticky-col sticky-col-0"'
+            if i == 0
+            else (' class="sticky-col sticky-col-1"' if i == 1 else "")
+        )
+        if i == acc_col:
+            select = _build_filter_select("accFilter", sorted(acc_values))
+            lines.append(f"<th{cls}>{field}<br>{select}</th>")
+        elif i == perf_col:
+            select = _build_filter_select("perfFilter", sorted(perf_values))
+            lines.append(f"<th{cls}>{field}<br>{select}</th>")
+        elif i == avg_col:
+            lines.append(
+                f"<th{cls}>{field}<br>"
+                f'<button class="sort-btn" onclick="sortTable({avg_col}, \'asc\')">&#9650;</button>'
+                f'<button class="sort-btn" onclick="sortTable({avg_col}, \'desc\')">&#9660;</button>'
+                f'<button class="sort-btn" onclick="sortTable({avg_col}, \'reset\')">&#8634;</button>'
+                f"</th>"
+            )
+        else:
+            lines.append(f"<th{cls}>{field}</th>")
+    lines.extend(["</tr>", "</thead>", "<tbody>"])
+    lines.extend(data_rows)
+    lines.extend(["</tbody>", "</table>", "</div>"])
+    return lines
+
+
+def _build_filter_select(name, values):
+    """Build a <select> dropdown for filtering."""
+    opts = ['<option value="">All</option>']
+    for v in values:
+        escaped = html_module.escape(v)
+        opts.append(f'<option value="{escaped}">{escaped}</option>')
+    return f'<select class="filter-select" onchange="filterTable()">{" ".join(opts)}</select>'
+
+
+def _extract_html_cells(row_html):
+    """Extract cell inner HTML from a <tr>...</tr> string."""
+    return re.findall(r"<td[^>]*>(.*?)</td>", row_html, re.DOTALL)
+
+
+def _strip_html_tags(s):
+    """Strip HTML tags to get plain text for filter matching."""
+    # For <details><summary>TEXT</summary>...</details>, extract summary text
+    m = re.search(r"<summary>(.*?)</summary>", s)
+    if m:
+        return re.sub(r"<[^>]+>", "", m.group(1)).strip()
+    return re.sub(r"<[^>]+>", "", s).strip()
+
+
+def main():
+    global DATA
+    global DATA_DIR
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dir", default="result", help="the data directory to process")
+    parser.add_argument(
+        "-o", "--output", default="<stdout>", help="path to the output file."
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action=argparse.BooleanOptionalAction,
+        help="flag for printing verbose information for debugging",
+    )
+    args = parser.parse_args()
+
+    data_path = Path(args.dir) / "summary.json"
+    DATA, res = load_data(data_path)
+    if not res:
+        return 1
+
+    DATA_DIR = args.dir
+
+    result_heading = ["<h3>Test Result</h3>"]
+    lines = parse_env() + result_heading + parse_data()
+    lines = wrap_html(lines)
+
+    # never dump debug information to result file
+    if args.output == "<stdout>" or args.debug:
+        for ln in lines:
+            print(ln)
+    else:
+        with open(args.output, "w") as f:
+            for ln in lines:
+                f.write(ln + "\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/psum_text
+++ b/tools/psum_text
@@ -1,0 +1,582 @@
+#!/usr/bin/env python
+
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+DTYPE_MAP = {
+    "torch.float16": "fp16",
+    "torch.float32": "fp32",
+    "torch.bfloat16": "bf16",
+    "torch.complex64": "cf64",
+    "torch.int16": "int16",
+    "torch.int32": "int32",
+    "torch.int8": "int8",
+    "torch.uint8": "uint8",
+    "torch.int64": "int64",
+    "torch.bool": "bool",
+    "torch.float8_e4m3fn": "f8-e4m3fn",
+    "torch.float8_e5m2": "f8-e5m2",
+}
+DATA = {}
+DEBUG = False
+DATA_DIR = None
+ARGS = argparse.Namespace()
+
+
+def load_data(data_path):
+    try:
+        with data_path.open("r") as f:
+            data = json.load(f)
+        return data, True
+    except Exception as ex:
+        print(f"Failed to load data: {ex}")
+    return {}, False
+
+
+def format_record(fields):
+    if ARGS.format == "csv":
+        return ",".join(fields)
+
+    # markdown
+    line = " | ".join(fields)
+    return f"| {line} |"
+
+
+def parse_env():
+    if ARGS.compare:
+        env = DATA["before"].get("env", {})
+    else:
+        env = DATA.get("env", {})
+
+    arch = env.get("architecture", "?")
+    os = env.get("os_name", "") + " " + env.get("os_release", "")
+    pyver = env.get("python", "?")
+    torch_obj = env.get("torch", {})
+    torch_ver = torch_obj.get("version", "?")
+    flagtree_ver = env.get("flagtree", "?")
+    triton_ver = env.get("triton", {}).get("version", "?")
+    flaggems_vendor = env.get("flaggems_vllm", {}).get("vendor", "?")
+    flaggems_device = env.get("flaggems_vllm", {}).get("device", "?")
+    if ARGS.compare:
+        ts1 = DATA["before"].get("timestamp", "?")
+        ts2 = DATA["after"].get("timestamp", "?")
+        timestamp = f"{ts1} -> {ts2}"
+        env1 = env
+        env2 = DATA["after"].get("env", {})
+        ver1 = env1.get("flaggems_vllm", {}).get("version", "?")
+        ver2 = env2.get("flaggems_vllm", {}).get("version", "?")
+        flaggems_ver = f"{ver1} -> {ver2}"
+    else:
+        timestamp = DATA.get("timestamp", "?")
+        flaggems_ver = env.get("flaggems_vllm", {}).get("version", "?")
+
+    lines = []
+    if ARGS.format == "markdown":
+        lines.append("### Test Environment")
+        lines.append("")
+        lines.append("| Env | Setting | Env | Setting |")
+        lines.append("| --- | ------- | ----| --------|")
+        lines.append(
+            f"| **Time** | `{timestamp}` | **FlagGems-vllm** | `{flaggems_ver}` |"
+        )
+        lines.append(f"| **Arch** | `{arch}` | **OS** | `{os}` |")
+        lines.append(f"| **Python** | `{pyver}` | **Torch** | `{torch_ver}` |")
+        lines.append(
+            f"| **FlagTree** | `{flagtree_ver}` | **Triton** | `{triton_ver}` |"
+        )
+        lines.append(
+            f"| **Vendor** | `{flaggems_vendor}`| **Device** | `{flaggems_device}` |"
+        )
+        lines.append("")
+
+    return lines
+
+
+def parse_single_accuracy_details(details, kind, case):
+    lines = []
+    lines.append(f"#### {kind.title()} Cases {case}")
+    lines.append("")
+
+    for reason, cases in details.get(kind, {}).items():
+        reason_strs = reason.split("\n")
+        lines.append("- **Reason**")
+        lines.append("")
+        for s in reason_strs:
+            lines.append(f"  > {s}")
+        lines.append("")
+        lines.append("  **Test cases**")
+        lines.append("")
+        for case in cases:
+            lines.append(f"  - `{case}`")
+        lines.append("")
+
+    return lines
+
+
+def parse_single_accuracy():
+    def _compose_summary(op_data):
+        s = op_data.get("status", "?")
+        d = op_data.get("duration", 0)
+        t = op_data.get("total", 0)
+        p = op_data.get("passed", 0)
+        k = op_data.get("skipped", 0)
+        f = op_data.get("failed", 0)
+        if s == "Passed":
+            s = f"<span style='color:Green'>{s}</span>"
+        else:
+            s = f"<span style='color:Red'>{s}</span>"
+        p = f"<span style='color:Green'>{p}</span>"
+        k = f"<span style='color:DeepPink'>{k}</span>"
+        f = f"<span style='color:Red'>{f}</span>"
+        return f"| {s} | {d:6.2f} sec | {t} | {p} | {k} | {f} |"
+
+    if ARGS.compare:
+        data1 = DATA["before"].get("result", {})
+        data2 = DATA["after"].get("result", {})
+    else:
+        data1 = DATA.get("result", {})
+        data2 = {}
+
+    if not data1 and not data2:
+        return ["### Accuracy Result", "", "*No accuracy data collected!*", ""]
+
+    op = list(data1.keys())[0] if data1 else list(data2.keys())[0]
+    op_data1 = data1.get(op, {}).get("accuracy", {})
+    op_data2 = {}
+    if ARGS.compare:
+        op_data2 = data2.get(op, {}).get("accuracy", {})
+
+    lines = []
+    lines.append("### Accuracy Result")
+    lines.append("")
+    lines.append("#### Summary")
+    lines.append("")
+    if ARGS.compare:
+        line0 = "| Case | Status | Duration | Total | Passed | Skipped | Failed |"
+        line1 = "|------|--------|----------|-------|--------|---------|--------|"
+    else:
+        line0 = "| Status | Duration | Total | Passed | Skipped | Failed |"
+        line1 = "|--------|----------|-------|--------|---------|--------|"
+    lines.append(line0)
+    lines.append(line1)
+    summary1 = _compose_summary(op_data1)
+    if not ARGS.compare:
+        lines.append(summary1)
+    else:
+        lines.append("| **Before** " + summary1)
+        summary2 = _compose_summary(op_data2)
+        lines.append("| **After** " + summary2)
+
+    lines.append("")
+
+    # Append failed and skipped cases if any, for the first run
+    details = op_data1.get("details", {})
+    case = " Before" if ARGS.compare else ""
+    if op_data1.get("failed", 0) > 0:
+        f_lines = parse_single_accuracy_details(details, "failed", case)
+        lines.extend(f_lines)
+    if op_data1.get("skipped", 0) > 0:
+        k_lines = parse_single_accuracy_details(details, "skipped", case)
+        lines.extend(k_lines)
+
+    if not ARGS.compare:
+        return lines
+
+    details = op_data2.get("details", {})
+    if op_data2.get("failed", 0) > 0:
+        f_lines = parse_single_accuracy_details(details, "failed", " After")
+        lines.extend(f_lines)
+    if op_data2.get("skipped", 0) > 0:
+        k_lines = parse_single_accuracy_details(details, "skipped", " After")
+        lines.extend(k_lines)
+
+    return lines
+
+
+def parse_single_performance():
+    def _get_summary(op_data, case=None):
+        status = op_data.get("status", "OK")
+        duration = op_data.get("duration", 0)
+        if status in ["Skipped", "Failed"]:
+            reason = op_data.get("reason", "Unknown")
+            reason = "<blockquote>" + reason.replace("\n", "<br/>") + "</blockquote>"
+            if status == "Failed":
+                status = "<span style='color:Red'>Failed</span>"
+            else:
+                status = "<span style='color:DeepPink'>Skipped</span>"
+            line = f"| {status} | {duration:6.2f} seconds | {reason} |"
+        elif status == "NotFound":
+            status = f"<span style='color:Gray'>{status}</span>"
+            line = f"| {status} | {duration:6.2f} seconds | *No test case found.* |"
+        else:
+            status = f"<span style='color:Green'>{status}</span>"
+            line = f"| {status} | {duration:6.2f} seconds | *All tests completed.* |"
+
+        if case is None:
+            return line
+
+        return f"| **{case}** {line}"
+
+    if ARGS.compare:
+        data1 = DATA["before"].get("result", {})
+        data2 = DATA["after"].get("result", {})
+    else:
+        data1 = DATA.get("result", {})
+        data2 = {}
+
+    if not data1 and not data2:
+        return ["### Performance Result", "", "*No performance data collected!*", ""]
+
+    op = list(data1.keys())[0] if data1 else list(data2.keys())[0]
+    op_data1 = data1.get(op, {}).get("performance", {})
+    op_data2 = {}
+    if ARGS.compare:
+        op_data2 = data2.get(op, {}).get("performance", {})
+
+    lines = []
+    lines.append("### Performance Result")
+    lines.append("")
+    lines.append("#### Summary")
+    lines.append("")
+    if ARGS.compare:
+        lines.append("| Case | Status | Duration | Reason |")
+        lines.append("|------|--------|----------|--------|")
+    else:
+        lines.append("| Status | Duration | Reason |")
+        lines.append("|--------|----------|--------|")
+
+    if ARGS.compare:
+        lines.append(_get_summary(op_data1, "Before"))
+        lines.append(_get_summary(op_data2, "After"))
+    else:
+        lines.append(_get_summary(op_data1))
+
+    lines.append("")
+
+    lines.append("#### Benchmark data")
+    lines.append("")
+
+    perf_data1 = op_data1.get("data", {})
+    perf_data2 = {}
+    if ARGS.compare:
+        perf_data2 = op_data2.get("data", {})
+    if not perf_data1 and not perf_data2:
+        lines.append("*No performance data collected!*")
+        return lines
+
+    lines.append("| Dtype  | Speedup | Base | Gems  | Shape |")
+    lines.append("|--------|---------|------|-------|-------|")
+    for dtype, ddata1 in perf_data1.items():
+        ddata2 = perf_data2.get(dtype, {})
+        speedup1 = ddata1.get("speedup", 0)
+        if ARGS.compare:
+            speedup2 = ddata2.get("speedup", 0)
+            spd_str = f"**{speedup1:.3f} -> {speedup2:.3f}**"
+            if speedup2 > speedup1:
+                spd_str = f"<span style='color:Green'>**{spd_str}**</span>"
+            else:
+                spd_str = f"<span style='color:Red'>**{spd_str}**</span>"
+
+            line = f"| {dtype} | {spd_str} | - | - | - |"
+        else:
+            line = f"| {dtype} | **{speedup1:.3f}** | - | - | - |"
+        lines.append(line)
+
+        for shp, res1 in ddata1.get("details", {}).items():
+            s1 = res1.get("speedup", 0)
+            b1 = res1.get("base", 0)
+            g1 = res1.get("gems", 0)
+
+            if ARGS.compare and shp in ddata2.get("details", {}):
+                res2 = ddata2.get("details").get(shp)
+                s2 = res2.get("speedup", 0)
+                b2 = res2.get("base", 0)
+                g2 = res2.get("gems", 0)
+
+                spd_str = f"{s1:.3f} -> {s2:.3f}"
+                if s2 > s1:
+                    spd_str = f"<span style='color:Green'>{spd_str}</span>"
+                else:
+                    spd_str = f"<span style='color:Red'>{spd_str}</span>"
+
+                line = (
+                    f"| | {spd_str} |"
+                    f" {b1:.3f} -> {b2:.3f} |"
+                    f" {g1:.3f} -> {g2:.3f} |"
+                    f" `{shp}` |"
+                )
+            else:
+                line = f"| | {s1:6.3f} | {b1:6.3f} | {g1:6.3f} | `{shp}` |"
+
+            lines.append(line)
+
+        # Deal with case where dtype in _after_ but not in _before_
+        if ARGS.compare:
+            for shp, res2 in ddata2.get("details", {}).items():
+                if shp in ddata1.get("details", {}):
+                    continue
+                s2 = res2.get("speedup", 0)
+                b2 = res2.get("base", 0)
+                g2 = res2.get("gems", 0)
+                line = (
+                    f"| | 0 -> {s2:.3f} |"
+                    f" 0 -> {b2:.3f} |"
+                    f" 0 -> {g2:.3f} |"
+                    f" `{shp}` |"
+                )
+                lines.append(line)
+
+    # Handle dtypes that only exist in the 'after' data
+    if ARGS.compare:
+        for dtype, ddata2 in perf_data2.items():
+            if dtype in perf_data1:
+                continue
+            speedup2 = ddata2.get("speedup", 0)
+            spd_str = f"**0 -> {speedup2:.3f}**"
+            spd_str = f"<span style='color:Green'>**{spd_str}**</span>"
+            line = f"| {dtype} | {spd_str} | - | - | - |"
+            lines.append(line)
+
+            for shp, res2 in ddata2.get("details", {}).items():
+                s2 = res2.get("speedup", 0)
+                b2 = res2.get("base", 0)
+                g2 = res2.get("gems", 0)
+                line = (
+                    f"| | 0 -> {s2:.3f} |"
+                    f" 0 -> {b2:.3f} |"
+                    f" 0 -> {g2:.3f} |"
+                    f" `{shp}` |"
+                )
+                lines.append(line)
+
+    lines.append("")
+    return lines
+
+
+def parse_lines():
+    """Write result.
+
+    The layout is as follows:
+    <id>,<astatus>,<pass/fail/skip>,<pstatus>,[<metric for each dtype>],<note>
+    """
+    data = DATA.get("result", {})
+    lines = []
+    for op, item in data.items():
+        if ARGS.debug:
+            print(f"[DEBUG] processing {op}", file=sys.stderr)
+
+        fields = []
+        accu = item["accuracy"]["status"]
+        accud = "/".join(
+            [
+                str(item["accuracy"]["passed"]),
+                str(item["accuracy"]["failed"]),
+                str(item["accuracy"]["skipped"]),
+            ]
+        )
+        fields.extend([op, accu, accud])
+
+        perf_data = item["performance"]["data"]
+        perf_status = item["performance"]["status"]
+        if perf_status == "NotFound":
+            fields.append("NotFound")
+            fields.extend([""] * (len(DTYPE_MAP) + 1))
+
+        elif perf_status in ["Failed", "Skipped"]:
+            reason = item["performance"]["reason"]
+            reason = reason.split("\n")[0]
+            fields.append(perf_status)
+            fields.extend([""] * (len(DTYPE_MAP)))
+            fields.append(f'"{reason}"')
+
+        else:
+            fields.append(perf_status)
+            metric_list = []
+            for dtype in list(DTYPE_MAP.values()):
+                dobj = perf_data.get(dtype, {})
+
+                if ARGS.metric == "speedup":
+                    # Process `speedup`
+                    metric = dobj.get("speedup", None)
+                else:
+                    # Process `base` by averaging across all shapes
+                    total = 0
+                    count = 0
+                    for sdata in dobj.get("details", {}).values():
+                        total += sdata.get("base", 0)
+                        count += 1
+
+                    if count == 0:
+                        metric = None
+                    else:
+                        metric = total / count
+
+                if metric is None:
+                    fields.append("")
+                else:
+                    fields.append(f"{metric:.3f}")
+                    metric_list.append(metric)
+
+            if len(metric_list) > 0:
+                metric_avg = sum(metric_list) / len(metric_list)
+                fields.append(f"{metric_avg:.3f}")
+            else:
+                fields.append("")
+            # The note column
+            fields.append("")
+
+        lines.append(format_record(fields))
+
+    return sorted(lines)
+
+
+def parse_single():
+    lines = []
+    lines.extend(parse_single_accuracy())
+    lines.extend(parse_single_performance())
+    return lines
+
+
+def parse_multi():
+    lines = parse_lines()
+    header_fields = (
+        [
+            "No.",
+            "ID",
+            "AccRes",
+            "AccStat(pass/fail/skip)",
+            "PerfRes",
+        ]
+        + list(DTYPE_MAP.values())
+        + ["PerfAvg", "Note"]
+    )
+
+    # Add sequence number to each sorted line
+    numbered_lines = []
+    for idx, line in enumerate(lines, 1):
+        seq = str(idx)
+        if ARGS.format == "csv":
+            numbered_lines.append(seq + "," + line)
+        else:
+            numbered_lines.append(f"| {seq} {line}")
+    lines = numbered_lines
+
+    if ARGS.format == "csv":
+        lines.insert(0, ",".join(header_fields))
+    else:  # fmt == markdown
+        header = "|" + "----|" * len(header_fields)
+        lines.insert(0, header)
+        header = "| " + " | ".join(header_fields) + " |"
+        lines.insert(0, header)
+
+    return lines
+
+
+def main():
+    global DATA
+    global ARGS
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dir", default="result", help="the data directory to process")
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=["csv", "markdown"],
+        default="csv",
+        help="the output format",
+    )
+    parser.add_argument(
+        "-o", "--output", default="<stdout>", help="path to the output file."
+    )
+    parser.add_argument(
+        "--single",
+        action=argparse.BooleanOptionalAction,
+        help="only parse the result from the first operator",
+    )
+    parser.add_argument(
+        "-c",
+        "--compare",
+        action=argparse.BooleanOptionalAction,
+        help="parse data for comparison",
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action=argparse.BooleanOptionalAction,
+        help="flag for printing verbose information for debugging",
+    )
+    parser.add_argument(
+        "-m",
+        "--metric",
+        choices=["speedup", "base"],
+        default="speedup",
+        help="metric to summarize from the summary JSON",
+    )
+
+    ARGS = parser.parse_args()
+    if ARGS.compare and not ARGS.single:
+        print("Error: --compare can only be used with --single.")
+        return 1
+    if ARGS.format == "csv" and ARGS.single:
+        print("Error: --single mode only supports markdown.")
+        return 1
+
+    if not ARGS.compare:
+        data_path = Path(ARGS.dir) / "summary.json"
+        DATA, res = load_data(data_path)
+        if not res:
+            return 1
+    else:
+        data_path1 = data_path = Path(ARGS.dir) / "before" / "summary.json"
+        before, res = load_data(data_path1)
+        if not res:
+            return 1
+        data_path2 = data_path = Path(ARGS.dir) / "after" / "summary.json"
+        after, res = load_data(data_path2)
+        DATA = {
+            "before": before,
+            "after": after,
+        }
+
+    lines = parse_env()
+    if ARGS.format == "markdown":
+        lines.append("")
+        lines.append("### Test Result")
+        lines.append("")
+
+    if ARGS.single:
+        lines += parse_single()
+    else:
+        lines += parse_multi()
+
+    # never dump debug information to result file
+    if ARGS.output == "<stdout>":
+        for ln in lines:
+            print(ln)
+    else:
+        with open(ARGS.output, "w") as f:
+            for ln in lines:
+                f.write(ln + "\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/psum_web
+++ b/tools/psum_web
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+STATUS_NORMALIZE = {
+    "pass": "Passed",
+    "passed": "Passed",
+    "fail": "Failed",
+    "failed": "Failed",
+    "error": "Error",
+    "notfound": "NotFound",
+    "skipped": "Skipped",
+    "timeout": "Timeout",
+}
+
+
+def parse_dir_name(name):
+    """Parse directory name into (platform, compiler, date)."""
+    m = re.match(r"^(.+)-(\w+)-(\d+)$", name)
+    if m:
+        return m.group(1), m.group(2), m.group(3)
+    m = re.match(r"^(.+)-(\d{4,})$", name)
+    if m:
+        return m.group(1), None, m.group(2)
+    return name, None, ""
+
+
+def select_best_dirs(raw_dir):
+    """Select one directory per platform: prefer flagtree, fallback to triton, latest date."""
+    raw_path = Path(raw_dir)
+    if not raw_path.is_dir():
+        return []
+
+    # Group by (platform, compiler), keep latest date
+    groups = {}
+    for d in sorted(raw_path.iterdir()):
+        if not d.is_dir():
+            continue
+        if not (d / "summary.json").exists():
+            continue
+        platform, compiler, date = parse_dir_name(d.name)
+        key = (platform, compiler)
+        if key not in groups or date > groups[key][1]:
+            groups[key] = (d, date, compiler)
+
+    # Per platform, prefer flagtree over triton over others
+    platform_best = {}
+    for (platform, compiler), (d, date, comp) in groups.items():
+        if platform not in platform_best:
+            platform_best[platform] = (d, comp, date)
+        else:
+            existing_comp = platform_best[platform][1]
+            if existing_comp != "flagtree" and comp == "flagtree":
+                platform_best[platform] = (d, comp, date)
+            elif existing_comp not in ("flagtree", "triton") and comp == "triton":
+                platform_best[platform] = (d, comp, date)
+
+    return [
+        (platform, d, comp) for platform, (d, comp, _) in sorted(platform_best.items())
+    ]
+
+
+def convert_summary(data_dir, platform, compiler):
+    """Convert a summary.json to the Hugo data format."""
+    summary_path = Path(data_dir) / "summary.json"
+    data = json.loads(summary_path.read_text())
+
+    timestamp = data.get("timestamp", "")
+    result = data.get("result", {})
+
+    operators = []
+    for op, item in sorted(result.items()):
+        acc = item.get("accuracy", {})
+        acc_status = acc.get("status", "Unknown")
+        acc_status = STATUS_NORMALIZE.get(acc_status.lower(), acc_status)
+
+        perf = item.get("performance", {})
+        perf_status = perf.get("status", "Unknown")
+        perf_status = STATUS_NORMALIZE.get(perf_status.lower(), perf_status)
+
+        row = {
+            "id": op,
+            "accuracy": acc_status,
+            "acc_passed": acc.get("passed", 0),
+            "acc_failed": acc.get("failed", 0),
+            "acc_skipped": acc.get("skipped", 0),
+            "perf_status": perf_status,
+        }
+
+        perf_data = perf.get("data", {})
+        if not isinstance(perf_data, dict):
+            perf_data = {}
+        for dtype in ["fp16", "fp32", "bf16"]:
+            spd = perf_data.get(dtype, {}).get("speedup")
+            row[dtype] = round(spd, 3) if spd is not None else None
+
+        # Extract note from failure/skip reasons
+        note = ""
+        if perf_status in ("Failed", "Skipped") and perf.get("reason"):
+            note = perf["reason"].split("\n")[0]
+        elif acc_status == "Failed":
+            details = acc.get("details", {})
+            for reason in details.get("failed", {}):
+                note = reason.split("\n")[0]
+                break
+        elif acc.get("skipped", 0) > 0 and acc.get("passed", 0) == 0:
+            details = acc.get("details", {})
+            for reason in details.get("skipped", {}):
+                note = reason.split("\n")[0]
+                break
+        row["note"] = note
+
+        operators.append(row)
+
+    return {
+        "platform": platform,
+        "compiler": compiler,
+        "timestamp": timestamp,
+        "operators": operators,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert summary.json files to Hugo data JSON for the docs site"
+    )
+    parser.add_argument(
+        "--raw-dir",
+        required=True,
+        help="directory containing per-platform result directories",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        default="docs/benchmark",
+        help="output directory for JSON files",
+    )
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    selections = select_best_dirs(args.raw_dir)
+    if not selections:
+        print("No data directories found.", file=sys.stderr)
+        return 1
+
+    for platform, data_dir, compiler in selections:
+        try:
+            result = convert_summary(data_dir, platform, compiler)
+            out_path = output_dir / f"{platform}.json"
+            out_path.write_text(json.dumps(result, indent=2))
+            print(f"  {out_path} ({compiler})")
+        except Exception as ex:
+            print(f"  Error processing {data_dir}: {ex}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -1,0 +1,1341 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -*- coding: utf-8 -*-
+"""
+run_tests.py - FlagGems Operator Accuracy & Performance Automated Test Scheduler
+=================================================================================
+
+Overview
+--------
+This script batch-runs FlagGems operator accuracy tests and performance benchmarks.
+It supports multi-GPU parallel scheduling: each GPU corresponds to a worker process
+that pulls operators from a shared queue and sequentially runs pytest accuracy tests
+and benchmark tests.
+
+When stdout is a TTY, a live-refreshing display with GPU status lines is shown;
+when output is redirected, it falls back to plain line-by-line output without ANSI
+colors.
+
+Operator Source
+---------------
+By default, the operator list is read from conf/operators.yaml and filtered by
+stage (alpha/beta/stable). You can also explicitly specify operators via --ops or
+--op-list-file.
+
+Output Structure
+----------------
+All test results are written to the directory specified by --output-dir
+(default: logs_results_YYYYMMDD_HHMM). Directory layout::
+
+    <output-dir>/
+    ├── summary.json              # Aggregated results (with env info)
+    ├── summary0.json             # Intermediate results for GPU0
+    ├── summary1.json             # Intermediate results for GPU1 (if any)
+    └── <op_name>/
+        ├── accuracy_result.json  # Accuracy test pytest records
+        ├── accuracy_stdout.log   # Accuracy test stdout (requires --dump-output)
+        ├── accuracy_stderr.log   # Accuracy test stderr (requires --dump-output)
+        ├── performance_result.json
+        ├── performance_stdout.log
+        └── performance_stderr.log
+
+CLI Arguments
+-------------
+  --ops OPS           Comma-separated operator ID list. Directly specify which
+                      operators to test, bypassing operators.yaml stage filtering.
+                      Example: --ops "add,mul,softmax"
+
+  --op-list-file FILE Read operator list from file, one ID per line (# = comment).
+                      Mutually exclusive with --ops.
+                      Priority: --ops > --op-list-file > --stages
+
+  --start OP_ID       Start from this operator ID; only test operators with
+                      lexicographic order >= this ID. Useful for resuming.
+
+  --gpus GPUS         Comma-separated GPU ID list, or "all" for all detected GPUs.
+                      Default: "0" (single GPU).
+                      Example: --gpus "0,1,2,3" or --gpus all
+
+  --output-dir DIR    Test results output directory (relative or absolute path).
+                      Default: logs_results_YYYYMMDD_HHMM (current timestamp).
+
+  --stages STAGES     Comma-separated operator stage filter.
+                      Options: alpha, beta, stable, all, removed
+                      Default: "stable" (only test stable-stage operators).
+                      Example: --stages "stable,beta"
+
+  --dump-output       Save each test's stdout/stderr to log files.
+                      Without this flag, subprocess output is discarded.
+
+  --color MODE        ANSI color output mode.
+                      Options: auto (TTY only), always, never
+                      Default: "auto"
+
+Examples
+--------
+  # Run all stable operators on 4 GPUs, saving logs
+  python run_tests.py --gpus 0,1,2,3 --dump-output
+
+  # Test specific operators only
+  python run_tests.py --ops "add,softmax,multinomial" --gpus 0
+
+  # Read operator list from file, use all GPUs
+  python run_tests.py --op-list-file my_ops.txt --gpus all
+
+  # Resume from "mul", test stable+beta stages
+  python run_tests.py --start mul --stages "stable,beta" --gpus 0,1
+
+  # Show help
+  python run_tests.py -h
+"""
+
+import argparse
+import datetime
+import json
+import os
+import platform
+import queue as queue_module
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import types
+from decimal import getcontext
+from importlib import metadata
+from multiprocessing import Process, Queue
+from pathlib import Path
+
+import consts
+import distro
+import yaml
+
+import flaggems_vllm
+
+getcontext().prec = 18
+RED = "\033[31m"
+GREEN = "\033[32m"
+YELLOW = "\033[93m"
+CYAN = "\033[36m"
+DIM = "\033[2m"
+NC = "\033[0m"
+
+ROOT = Path(__file__).parent.parent
+
+OPTS = argparse.Namespace()
+CFG = types.SimpleNamespace()
+
+GLOBAL_RESULTS = {}
+ENV_INFO = {}
+
+TIMEOUT = -100
+WORKER_PROCESSES = []
+INTERRUPTED = False
+
+IS_TTY = sys.stdout.isatty()
+USE_COLORS = IS_TTY
+
+if not USE_COLORS:
+    RED = GREEN = YELLOW = CYAN = DIM = NC = ""
+
+
+def pinfo(msg, **kwargs):
+    print(f"{GREEN}[INFO]{NC} {msg}", flush=True, **kwargs)
+
+
+def perror(msg, **kwargs):
+    print(f"{RED}[ERROR]{NC} {msg}", flush=True, **kwargs)
+
+
+def pwarn(msg, **kwargs):
+    print(f"{YELLOW}[WARN]{NC} {msg}", flush=True, **kwargs)
+
+
+def ensure_dir(p):
+    p.mkdir(parents=True, exist_ok=True)
+    # set directory permissions to 755/0o755 (drwxr-xr-x)
+    p.chmod(0o755)
+
+
+class LiveDisplay:
+    """Manages terminal output with a pinned footer for GPU status lines."""
+
+    def __init__(self, gpu_ids, op_count, op_width=20):
+        self.gpu_ids = gpu_ids
+        self.op_count = op_count
+        self.op_width = op_width
+        self.gpu_index = {gid: i + 1 for i, gid in enumerate(gpu_ids)}
+        # Match progress line width to scrolling log lines (55 + op_width visible chars).
+        # Progress line: "[Progress] [" (12) + bar + "]  " (3) + nums_str
+        nums_width = len(f"{op_count}/{op_count} ops")
+        self.bar_width = max(20, 55 + op_width - 12 - 3 - nums_width)
+        self.nums_width = nums_width
+        progress_line = self._fmt_progress(0)
+        gpu_lines = [f"{DIM}[GPU {gid:2d}] idle{NC}" for gid in gpu_ids]
+        self.footer = [progress_line] + gpu_lines
+        self.n = len(self.footer)
+        self.footer_drawn = False
+
+    def _fmt_progress(self, tests_done):
+        total_tests = self.op_count * 2
+        color = GREEN if tests_done >= total_tests else CYAN
+        bar = (
+            _progress_bar(tests_done, total_tests, self.bar_width, color=color)
+            if self.op_count
+            else " " * self.bar_width
+        )
+        ops_done = tests_done // 2
+        nums = f"{ops_done}/{self.op_count} ops"
+        return f"[Progress] [{color}{bar}{NC}]  {nums:>{self.nums_width}}"
+
+    def _draw_footer(self):
+        if not IS_TTY:
+            return
+        for line in self.footer:
+            sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+        self.footer_drawn = True
+
+    def _erase_footer(self):
+        if not IS_TTY or not self.footer_drawn:
+            return
+        for _ in range(self.n):
+            sys.stdout.write("\033[A\033[2K")
+
+    def init(self):
+        if IS_TTY:
+            self._draw_footer()
+
+    def log(self, msg):
+        """Print a scrolling log line above the footer."""
+        if IS_TTY:
+            self._erase_footer()
+            sys.stdout.write(msg + "\n")
+            self._draw_footer()
+        else:
+            sys.stdout.write(msg + "\n")
+            sys.stdout.flush()
+
+    def update_gpu(self, gpu_id, status_line):
+        """Update a GPU's footer line."""
+        idx = self.gpu_index.get(gpu_id)
+        if idx is None:
+            return
+        self.footer[idx] = status_line
+        if IS_TTY:
+            self._erase_footer()
+            self._draw_footer()
+
+    def update_progress(self, tests_done):
+        """Update the global progress bar."""
+        self.footer[0] = self._fmt_progress(tests_done)
+        if IS_TTY:
+            self._erase_footer()
+            self._draw_footer()
+        else:
+            sys.stdout.write(self.footer[0] + "\n")
+            sys.stdout.flush()
+
+    def finish(self):
+        """Clear the footer when done."""
+        if IS_TTY:
+            self._erase_footer()
+            sys.stdout.flush()
+
+
+def _progress_bar(done, total, width=40, color=""):
+    if not total:
+        return " " * width
+    frac = done * width / total
+    full = int(frac)
+    has_half = (frac - full) >= 0.5 and full < width
+    empty = width - full - (1 if has_half else 0)
+    bar = "█" * full
+    if has_half:
+        bar += f"{DIM}█{NC}{color}"
+    bar += " " * empty
+    return bar
+
+
+def _format_status(status, dur):
+    STATUS_MAP = {
+        "Passed": (GREEN, "OK"),
+        "Failed": (RED, "FAILED"),
+        "Timeout": (RED, "TIMEOUT"),
+        "Error": (RED, "ERROR"),
+        "NotFound": (YELLOW, "NOTFOUND"),
+        "Skipped": (YELLOW, "SKIPPED"),
+    }
+    color, label = STATUS_MAP.get(status, (YELLOW, status.upper()))
+    return f"{color}[{label:<8} {dur:>6.1f}s]{NC}"
+
+
+def get_ops_from_inventory():
+    catalog = []
+    try:
+        op_inventory = ROOT / "conf" / "operators.yaml"
+        with open(str(op_inventory), "r") as f:
+            data = yaml.safe_load(f)
+            catalog = data.get("ops", [])
+    except Exception as e:
+        perror(f"Failed to load operator inventory: {e}")
+    return catalog
+
+
+def _probe_torch():
+    ENV_INFO.setdefault("torch", {})
+    try:
+        import torch
+
+        version = torch.__version__
+        ENV_INFO["torch"]["version"] = version
+        pinfo(f"PyTorch detected ... {version}")
+    except Exception as e:
+        perror(f"pytorch not installed, please fix it - {e}")
+        sys.exit(-1)
+
+    try:
+        cuda_available = torch.cuda.is_available()
+        ENV_INFO["torch"]["cuda_available"] = cuda_available
+        pinfo(f"PyTorch CUDA support ... {cuda_available}")
+    except Exception:
+        ENV_INFO["torch"]["cuda_available"] = False
+
+    try:
+        dev_name = torch.cuda.get_device_name()
+        ENV_INFO["torch"]["device_name"] = dev_name
+        pinfo(f"PyTorch device name ... {dev_name}")
+    except Exception:
+        ENV_INFO["torch"]["device_name"] = "N/A"
+
+    try:
+        dev_count = torch.cuda.device_count()
+        ENV_INFO["torch"]["device_count"] = dev_count
+        pinfo(f"PyTorch device count ... {dev_count}")
+    except Exception:
+        ENV_INFO["torch"]["device_count"] = 0
+        dev_count = 0
+
+    if dev_count > 0:
+        return
+
+    try:
+        # Is this a TsingMicro chip?
+        import torch_txda
+
+        dev_count = torch_txda.device_count()
+
+        ENV_INFO["torch"]["device_count"] = dev_count
+        pinfo(f"TorchTXDA device count ... {dev_count}")
+    except Exception:
+        pass
+
+    try:
+        # Is this a Ascend chip?
+        import torch.npu
+
+        dev_count = torch.npu.device_count()
+
+        ENV_INFO["torch"]["device_count"] = dev_count
+        pinfo(f"Torch NPU device count ... {dev_count}")
+    except Exception:
+        pass
+
+
+def _probe_triton():
+    try:
+        version = metadata.version("flagtree")
+        ENV_INFO["flagtree"] = version
+        pinfo(f"FlagTree (flagtree) detected ... {version}")
+        has_flagtree = True
+    except Exception:
+        has_flagtree = False
+        ENV_INFO["flagtree"] = None
+        pwarn("FlagTree (flagtree) not installed, testing Triton ...")
+
+    try:
+        import triton
+
+        version = triton.__version__
+        ENV_INFO["triton"] = {"version": version}
+        pinfo(f"Triton (triton) detected ... {version}")
+
+        if version:
+            has_config = hasattr(triton, "Config")
+            ENV_INFO["triton"]["has_config"] = has_config
+            pinfo(f"Triton (triton) has Config ... [{has_config}]")
+    except Exception:
+        ENV_INFO["triton"] = None
+        if not has_flagtree:
+            perror("Neither FlagTree nor Triton is installed, please fix it.")
+            sys.exit(-1)
+
+
+def _probe_flaggems():
+    try:
+        version = flaggems_vllm.__version__
+        ENV_INFO["flaggems_vllm"] = {"version": version}
+        pinfo(f"flaggems_vllm detected ... {version}")
+    except Exception as e:
+        perror(f"{e}")
+        perror("flaggems_vllm has not been installed, please run `uv pip install -e .`")
+        sys.exit(-1)
+
+    try:
+        vendor = flaggems_vllm.vendor_name
+        ENV_INFO["flaggems_vllm"]["vendor"] = vendor
+        pinfo(f"flaggems_vllm vendor detection ... {vendor}")
+    except Exception as e:
+        perror(f"{e}")
+        perror("flaggems_vllm failed to detect vendor info.`")
+        sys.exit(-1)
+
+    try:
+        device = flaggems_vllm.device
+        ENV_INFO["flaggems_vllm"]["device"] = device
+        pinfo(f"flaggems_vllm device detection ... {device}")
+    except Exception as e:
+        perror(f"{e}")
+        perror("flaggems_vllm failed to detect device info.`")
+        sys.exit(-1)
+
+
+def _probe_vllm():
+    try:
+        import vllm
+
+        version = vllm.__version__
+        ENV_INFO["vllm"] = {"version": version}
+        pinfo(f"vllm detected ... {version}")
+    except ImportError:
+        ENV_INFO["vllm"] = {"version": None}
+        pwarn(
+            "vllm is NOT installed (some ops like grouped_topk/topk_softmax may skip)"
+        )
+    except Exception as e:
+        ENV_INFO["vllm"] = {"version": None}
+        pwarn(f"vllm detection failed: {e}")
+
+
+def probe_env():
+    ENV_INFO["architecture"] = platform.machine()
+    ENV_INFO["os_name"] = distro.id()
+    ENV_INFO["os_release"] = distro.version()
+    ENV_INFO["python"] = platform.python_version()
+
+    _probe_torch()
+    _probe_triton()
+    _probe_flaggems()
+    _probe_vllm()
+
+
+def get_env(gpu_ids):
+    env = os.environ.copy()
+    vendor = ENV_INFO.get("flaggems_vllm", {}).get("vendor", "")
+
+    vendor_env_map = {
+        "ascend": ["ASCEND_RT_VISIBLE_DEVICES", "NPU_VISIBLE_DEVICES"],
+        "hygon": ["HIP_VISIBLE_DEVICES"],
+        "metax": ["MACA_VISIBLE_DEVICES"],
+        "mthreads": ["MUSA_VISIBLE_DEVICES"],
+        "tsingmicro": ["TXDA_VISIBLE_DEVICES"],
+        "iluvatar": ["ILUVATAR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"],
+        "thead": ["CUDA_VISIBLE_DEVICES"],
+        "cambricon": ["MLU_VISIBLE_DEVICES"],
+        "kunlunxin": ["CUDA_VISIBLE_DEVICES"],
+        "sunrise": ["TANG_VISIBLE_DEVICES"],
+        "enflame": ["TOPS_VISIBLE_DEVICES"],
+    }
+
+    env_vars = vendor_env_map.get(vendor, None)
+    # new vendor not in the map, fallback to CUDA_VISIBLE_DEVICES with a warning
+    if env_vars is None:
+        pwarn(
+            f"No vendor-specific device masking for '{vendor}', falling back to  CUDA_VISIBLE_DEVICES"
+        )
+        env_vars = ["CUDA_VISIBLE_DEVICES"]
+    for var in env_vars:
+        env[var] = gpu_ids
+    return env
+
+
+def run_cmd(op, cmd, cwd=None, env=None, timeout=600, flavor=None):
+    stdout = subprocess.DEVNULL
+    stderr = subprocess.DEVNULL
+    if CFG.dump_output:
+        op_dir = CFG.output_dir.joinpath(op)
+        stdout_log = str(op_dir / f"{flavor}_stdout.log")
+        stderr_log = str(op_dir / f"{flavor}_stderr.log")
+        try:
+            stdout = open(stdout_log, "w")
+            stderr = open(stderr_log, "w")
+            # Log the executed command to stderr log for debugging
+            stderr.write(f"[CMD] {cmd}\n")
+            stderr.write(f"[CWD] {cwd}\n\n")
+            stderr.flush()
+        except Exception:
+            pass
+
+    p = subprocess.Popen(
+        shlex.split(cmd),
+        cwd=cwd,
+        env=env,
+        stdout=stdout,
+        stderr=stderr,
+        start_new_session=True,
+    )
+
+    try:
+        p.wait(timeout=timeout)
+        return p.returncode
+    except subprocess.TimeoutExpired:
+        pgid = os.getpgid(p.pid)
+        try:
+            os.killpg(pgid, signal.SIGTERM)
+        except ProcessLookupError:
+            return TIMEOUT
+        try:
+            p.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        return TIMEOUT
+    except Exception as e:
+        perror(f"run_cmd failed: {e}")
+        return -1
+    finally:
+        if stdout != subprocess.DEVNULL:
+            stdout.close()
+        if stderr != subprocess.DEVNULL:
+            stderr.close()
+
+
+def parse_accuracy_data(result_file):
+    raw_data = {}
+    try:
+        with result_file.open("r") as f:
+            raw_data = json.load(f)
+    except (json.JSONDecodeError, ValueError):
+        return {
+            "total": 0,
+            "skipped": 0,
+            "failed": 0,
+            "passed": 0,
+            "status": "Error",
+            "details": {"error": f"Invalid JSON in {result_file}"},
+        }
+
+    passed = []
+    skipped = {}
+    failed = {}
+    num_skipped = 0
+    num_failed = 0
+    num_passed = 0
+    skipped_with_issue = False
+    for test_case, item in raw_data.items():
+        case_str = test_case[: test_case.find("[")]
+        result = item.get("result", "")
+        params = [case_str]
+        for k, v in item.get("params", {}).items():
+            params.append(str(v).replace(" ", ""))
+        param_str = ":".join(params)
+
+        if result == "passed":
+            passed.append(param_str)
+            num_passed += 1
+        elif result == "skipped":
+            reason = item.get("reason", "Unknown")
+            if "Issue" in reason:
+                skipped_with_issue = True
+            skipped.setdefault(reason, set())
+            skipped[reason].add(param_str)
+            num_skipped += 1
+        else:
+            reason = item.get("reason", "Unknown")
+            failed.setdefault(reason, set())
+            failed[reason].add(param_str)
+            num_failed += 1
+
+    num_total = num_passed + num_skipped + num_failed
+    result = {
+        "total": num_total,
+        "skipped": num_skipped,
+        "failed": num_failed,
+        "passed": num_passed,
+        "details": {},
+    }
+    if len(skipped) == 0 and len(failed) == 0:
+        if len(passed) == 0:
+            result["status"] = "NotFound"
+        else:
+            result["status"] = "Passed"
+        return result
+
+    if num_failed > 0:
+        result["status"] = "Failed"
+        for k, v in failed.items():
+            failed[k] = list(v)
+        result["details"]["failed"] = failed
+        return result
+
+    # Some tests skipped but none failed.
+    # If there are also passing tests, treat overall status as Passed
+    # (e.g. to_copy skips "same dtype conversion" but other cases pass).
+    if num_passed > 0:
+        result["status"] = "Passed"
+    elif skipped_with_issue:
+        result["status"] = "Failed"
+    else:
+        result["status"] = "Skipped"
+
+    for k, v in skipped.items():
+        skipped[k] = list(v)
+    result["details"]["skipped"] = skipped
+    return result
+
+
+def parse_perf_data(op, result_file):
+    raw_data = {}
+    try:
+        with result_file.open("r") as f:
+            raw_data = json.load(f)
+    except (json.JSONDecodeError, ValueError):
+        return {
+            "status": "Error",
+            "reason": f"Invalid JSON in {result_file}",
+        }
+
+    data = raw_data.get(op, {})
+    if not data:
+        return {"status": "NotFound"}
+
+    result = data.get("result", "NotFound")
+    if result in ["failed", "skipped"]:
+        return {
+            "status": result.title(),
+            "reason": data.get("reason", "Unknown"),
+            "test_case": data.get("test_case", "Unknown"),
+        }
+
+    bench_res = {}
+    records = data.get("details", [])
+
+    for item in records:
+        dtype = consts.DTYPE_MAP.get(item["dtype"], item["dtype"])
+        details = {}
+        total = 0.0
+        count = 0
+        for res in item.get("result", []):
+            shape = str(res.get("shape_detail", "Unknown")).replace(" ", "")
+            details.setdefault(shape, {})
+            details[shape]["base"] = res.get("latency_base", 0.0)
+            details[shape]["gems"] = res.get("latency", 0.0)
+            speedup = res.get("speedup", 0.0)
+            details[shape]["speedup"] = speedup
+            count += 1
+            total += speedup
+
+        if details:
+            bench_res[dtype] = {
+                "result": "OK",
+                "details": details,
+                "speedup": total / count,
+            }
+        else:
+            bench_res[dtype] = {
+                "result": "Unknown",
+                "details": {},
+                "speedup": 0,
+            }
+
+    return {
+        "status": result.title(),
+        "data": bench_res,
+        "test_case": data.get("test_case", "Unknown"),
+    }
+
+
+def run_accuracy_q(gpu_id, op):
+    """Run accuracy test for one op. Returns result dict."""
+    env = get_env(str(gpu_id))
+
+    base = f'pytest -m "{op}" --record json --output accuracy_{op}.json'
+    if op not in CFG.skip_cpu_tests:
+        base += " --ref cpu"
+    cmd = base + " --continue-on-collection-errors -vs"
+
+    accuracy_dir = ROOT.joinpath("tests")
+    result_file = accuracy_dir / f"accuracy_{op}.json"
+    if result_file.exists():
+        result_file.unlink()
+
+    op_dir = CFG.output_dir.joinpath(op)
+    ensure_dir(op_dir)
+    dur = time.time()
+    code = run_cmd(op, cmd, cwd=accuracy_dir, env=env, flavor="accuracy")
+    dur = time.time() - dur
+
+    if code == TIMEOUT:
+        return {
+            "status": "Timeout",
+            "exit_code": TIMEOUT,
+            "total": 0,
+            "passed": 0,
+            "failed": 0,
+            "skipped": 0,
+            "errors": 0,
+            "duration": dur,
+        }
+
+    if not result_file.exists():
+        return {
+            "status": "Error",
+            "exit_code": code,
+            "total": 0,
+            "passed": 0,
+            "failed": 0,
+            "skipped": 0,
+            "errors": 1,
+            "duration": dur,
+            "data_file": None,
+        }
+
+    op_dir = CFG.output_dir.joinpath(op)
+    dest = op_dir / "accuracy_result.json"
+    shutil.move(result_file, str(dest))
+    result_file = dest
+
+    result = parse_accuracy_data(result_file)
+    result["exit_code"] = code
+    result["duration"] = dur
+    result["data_file"] = str(result_file.relative_to(CFG.output_dir))
+    return result
+
+
+def run_benchmark_q(gpu_id, op):
+    """Run benchmark for one op. Returns result dict."""
+    env = get_env(str(gpu_id))
+
+    benchmark_dir = ROOT / "benchmark"
+    result_file = benchmark_dir / f"benchmark_{op}.json"
+    if result_file.exists():
+        result_file.unlink()
+
+    op_dir = CFG.output_dir.joinpath(op)
+    ensure_dir(op_dir)
+
+    dur = time.time()
+    cmd = f'pytest -m "{op}" --level core --record json --output benchmark_{op}.json --continue-on-collection-errors'
+    code = run_cmd(op, cmd, cwd=benchmark_dir, env=env, flavor="performance")
+    dur = time.time() - dur
+
+    if code == TIMEOUT:
+        return {
+            "status": "Timeout",
+            "exit_code": TIMEOUT,
+            "duration": dur,
+            "data": {},
+        }
+
+    if not result_file.exists():
+        return {
+            "status": "NotFound",
+            "duration": dur,
+            "exit_code": code,
+            "data": {},
+        }
+
+    dest = op_dir / "performance_result.json"
+    shutil.move(result_file, str(dest))
+    result_file = dest
+
+    record = {
+        "duration": dur,
+        "exit_code": code,
+        "data_file": str(result_file.relative_to(CFG.output_dir)),
+        "data": {},
+    }
+    record.update(parse_perf_data(op, result_file))
+    return record
+
+
+def worker_proc(gpu_id, work_queue, display_queue):
+    # Suppress direct stdout/stderr from worker processes to prevent
+    # corrupting the main process's terminal cursor positioning.
+    sys.stdout = open(os.devnull, "w")
+    sys.stderr = open(os.devnull, "w")
+
+    notfound_result = {
+        "status": "NotFound",
+        "exit_code": 0,
+        "total": 0,
+        "passed": 0,
+        "failed": 0,
+        "skipped": 0,
+        "duration": 0,
+    }
+
+    worker_result = {}
+    while True:
+        try:
+            op = work_queue.get_nowait()
+        except queue_module.Empty:
+            break
+        op = op.strip()
+        if not op:
+            continue
+
+        op_dir = CFG.output_dir.joinpath(op)
+        ensure_dir(op_dir)
+
+        if op in CFG.accuracy_marks:
+            display_queue.put(("start", gpu_id, "accuracy", op))
+            acc = run_accuracy_q(gpu_id, op)
+            display_queue.put(
+                (
+                    "done",
+                    gpu_id,
+                    "accuracy",
+                    op,
+                    acc.get("status", "Error"),
+                    acc.get("duration", 0),
+                )
+            )
+        else:
+            acc = notfound_result
+            display_queue.put(("done", gpu_id, "accuracy", op, "NotFound", 0))
+
+        if op in CFG.benchmark_marks:
+            display_queue.put(("start", gpu_id, "benchmark", op))
+            perf = run_benchmark_q(gpu_id, op)
+            display_queue.put(
+                (
+                    "done",
+                    gpu_id,
+                    "benchmark",
+                    op,
+                    perf.get("status", "Error"),
+                    perf.get("duration", 0),
+                )
+            )
+        else:
+            perf = {"status": "NotFound", "exit_code": 0, "duration": 0, "data": {}}
+            display_queue.put(("done", gpu_id, "benchmark", op, "NotFound", 0))
+
+        customized_ops = [
+            o[0] for o in flaggems_vllm.runtime.backend.get_customized_ops()
+        ]
+        result = {
+            "customized": op in customized_ops,
+            "accuracy": acc,
+            "performance": perf,
+        }
+        worker_result.setdefault(op, result)
+
+        json_path = CFG.output_dir.joinpath(f"summary{gpu_id}.json")
+        tmp_path = json_path.with_suffix(".tmp")
+        with open(tmp_path, "w") as f:
+            json.dump(worker_result, f, indent=2)
+        os.replace(tmp_path, json_path)
+
+    display_queue.put(("exit", gpu_id))
+
+
+def display_loop(queue, display, n_workers):
+    exited = 0
+    tests_done = 0
+    per_gpu_done = {gid: 0 for gid in display.gpu_ids}
+
+    while exited < n_workers:
+        try:
+            msg = queue.get(timeout=1)
+        except Exception:
+            continue
+
+        kind = msg[0]
+
+        if kind == "exit":
+            gpu_id = msg[1]
+            n = per_gpu_done.get(gpu_id, 0)
+            display.update_gpu(gpu_id, f"{DIM}[GPU {gpu_id:2d}] done ({n} ops){NC}")
+            exited += 1
+
+        elif kind == "start":
+            _, gpu_id, phase, op = msg
+            label = "accuracy " if phase == "accuracy" else "benchmark"
+            op_display = (
+                op
+                if len(op) <= display.op_width
+                else op[: display.op_width - 3] + "..."
+            )
+            op_col = op_display.ljust(display.op_width)
+            n = per_gpu_done.get(gpu_id, 0)
+            if IS_TTY:
+                display.update_gpu(
+                    gpu_id,
+                    f"[GPU {gpu_id:2d}] ({n:>3} done)  {label} {op_col}",
+                )
+            else:
+                ts = datetime.datetime.now().strftime("%H:%M:%S")
+                display.log(f"[INFO] [{ts}][GPU {gpu_id:2d}]" f" {label} {op_col} ...")
+
+        elif kind == "done":
+            _, gpu_id, phase, op, status, dur = msg
+            ts = datetime.datetime.now().strftime("%H:%M:%S")
+            label = "accuracy " if phase == "accuracy" else "benchmark"
+            op_display = (
+                op
+                if len(op) <= display.op_width
+                else op[: display.op_width - 3] + "..."
+            )
+            op_col = op_display.ljust(display.op_width)
+            status_str = _format_status(status, dur)
+            log_line = (
+                f"{GREEN}[INFO]{NC} [{ts}][GPU {gpu_id:2d}]"
+                f" {label} {op_col} {status_str}"
+            )
+
+            tests_done += 1
+            if phase == "benchmark":
+                per_gpu_done[gpu_id] = per_gpu_done.get(gpu_id, 0) + 1
+
+            ops_done = tests_done // 2
+            total_ops = display.op_count
+            pct = ops_done * 100 // total_ops
+            if not IS_TTY:
+                total_w = len(str(total_ops))
+                log_line += f"  ({pct:>3}% {ops_done:>{total_w}}/{total_ops} ops)"
+
+            # Update progress state BEFORE log so the footer is drawn once
+            # with the correct progress value.
+            display.footer[0] = display._fmt_progress(tests_done)
+            display.log(log_line)
+
+
+def cleanup_intermediate_files():
+    patterns = [
+        (ROOT / "tests", "accuracy_*.json"),
+        (ROOT / "benchmark", "benchmark_*.json"),
+    ]
+    for directory, pattern in patterns:
+        for f in directory.glob(pattern):
+            try:
+                f.unlink()
+            except OSError:
+                pass
+
+    if hasattr(CFG, "output_dir"):
+        for f in CFG.output_dir.glob("summary*.tmp"):
+            try:
+                f.unlink()
+            except OSError:
+                pass
+
+
+def terminate_workers():
+    for p in WORKER_PROCESSES:
+        if p.is_alive():
+            try:
+                os.killpg(os.getpgid(p.pid), signal.SIGTERM)
+            except (OSError, ProcessLookupError):
+                pass
+    for p in WORKER_PROCESSES:
+        p.join(timeout=5)
+        if p.is_alive():
+            p.kill()
+
+
+def handle_interrupt(signum, frame):
+    global INTERRUPTED
+    if INTERRUPTED:
+        return
+    INTERRUPTED = True
+    if IS_TTY:
+        sys.stdout.write("\n")
+    pwarn("Interrupted. Cleaning up ...")
+    terminate_workers()
+    cleanup_intermediate_files()
+    pwarn("Cleanup done.")
+    sys.exit(1)
+
+
+def get_ops_to_test():
+    op_catalog = get_ops_from_inventory()
+    skip_cpu_tests = []
+    for op in op_catalog:
+        labels = op.get("labels", [])
+        if "NoCPU" in labels:
+            skip_cpu_tests.append(op["id"])
+    CFG.skip_cpu_tests = skip_cpu_tests
+
+    if OPTS.ops:
+        ops = []
+        for op in OPTS.ops.split(","):
+            ops.append(op.strip().lstrip("_"))
+        return ops
+
+    if OPTS.op_list_file:
+        lines = []
+        try:
+            with open(OPTS.op_list_file, "r") as f:
+                lines = f.readlines()
+        except Exception as e:
+            perror(f"Failed reading the specified op list file: {e}")
+            return []
+
+        ops = []
+        for ln in lines:
+            ln = ln.strip()
+            if ln.startswith("#"):
+                continue
+            ops.append(ln.lstrip("_"))
+        return ops
+
+    effective_stages = []
+    for s in OPTS.stages.split(","):
+        stage = s.strip()
+        if stage not in ["alpha", "beta", "stable", "all", "removed"]:
+            pwarn(f"ignoring unsupported stage name '{s}'...")
+            continue
+        if stage == "all":
+            effective_stages = ["alpha", "beta", "stable"]
+            break
+        effective_stages.append(stage)
+
+    if not effective_stages:
+        effective_stages = ["stable"]
+
+    ops = []
+    for op in op_catalog:
+        stages = op.get("stages", [])
+        if len(stages) == 0:
+            continue
+        stage = next(iter(stages[-1].keys()), None)
+        if stage not in effective_stages:
+            continue
+        if OPTS.start is not None and op["id"] < OPTS.start:
+            continue
+        ops.append(op["id"])
+
+    return ops
+
+
+def _parse_marks_file(marks_file):
+    marks = set()
+    try:
+        with open(marks_file, "r") as f:
+            data = yaml.safe_load(f)
+        if data:
+            for item in data:
+                for mark in item.get("marks", []):
+                    marks.add(mark)
+    except Exception as e:
+        pwarn(f"Failed to read or parse marks file {marks_file}: {e}")
+    return marks
+
+
+def collect_marks(ops):
+    if len(ops) <= 10:
+        pinfo(f"Only {len(ops)} operators requested, skipping mark collection")
+        return set(ops), set(ops)
+
+    accuracy_marks = set()
+    benchmark_marks = set()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        acc_file = os.path.join(tmpdir, "accuracy_marks.yaml")
+        bench_file = os.path.join(tmpdir, "benchmark_marks.yaml")
+
+        pinfo("Collecting accuracy test marks ...")
+        subprocess.call(
+            [
+                "pytest",
+                f"--collect-marks={acc_file}",
+                "--continue-on-collection-errors",
+                "tests/",
+            ],
+            cwd=str(ROOT),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if os.path.exists(acc_file):
+            accuracy_marks = _parse_marks_file(acc_file)
+            if accuracy_marks:
+                pinfo(f"Found accuracy tests for {len(accuracy_marks)} operators")
+            else:
+                pwarn("Marks file empty, falling back to all ops for accuracy")
+                accuracy_marks = set(ops)
+        else:
+            pwarn(
+                "Failed to collect accuracy marks, all ops will be tested for accuracy"
+            )
+            accuracy_marks = set(ops)
+
+        pinfo("Collecting benchmark marks ...")
+        subprocess.call(
+            [
+                "pytest",
+                f"--collect-marks={bench_file}",
+                "--continue-on-collection-errors",
+                "benchmark/",
+            ],
+            cwd=str(ROOT),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if os.path.exists(bench_file):
+            benchmark_marks = _parse_marks_file(bench_file)
+            if benchmark_marks:
+                pinfo(f"Found benchmark tests for {len(benchmark_marks)} operators")
+            else:
+                pwarn("Marks file empty, falling back to all ops for benchmark")
+                benchmark_marks = set(ops)
+        else:
+            pwarn("Failed to collect benchmark marks, all ops will be benchmarked")
+            benchmark_marks = set(ops)
+
+    # Ensure all requested ops are included even if mark collection missed them
+    accuracy_marks.update(ops)
+    benchmark_marks.update(ops)
+    return accuracy_marks, benchmark_marks
+
+
+def main():
+    global OPTS
+
+    signal.signal(signal.SIGINT, handle_interrupt)
+    signal.signal(signal.SIGTERM, handle_interrupt)
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "FlagGems operator accuracy & performance automated test scheduler.\n"
+            "Supports multi-GPU parallel scheduling: each GPU has a worker process\n"
+            "that sequentially runs pytest accuracy tests and benchmark tests.\n"
+            "Operator list defaults to conf/operators.yaml, filtered by --stages."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  python run_tests.py --gpus 0,1,2,3 --dump-output\n"
+            '  python run_tests.py --ops "add,softmax,multinomial" --gpus 0\n'
+            "  python run_tests.py --op-list-file my_ops.txt --gpus all\n"
+            '  python run_tests.py --start mul --stages "stable,beta" --gpus 0,1\n'
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--ops",
+        required=False,
+        metavar="OPS",
+        help=(
+            "Comma-separated operator ID list. Directly specify operators to test, "
+            "bypassing operators.yaml stage filtering. "
+            'Example: --ops "add,mul,softmax"'
+        ),
+    )
+    parser.add_argument(
+        "--op-list-file",
+        required=False,
+        metavar="FILE",
+        help=(
+            "Read operator list from file, one ID per line (# = comment). "
+            "Priority: --ops > --op-list-file > --stages"
+        ),
+    )
+    parser.add_argument(
+        "--start",
+        required=False,
+        metavar="OP_ID",
+        help=(
+            "Start from this operator ID; only test operators with "
+            "lexicographic order >= this ID. Useful for resuming."
+        ),
+    )
+    parser.add_argument(
+        "--gpus",
+        default="0",
+        metavar="GPUS",
+        help=(
+            'Comma-separated GPU ID list, or "all" for all detected GPUs. '
+            'Default: "0" (single GPU). Example: --gpus "0,1,2,3"'
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        metavar="DIR",
+        help=(
+            "Test results output directory (relative or absolute path). "
+            "Default: logs_results_YYYYMMDD_HHMM"
+        ),
+    )
+    parser.add_argument(
+        "--stages",
+        required=False,
+        default="stable",
+        metavar="STAGES",
+        help=(
+            "Comma-separated operator stage filter. "
+            "Options: alpha, beta, stable, all, removed. "
+            'Default: "stable". Example: --stages "stable,beta"'
+        ),
+    )
+    parser.add_argument(
+        "--dump-output",
+        action="store_true",
+        default=False,
+        help="Save each test's stdout/stderr to log files (default: discard)",
+    )
+    parser.add_argument(
+        "--color",
+        choices=["auto", "always", "never"],
+        default="auto",
+        help="ANSI color output mode: auto (TTY only), always, never. Default: auto",
+    )
+    OPTS = parser.parse_args()
+    CFG.dump_output = OPTS.dump_output
+    CFG.start = OPTS.start
+
+    # Apply color mode (IS_TTY controls cursor-based footer, USE_COLORS controls ANSI colors)
+    global USE_COLORS, RED, GREEN, YELLOW, CYAN, DIM, NC
+    if OPTS.color == "always":
+        USE_COLORS = True
+        RED, GREEN, YELLOW, CYAN, DIM, NC = (
+            "\033[31m",
+            "\033[32m",
+            "\033[93m",
+            "\033[36m",
+            "\033[2m",
+            "\033[0m",
+        )
+    elif OPTS.color == "never":
+        USE_COLORS = False
+        RED = GREEN = YELLOW = CYAN = DIM = NC = ""
+
+    # ---- Record the start time of the whole test run ----
+    # Kept as a datetime object so the total elapsed time can be computed
+    # once all accuracy/benchmark tests finish.
+    test_start_time = datetime.datetime.now()
+    pinfo(f"Test started at ... {test_start_time.strftime('%Y-%m-%d %H:%M:%S')}")
+
+    probe_env()
+
+    ops = get_ops_to_test()
+    op_count = len(ops)
+    if op_count == 0:
+        pwarn("No operators to test. Please specify at lease one operator.")
+        sys.exit(1)
+    pinfo(f"Testing {op_count} operators ...")
+
+    CFG.accuracy_marks, CFG.benchmark_marks = collect_marks(ops)
+
+    CFG.ops = ops
+
+    if OPTS.output_dir is None:
+        output_dir = Path(
+            f"logs_results_{datetime.datetime.now().strftime('%Y%m%d_%H%M')}"
+        )
+    else:
+        output_dir = Path(OPTS.output_dir)
+    ensure_dir(output_dir)
+    CFG.output_dir = output_dir
+
+    if OPTS.gpus.strip().lower() == "all":
+        dev_count = ENV_INFO.get("torch", {}).get("device_count", 0)
+        if dev_count == 0:
+            perror("--gpus all specified but no devices detected.")
+            sys.exit(1)
+        gpu_ids = list(range(dev_count))
+    else:
+        gpu_list = OPTS.gpus.strip().split(",")
+        if len(gpu_list) == 0:
+            pwarn("Empty GPU list specified.")
+            sys.exit(1)
+        gpu_ids = [int(x) for x in gpu_list if x.strip()]
+    gpu_count = len(gpu_ids)
+
+    # Don't spawn more workers than there are ops to test
+    if gpu_count > op_count:
+        gpu_ids = gpu_ids[:op_count]
+        gpu_count = op_count
+
+    op_width = min(max(len(op) for op in ops), 40) if ops else 20
+
+    work_queue = Queue()
+    for op in ops:
+        work_queue.put(op)
+
+    display_queue = Queue()
+    display = LiveDisplay(gpu_ids, op_count, op_width=op_width)
+
+    for gpu in gpu_ids:
+        p = Process(target=worker_proc, args=(gpu, work_queue, display_queue))
+        p.start()
+        WORKER_PROCESSES.append(p)
+
+    display.init()
+    display_loop(display_queue, display, gpu_count)
+
+    for p in WORKER_PROCESSES:
+        p.join()
+
+    display.finish()
+
+    # ---- Record the end time of the whole test run ----
+    # Replaces the old `timestamp`; the run's end time is stored directly as
+    # `end_time` in summary.json and reused for the elapsed-time calculation.
+    test_end_time = datetime.datetime.now()
+
+    # Total wall-clock time the whole run took (start -> end).
+    total_duration = round((test_end_time - test_start_time).total_seconds(), 2)
+    total_duration_str = str(datetime.timedelta(seconds=int(total_duration)))
+
+    op_data = {}
+    for gpu_id in gpu_ids:
+        gpu_file = CFG.output_dir.joinpath(f"summary{gpu_id}.json")
+        if not gpu_file.exists():
+            perror(f"GPU {gpu_id} failed to produce a summary, recovery needed.")
+            continue
+        with gpu_file.open("r") as f:
+            try:
+                result = json.load(f)
+            except (json.JSONDecodeError, ValueError):
+                perror(f"GPU {gpu_id} summary is invalid JSON, skipping.")
+                continue
+            op_data.update(result)
+
+    final_data = {
+        "timestamp": test_end_time.strftime("%Y-%m-%d %H:%M:%S"),
+        "total_duration": total_duration_str,
+        "env": ENV_INFO,
+        "result": op_data,
+    }
+
+    json_path = CFG.output_dir.joinpath("summary.json")
+    with json_path.open("w") as f:
+        json.dump(final_data, f, indent=2)
+
+    cleanup_intermediate_files()
+    pinfo(f"Total elapsed time ... {total_duration_str} ({total_duration}s)")
+    pinfo("Test completed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### PR Category
CI/CD, User Experience

### Type of Change
New Feature

### Description

This PR ports the test execution and reporting toolchain from the FlagGems repository to FlagGems-vllm, adapting all references to use `flaggems_vllm` instead of `flag_gems`.

**Added files:**
- `tools/run_tests.py` — main test runner with pytest orchestration, environment detection, and result aggregation
- `tools/psum_html`, `tools/psum_text`, `tools/psum_web` — test result summary generators (HTML, markdown, web server)
- `tools/consts.py` — shared DTYPE_MAP constant
- `tools/html_assets/` — CSS and JavaScript assets for HTML reports

**Code adaptations:**
- All Python imports changed from `import flag_gems` to `import flaggems_vllm`
- All module attribute accesses updated (`flaggems_vllm.__version__`, `.vendor_name`, `.device`, `.runtime.backend.get_customized_ops()`)
- `ENV_INFO` dictionary keys changed from `"flag_gems"` to `"flaggems_vllm"` for consistency across summary.json write/read
- User-facing display labels in reports changed to "FlagGems-vllm" to distinguish from FlagGems test results

**Dependency update:**
- Added `distro>=1.9.0` to `[project.optional-dependencies].test` (required by run_tests.py for OS detection via `distro.id()` and `distro.version()`)

**Verification:**
- All 5 Python files pass syntax validation
- File structure matches FlagGems repo layout (all tools under `tools/`)
- Diff against FlagGems source shows only the intended renames plus two black-compliant line breaks
- Ready for H800 test run to validate end-to-end functionality

### Issue

This change enables consistent test execution and reporting infrastructure for FlagGems-vllm, matching the workflow established in the parent FlagGems repository.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

H800 validation test pending — will be run post-PR to confirm all operators execute correctly with the ported tooling.