### PR TITLE
[KMCompiler]Fused moe metax mc550

### DIFF
--- a/src/flaggems_vllm/runtime/backend/_metax/fused/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/fused/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+from .fused_moe import fused_experts_impl, inplace_fused_experts, outplace_fused_experts
+
+__all__ = [
+    "fused_experts_impl",
+    "inplace_fused_experts",
+    "outplace_fused_experts",
+]

--- a/src/flaggems_vllm/runtime/backend/_metax/fused/fused_moe.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/fused/fused_moe.py
@@ -1,0 +1,243 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+import contextlib
+import threading
+from typing import Any
+
+import flaggems_vllm.ops.fused_moe as generic_fused_moe
+
+from .moe_sum import moe_sum as metax_moe_sum
+
+_PATCH_LOCK = threading.RLock()
+_GENERIC_GET_DEFAULT_CONFIG = generic_fused_moe.get_default_config
+_PLAIN_HALF_CONFIG_DTYPES = ("fp16", "bf16")
+_DIRECT_SUM_DISABLED_MIN_TOKENS = 1 << 60
+
+
+def _is_qwen_moe_shape(E, N, K, topk, dtype, gemm_stage):
+    if dtype not in _PLAIN_HALF_CONFIG_DTYPES:
+        return False
+    if E == 512 and topk == 10:
+        return (N, K) == ((2048, 4096) if gemm_stage == "gemm1" else (4096, 1024))
+    if E == 256 and topk == 8:
+        if gemm_stage == "gemm1":
+            return (N, K) in ((1024, 2048), (256, 2048))
+        return (N, K) in ((2048, 512), (2048, 128))
+    return False
+
+
+def _metax_get_default_config(
+    M,
+    E,
+    N,
+    K,
+    topk,
+    dtype,
+    block_shape=None,
+    gemm_stage="gemm1",
+    enable_gemm_fast_path=False,
+):
+    if not _is_qwen_moe_shape(E, N, K, topk, dtype, gemm_stage):
+        return _GENERIC_GET_DEFAULT_CONFIG(
+            M,
+            E,
+            N,
+            K,
+            topk,
+            dtype,
+            block_shape,
+            gemm_stage,
+            enable_gemm_fast_path,
+        )
+
+    if M <= 1024:
+        block_m, block_n, block_k = 16, 128, 64
+        group_m, num_warps, num_stages = 1, 4, 2
+    elif M <= 2048:
+        block_m, block_n, block_k = 64, 128, 64
+        group_m, num_warps, num_stages = 1, 8, 2
+    elif M <= 4096:
+        block_m, block_n, block_k = 64, 256, 32
+        group_m, num_warps, num_stages = 1, 8, 2
+    else:
+        block_m, block_k = 128, 32
+        block_n = 256 if gemm_stage == "gemm2" else 128
+        group_m, num_warps = (1, 8) if M <= 16384 else (8, 8)
+        num_stages = 2 if gemm_stage == "gemm2" else 3
+
+    if gemm_stage == "gemm1" and (E, N, K, topk) == (256, 256, 2048, 8):
+        block_n = min(block_n, 128)
+
+    config = {
+        "BLOCK_SIZE_M": block_m,
+        "BLOCK_SIZE_N": block_n,
+        "BLOCK_SIZE_K": block_k,
+        "GROUP_SIZE_M": group_m,
+        "num_warps": num_warps,
+        "num_stages": num_stages,
+    }
+    if gemm_stage == "gemm1" and (
+        M >= 8192
+        or (M >= 4096 and (E, N, K, topk) == (256, 256, 2048, 8))
+    ):
+        config["PAIR_GATE_UP_DOT"] = True
+
+    shape = (E, N, K, topk)
+    if gemm_stage == "gemm1" and M <= 8 and shape == (512, 2048, 4096, 10):
+        config["SWAP_AB"] = True
+    elif gemm_stage == "gemm2" and M <= 1024:
+        config["SWAP_AB"] = True
+
+    if E == 512:
+        if M in (8192, 16384):
+            config["BLOCK_SIZE_K"] = 16
+        elif M == 32768 and gemm_stage == "gemm1":
+            config["num_stages"] = 2
+    elif M == 4096:
+        config["num_warps"] = 4
+    elif M in (8192, 16384):
+        config["num_warps"] = 4
+        config["num_stages"] = 2
+    elif M == 32768:
+        if (N, K) in ((256, 2048), (2048, 128)):
+            config["BLOCK_SIZE_K"] = 16
+        else:
+            config["num_warps"] = 4
+            config["num_stages"] = 2
+
+    if 4096 <= M < 8192:
+        if shape == (256, 1024, 2048, 8) and gemm_stage == "gemm1":
+            config.update(
+                BLOCK_SIZE_M=64, BLOCK_SIZE_N=256, BLOCK_SIZE_K=32, num_stages=2
+            )
+        elif shape == (256, 2048, 512, 8) and gemm_stage == "gemm2":
+            config.update(
+                BLOCK_SIZE_M=64, BLOCK_SIZE_N=256, BLOCK_SIZE_K=32, num_stages=2
+            )
+    return config
+
+
+def _is_qwen_plain_half_call(args, kwargs):
+    try:
+        hidden_states = args[0] if args else kwargs["hidden_states"]
+        w1 = args[1] if len(args) > 1 else kwargs["w1"]
+        w2 = args[2] if len(args) > 2 else kwargs["w2"]
+        topk_ids = args[4] if len(args) > 4 else kwargs["topk_ids"]
+    except (KeyError, IndexError):
+        return False
+    if str(hidden_states.dtype) not in ("torch.float16", "torch.bfloat16"):
+        return False
+    if topk_ids.ndim != 2:
+        return False
+    return (
+        (tuple(w1.shape), tuple(w2.shape), topk_ids.size(1))
+        in (
+            ((512, 2048, 4096), (512, 4096, 1024), 10),
+            ((256, 1024, 2048), (256, 2048, 512), 8),
+            ((256, 256, 2048), (256, 2048, 128), 8),
+        )
+    )
+
+
+def _router_weight_is_already_applied(args, kwargs, positional_index):
+    if "apply_router_weight_on_input" in kwargs:
+        return bool(kwargs["apply_router_weight_on_input"])
+    if len(args) > positional_index:
+        return bool(args[positional_index])
+    return False
+
+
+def _should_defer_router_weight_to_sum(args, kwargs, positional_index):
+    if not _is_qwen_plain_half_call(args, kwargs):
+        return False
+    if _router_weight_is_already_applied(args, kwargs, positional_index):
+        return False
+
+    hidden_states = args[0] if args else kwargs["hidden_states"]
+    w1 = args[1] if len(args) > 1 else kwargs["w1"]
+    num_tokens = hidden_states.size(0)
+    w1_shape = tuple(w1.shape)
+    if w1_shape == (512, 2048, 4096):
+        return 16 <= num_tokens <= 4096
+    if w1_shape == (256, 1024, 2048):
+        return 8 <= num_tokens <= 8192
+    return num_tokens >= 8
+
+
+@contextlib.contextmanager
+def _metax_moe_config_patch(use_metax, defer_router_weight):
+    if not use_metax:
+        yield
+        return
+    with _PATCH_LOCK:
+        original_get_default_config = generic_fused_moe.get_default_config
+        original_direct_sum_min_tokens = generic_fused_moe.MOE_DIRECT_SUM_MIN_TOKENS
+        original_moe_sum = generic_fused_moe.moe_sum
+        original_dispatch = generic_fused_moe.dispatch_fused_moe_kernel
+        router_weights_for_sum = None
+
+        def metax_dispatch(*dispatch_args, **dispatch_kwargs):
+            nonlocal router_weights_for_sum
+            # Generic GEMM2 uses top_k=1 and out_top_k=the model top-k.  For
+            # the selected MC550 ranges, leave the router weights for moe_sum.
+            positional = list(dispatch_args)
+            top_k = positional[11] if len(positional) > 11 else dispatch_kwargs.get("top_k")
+            topk_weights = (
+                positional[6]
+                if len(positional) > 6
+                else dispatch_kwargs.get("topk_weights")
+            )
+            out_top_k = dispatch_kwargs.get("out_top_k", 1)
+            if defer_router_weight and top_k == 1 and out_top_k in (8, 10):
+                router_weights_for_sum = topk_weights
+                if len(positional) > 10:
+                    positional[10] = False
+                else:
+                    dispatch_kwargs["mul_routed_weight"] = False
+                dispatch_args = tuple(positional)
+            return original_dispatch(*dispatch_args, **dispatch_kwargs)
+
+        def metax_sum(input, output):
+            return metax_moe_sum(input, output, router_weights_for_sum)
+
+        generic_fused_moe.get_default_config = _metax_get_default_config
+        generic_fused_moe.MOE_DIRECT_SUM_MIN_TOKENS = _DIRECT_SUM_DISABLED_MIN_TOKENS
+        generic_fused_moe.dispatch_fused_moe_kernel = metax_dispatch
+        generic_fused_moe.moe_sum = metax_sum
+        try:
+            yield
+        finally:
+            generic_fused_moe.get_default_config = original_get_default_config
+            generic_fused_moe.MOE_DIRECT_SUM_MIN_TOKENS = original_direct_sum_min_tokens
+            generic_fused_moe.moe_sum = original_moe_sum
+            generic_fused_moe.dispatch_fused_moe_kernel = original_dispatch
+
+
+def fused_experts_impl(*args, **kwargs):
+    is_qwen = _is_qwen_plain_half_call(args, kwargs)
+    with _metax_moe_config_patch(
+        is_qwen,
+        _should_defer_router_weight_to_sum(args, kwargs, 7),
+    ):
+        return generic_fused_moe.fused_experts_impl(*args, **kwargs)
+
+
+def inplace_fused_experts(*args, **kwargs):
+    is_qwen = _is_qwen_plain_half_call(args, kwargs)
+    with _metax_moe_config_patch(
+        is_qwen,
+        _should_defer_router_weight_to_sum(args, kwargs, 6),
+    ):
+        return generic_fused_moe.inplace_fused_experts(*args, **kwargs)
+
+
+def outplace_fused_experts(*args, **kwargs):
+    is_qwen = _is_qwen_plain_half_call(args, kwargs)
+    with _metax_moe_config_patch(
+        is_qwen,
+        _should_defer_router_weight_to_sum(args, kwargs, 6),
+    ):
+        return generic_fused_moe.outplace_fused_experts(*args, **kwargs)

--- a/src/flaggems_vllm/runtime/backend/_metax/fused/fused_moe.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/fused/fused_moe.py
@@ -15,31 +15,46 @@ _PATCH_LOCK = threading.RLock()
 _GENERIC_GET_DEFAULT_CONFIG = generic_fused_moe.get_default_config
 _PLAIN_HALF_CONFIG_DTYPES = ("fp16", "bf16")
 _DIRECT_SUM_DISABLED_MIN_TOKENS = 1 << 60
+_ROUTE_WEIGHT_STATE = threading.local()
 
 
-def _is_qwen_moe_shape(E, N, K, topk, dtype, gemm_stage):
+def _is_qwen_moe_shape(
+    E: int,
+    N: int,
+    K: int,
+    topk: int,
+    dtype: str | None,
+    gemm_stage: str,
+) -> bool:
     if dtype not in _PLAIN_HALF_CONFIG_DTYPES:
         return False
+
     if E == 512 and topk == 10:
-        return (N, K) == ((2048, 4096) if gemm_stage == "gemm1" else (4096, 1024))
+        if gemm_stage == "gemm1":
+            return (N, K) == (2048, 4096)
+        if gemm_stage == "gemm2":
+            return (N, K) == (4096, 1024)
+
     if E == 256 and topk == 8:
         if gemm_stage == "gemm1":
             return (N, K) in ((1024, 2048), (256, 2048))
-        return (N, K) in ((2048, 512), (2048, 128))
+        if gemm_stage == "gemm2":
+            return (N, K) in ((2048, 512), (2048, 128))
+
     return False
 
 
 def _metax_get_default_config(
-    M,
-    E,
-    N,
-    K,
-    topk,
-    dtype,
-    block_shape=None,
-    gemm_stage="gemm1",
-    enable_gemm_fast_path=False,
-):
+    M: int,
+    E: int,
+    N: int,
+    K: int,
+    topk: int,
+    dtype: str | None,
+    block_shape: list[int] | None = None,
+    gemm_stage: str = "gemm1",
+    enable_gemm_fast_path: bool = False,
+) -> dict[str, Any]:
     if not _is_qwen_moe_shape(E, N, K, topk, dtype, gemm_stage):
         return _GENERIC_GET_DEFAULT_CONFIG(
             M,
@@ -62,10 +77,20 @@ def _metax_get_default_config(
     elif M <= 4096:
         block_m, block_n, block_k = 64, 256, 32
         group_m, num_warps, num_stages = 1, 8, 2
+    elif M <= 8192:
+        block_m, block_k = 128, 32
+        block_n = 256 if gemm_stage == "gemm2" else 128
+        group_m, num_warps = 1, 8
+        num_stages = 2 if gemm_stage == "gemm2" else 3
+    elif M <= 16384:
+        block_m, block_k = 128, 32
+        block_n = 256 if gemm_stage == "gemm2" else 128
+        group_m, num_warps = 1, 8
+        num_stages = 2 if gemm_stage == "gemm2" else 3
     else:
         block_m, block_k = 128, 32
         block_n = 256 if gemm_stage == "gemm2" else 128
-        group_m, num_warps = (1, 8) if M <= 16384 else (8, 8)
+        group_m, num_warps = 8, 8
         num_stages = 2 if gemm_stage == "gemm2" else 3
 
     if gemm_stage == "gemm1" and (E, N, K, topk) == (256, 256, 2048, 8):
@@ -79,14 +104,13 @@ def _metax_get_default_config(
         "num_warps": num_warps,
         "num_stages": num_stages,
     }
-    if gemm_stage == "gemm1" and (
-        M >= 8192
-        or (M >= 4096 and (E, N, K, topk) == (256, 256, 2048, 8))
-    ):
+    use_pair_gate_up_dot = gemm_stage == "gemm1" and (
+        M >= 8192 or (M >= 4096 and (E, N, K, topk) == (256, 256, 2048, 8))
+    )
+    if use_pair_gate_up_dot:
         config["PAIR_GATE_UP_DOT"] = True
-
-    shape = (E, N, K, topk)
-    if gemm_stage == "gemm1" and M <= 8 and shape == (512, 2048, 4096, 10):
+    swap_ab_shape = (E, N, K, topk)
+    if gemm_stage == "gemm1" and M <= 8 and swap_ab_shape == (512, 2048, 4096, 10):
         config["SWAP_AB"] = True
     elif gemm_stage == "gemm2" and M <= 1024:
         config["SWAP_AB"] = True
@@ -102,47 +126,80 @@ def _metax_get_default_config(
         config["num_warps"] = 4
         config["num_stages"] = 2
     elif M == 32768:
-        if (N, K) in ((256, 2048), (2048, 128)):
+        qwen3_6_i128 = (N, K) in ((256, 2048), (2048, 128))
+        if qwen3_6_i128:
             config["BLOCK_SIZE_K"] = 16
         else:
             config["num_warps"] = 4
             config["num_stages"] = 2
 
     if 4096 <= M < 8192:
-        if shape == (256, 1024, 2048, 8) and gemm_stage == "gemm1":
+        if gemm_stage == "gemm1" and (E, N, K, topk) == (256, 1024, 2048, 8):
             config.update(
-                BLOCK_SIZE_M=64, BLOCK_SIZE_N=256, BLOCK_SIZE_K=32, num_stages=2
+                {
+                    "BLOCK_SIZE_M": 64,
+                    "BLOCK_SIZE_N": 256,
+                    "BLOCK_SIZE_K": 32,
+                    "num_stages": 2,
+                }
             )
-        elif shape == (256, 2048, 512, 8) and gemm_stage == "gemm2":
+        elif gemm_stage == "gemm2" and (E, N, K, topk) == (256, 2048, 512, 8):
             config.update(
-                BLOCK_SIZE_M=64, BLOCK_SIZE_N=256, BLOCK_SIZE_K=32, num_stages=2
+                {
+                    "BLOCK_SIZE_M": 64,
+                    "BLOCK_SIZE_N": 256,
+                    "BLOCK_SIZE_K": 32,
+                    "num_stages": 2,
+                }
             )
     return config
 
 
-def _is_qwen_plain_half_call(args, kwargs):
+def _is_qwen_plain_half_call(args, kwargs) -> bool:
     try:
-        hidden_states = args[0] if args else kwargs["hidden_states"]
+        hidden_states = args[0] if len(args) > 0 else kwargs["hidden_states"]
         w1 = args[1] if len(args) > 1 else kwargs["w1"]
         w2 = args[2] if len(args) > 2 else kwargs["w2"]
         topk_ids = args[4] if len(args) > 4 else kwargs["topk_ids"]
     except (KeyError, IndexError):
         return False
+
     if str(hidden_states.dtype) not in ("torch.float16", "torch.bfloat16"):
         return False
     if topk_ids.ndim != 2:
         return False
-    return (
-        (tuple(w1.shape), tuple(w2.shape), topk_ids.size(1))
-        in (
-            ((512, 2048, 4096), (512, 4096, 1024), 10),
-            ((256, 1024, 2048), (256, 2048, 512), 8),
-            ((256, 256, 2048), (256, 2048, 128), 8),
-        )
+
+    shapes = (tuple(w1.shape), tuple(w2.shape), topk_ids.size(1))
+    return shapes in (
+        ((512, 2048, 4096), (512, 4096, 1024), 10),
+        ((256, 1024, 2048), (256, 2048, 512), 8),
+        ((256, 256, 2048), (256, 2048, 128), 8),
     )
 
 
-def _router_weight_is_already_applied(args, kwargs, positional_index):
+def _use_metax_moe_sum(args, kwargs) -> bool:
+    try:
+        hidden_states = args[0] if len(args) > 0 else kwargs["hidden_states"]
+        w1 = args[1] if len(args) > 1 else kwargs["w1"]
+        w2 = args[2] if len(args) > 2 else kwargs["w2"]
+        topk_ids = args[4] if len(args) > 4 else kwargs["topk_ids"]
+    except (KeyError, IndexError):
+        return False
+
+    if str(hidden_states.dtype) not in ("torch.float16", "torch.bfloat16"):
+        return False
+    if topk_ids.ndim != 2:
+        return False
+
+    shapes = (tuple(w1.shape), tuple(w2.shape), topk_ids.size(1))
+    return shapes in (
+        ((512, 2048, 4096), (512, 4096, 1024), 10),
+        ((256, 1024, 2048), (256, 2048, 512), 8),
+        ((256, 256, 2048), (256, 2048, 128), 8),
+    )
+
+
+def _router_weight_is_already_applied(args, kwargs, positional_index: int) -> bool:
     if "apply_router_weight_on_input" in kwargs:
         return bool(kwargs["apply_router_weight_on_input"])
     if len(args) > positional_index:
@@ -150,13 +207,14 @@ def _router_weight_is_already_applied(args, kwargs, positional_index):
     return False
 
 
-def _should_defer_router_weight_to_sum(args, kwargs, positional_index):
+def _should_defer_router_weight_to_sum(args, kwargs, positional_index: int) -> bool:
+    """Select the backend-only fused GEMM2+weighted-reduction path."""
     if not _is_qwen_plain_half_call(args, kwargs):
         return False
     if _router_weight_is_already_applied(args, kwargs, positional_index):
         return False
 
-    hidden_states = args[0] if args else kwargs["hidden_states"]
+    hidden_states = args[0] if len(args) > 0 else kwargs["hidden_states"]
     w1 = args[1] if len(args) > 1 else kwargs["w1"]
     num_tokens = hidden_states.size(0)
     w1_shape = tuple(w1.shape)
@@ -167,46 +225,64 @@ def _should_defer_router_weight_to_sum(args, kwargs, positional_index):
     return num_tokens >= 8
 
 
+def _is_qwen_gemm2_dispatch(args, kwargs) -> bool:
+    """Identify GEMM2 without relying on a change to generic fused_moe.py."""
+    weights = args[1] if len(args) > 1 else kwargs.get("B")
+    if weights is None:
+        return False
+    return tuple(weights.shape) in (
+        (512, 4096, 1024),
+        (256, 2048, 512),
+        (256, 2048, 128),
+    )
+
+
 @contextlib.contextmanager
-def _metax_moe_config_patch(use_metax, defer_router_weight):
-    if not use_metax:
-        yield
-        return
+def _metax_moe_config_patch(
+    disable_direct_sum: bool,
+    use_metax_moe_sum: bool,
+    defer_router_weight_to_sum: bool,
+):
     with _PATCH_LOCK:
         original_get_default_config = generic_fused_moe.get_default_config
         original_direct_sum_min_tokens = generic_fused_moe.MOE_DIRECT_SUM_MIN_TOKENS
         original_moe_sum = generic_fused_moe.moe_sum
         original_dispatch = generic_fused_moe.dispatch_fused_moe_kernel
-        router_weights_for_sum = None
-
-        def metax_dispatch(*dispatch_args, **dispatch_kwargs):
-            nonlocal router_weights_for_sum
-            # Generic GEMM2 uses top_k=1 and out_top_k=the model top-k.  For
-            # the selected MC550 ranges, leave the router weights for moe_sum.
-            positional = list(dispatch_args)
-            top_k = positional[11] if len(positional) > 11 else dispatch_kwargs.get("top_k")
-            topk_weights = (
-                positional[6]
-                if len(positional) > 6
-                else dispatch_kwargs.get("topk_weights")
-            )
-            out_top_k = dispatch_kwargs.get("out_top_k", 1)
-            if defer_router_weight and top_k == 1 and out_top_k in (8, 10):
-                router_weights_for_sum = topk_weights
-                if len(positional) > 10:
-                    positional[10] = False
-                else:
-                    dispatch_kwargs["mul_routed_weight"] = False
-                dispatch_args = tuple(positional)
-            return original_dispatch(*dispatch_args, **dispatch_kwargs)
-
-        def metax_sum(input, output):
-            return metax_moe_sum(input, output, router_weights_for_sum)
-
         generic_fused_moe.get_default_config = _metax_get_default_config
-        generic_fused_moe.MOE_DIRECT_SUM_MIN_TOKENS = _DIRECT_SUM_DISABLED_MIN_TOKENS
-        generic_fused_moe.dispatch_fused_moe_kernel = metax_dispatch
-        generic_fused_moe.moe_sum = metax_sum
+        if disable_direct_sum:
+            generic_fused_moe.MOE_DIRECT_SUM_MIN_TOKENS = (
+                _DIRECT_SUM_DISABLED_MIN_TOKENS
+            )
+        if use_metax_moe_sum:
+            generic_fused_moe.moe_sum = metax_moe_sum
+        if defer_router_weight_to_sum:
+            _ROUTE_WEIGHT_STATE.router_weights = None
+
+            def dispatch_with_deferred_weight(*dispatch_args, **dispatch_kwargs):
+                if not _is_qwen_gemm2_dispatch(dispatch_args, dispatch_kwargs):
+                    return original_dispatch(*dispatch_args, **dispatch_kwargs)
+                router_weights = (
+                    dispatch_args[6]
+                    if len(dispatch_args) > 6
+                    else dispatch_kwargs.get("topk_weights")
+                )
+                _ROUTE_WEIGHT_STATE.router_weights = router_weights
+                if dispatch_args:
+                    mutable_args = list(dispatch_args)
+                    # dispatch_fused_moe_kernel's mul_routed_weight position.
+                    mutable_args[10] = False
+                    return original_dispatch(*mutable_args, **dispatch_kwargs)
+                dispatch_kwargs["mul_routed_weight"] = False
+                return original_dispatch(**dispatch_kwargs)
+
+            def weighted_metax_moe_sum(input_tensor, output_tensor):
+                router_weights = getattr(_ROUTE_WEIGHT_STATE, "router_weights", None)
+                if router_weights is None:
+                    return original_moe_sum(input_tensor, output_tensor)
+                return metax_moe_sum(input_tensor, output_tensor, router_weights)
+
+            generic_fused_moe.dispatch_fused_moe_kernel = dispatch_with_deferred_weight
+            generic_fused_moe.moe_sum = weighted_metax_moe_sum
         try:
             yield
         finally:
@@ -214,30 +290,35 @@ def _metax_moe_config_patch(use_metax, defer_router_weight):
             generic_fused_moe.MOE_DIRECT_SUM_MIN_TOKENS = original_direct_sum_min_tokens
             generic_fused_moe.moe_sum = original_moe_sum
             generic_fused_moe.dispatch_fused_moe_kernel = original_dispatch
+            if defer_router_weight_to_sum:
+                _ROUTE_WEIGHT_STATE.router_weights = None
 
 
 def fused_experts_impl(*args, **kwargs):
-    is_qwen = _is_qwen_plain_half_call(args, kwargs)
+    is_qwen_half = _is_qwen_plain_half_call(args, kwargs)
     with _metax_moe_config_patch(
-        is_qwen,
+        is_qwen_half,
+        _use_metax_moe_sum(args, kwargs),
         _should_defer_router_weight_to_sum(args, kwargs, 7),
     ):
         return generic_fused_moe.fused_experts_impl(*args, **kwargs)
 
 
 def inplace_fused_experts(*args, **kwargs):
-    is_qwen = _is_qwen_plain_half_call(args, kwargs)
+    is_qwen_half = _is_qwen_plain_half_call(args, kwargs)
     with _metax_moe_config_patch(
-        is_qwen,
+        is_qwen_half,
+        _use_metax_moe_sum(args, kwargs),
         _should_defer_router_weight_to_sum(args, kwargs, 6),
     ):
         return generic_fused_moe.inplace_fused_experts(*args, **kwargs)
 
 
 def outplace_fused_experts(*args, **kwargs):
-    is_qwen = _is_qwen_plain_half_call(args, kwargs)
+    is_qwen_half = _is_qwen_plain_half_call(args, kwargs)
     with _metax_moe_config_patch(
-        is_qwen,
+        is_qwen_half,
+        _use_metax_moe_sum(args, kwargs),
         _should_defer_router_weight_to_sum(args, kwargs, 6),
     ):
         return generic_fused_moe.outplace_fused_experts(*args, **kwargs)

--- a/src/flaggems_vllm/runtime/backend/_metax/fused/moe_sum.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/fused/moe_sum.py
@@ -1,0 +1,109 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flaggems_vllm.ops.moe_sum import moe_sum as generic_moe_sum
+
+logger = logging.getLogger(__name__)
+
+_QWEN_TOPKS = (8, 10)
+_QWEN_HIDDEN_SIZES = (2048, 4096)
+
+
+@triton.jit
+def _qwen_moe_sum_kernel(
+    input_ptr,
+    output_ptr,
+    router_weights_ptr,
+    router_weights_stride_token,
+    router_weights_stride_topk,
+    num_tokens,
+    hidden_size: tl.constexpr,
+    TOPK: tl.constexpr,
+    APPLY_ROUTER_WEIGHT: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    hidden_offsets = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    hidden_mask = hidden_offsets < hidden_size
+    input_base = input_ptr + token_idx * TOPK * hidden_size + hidden_offsets
+    acc = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+    for expert_idx in tl.static_range(0, TOPK):
+        values = tl.load(
+            input_base + expert_idx * hidden_size,
+            mask=hidden_mask,
+            other=0.0,
+        )
+        if APPLY_ROUTER_WEIGHT:
+            router_weight = tl.load(
+                router_weights_ptr
+                + token_idx * router_weights_stride_token
+                + expert_idx * router_weights_stride_topk
+            )
+            values = values.to(tl.float32) * router_weight.to(tl.float32)
+        acc += values.to(tl.float32)
+    output_offsets = token_idx * hidden_size + hidden_offsets
+    tl.store(
+        output_ptr + output_offsets,
+        acc.to(output_ptr.dtype.element_ty),
+        mask=hidden_mask,
+    )
+
+
+def _metax_moe_sum_block_size(hidden_size: int) -> int:
+    if hidden_size <= 256:
+        return 256
+    if hidden_size <= 512:
+        return 512
+    return 1024
+
+
+def moe_sum(
+    input: torch.Tensor,
+    output: torch.Tensor,
+    router_weights: torch.Tensor | None = None,
+):
+    """Use a statically-unrolled reduction for contiguous Qwen MoE outputs."""
+    num_tokens, topk, hidden_size = input.shape
+    if (
+        topk not in _QWEN_TOPKS
+        or hidden_size not in _QWEN_HIDDEN_SIZES
+        or not input.is_contiguous()
+        or not output.is_contiguous()
+    ):
+        assert router_weights is None
+        return generic_moe_sum(input, output)
+
+    if router_weights is not None:
+        assert router_weights.shape == input.shape[:2]
+        router_weights_strides = router_weights.stride()
+    else:
+        router_weights_strides = (0, 0)
+
+    logger.debug("GEMS_METAX QWEN MOE SUM")
+    use_qwen3_5_launch = topk == 10
+    block_size = 256 if use_qwen3_5_launch else _metax_moe_sum_block_size(hidden_size)
+    grid = (num_tokens, triton.cdiv(hidden_size, block_size))
+    launch_kwargs = {"num_warps": 4 if use_qwen3_5_launch else 8}
+    if use_qwen3_5_launch:
+        launch_kwargs["num_stages"] = 1
+    _qwen_moe_sum_kernel[grid](
+        input,
+        output,
+        input if router_weights is None else router_weights,
+        router_weights_strides[0],
+        router_weights_strides[1],
+        num_tokens,
+        hidden_size,
+        TOPK=topk,
+        APPLY_ROUTER_WEIGHT=router_weights is not None,
+        BLOCK_SIZE=block_size,
+        **launch_kwargs,
+    )

--- a/src/flaggems_vllm/runtime/backend/_metax/fused/moe_sum.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/fused/moe_sum.py
@@ -33,6 +33,7 @@ def _qwen_moe_sum_kernel(
     token_idx = tl.program_id(0)
     hidden_offsets = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     hidden_mask = hidden_offsets < hidden_size
+
     input_base = input_ptr + token_idx * TOPK * hidden_size + hidden_offsets
     acc = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
     for expert_idx in tl.static_range(0, TOPK):
@@ -49,6 +50,7 @@ def _qwen_moe_sum_kernel(
             )
             values = values.to(tl.float32) * router_weight.to(tl.float32)
         acc += values.to(tl.float32)
+
     output_offsets = token_idx * hidden_size + hidden_offsets
     tl.store(
         output_ptr + output_offsets,
@@ -80,7 +82,6 @@ def moe_sum(
     ):
         assert router_weights is None
         return generic_moe_sum(input, output)
-
     if router_weights is not None:
         assert router_weights.shape == input.shape[:2]
         router_weights_strides = router_weights.stride()


### PR DESCRIPTION
## Summary

- Add a MetaX-specific Qwen3.6 `fused_moe` path for MC550 without changing the generic NVIDIA implementation.
- Keep the Qwen3.6 real-shape benchmark on bf16 with fixed seeds and CUDA Graph mode.
- Fuse router-weight application into the MetaX `moe_sum` reduction for the supported Qwen half-precision shapes.

## Implementation highlights

- Add a MetaX backend `moe_sum` kernel with statically unrolled top-k reduction and optional router-weight multiplication.
- Apply the MetaX path only to the supported Qwen3.5 and Qwen3.6 half-precision shapes; other shapes and dtypes keep the generic implementation.
- Defer router-weight multiplication from GEMM2 to the final MetaX reduction, avoiding a separate weighted intermediate write.
- Preserve the MC550-specific GEMM tile, warp, stage, PAIR_GATE_UP_DOT, and SWAP_AB selections in the MetaX backend wrapper.
- Keep the generic `src/flaggems_vllm/ops/fused_moe.py` unchanged; backend-specific behavior is selected through a temporary MetaX dispatch/configuration patch.

## Testing

Correctness on MetaX MC550:

    pytest -s tests/test_fused_experts_impl_qwen3_6.py -k qwen3_6

Result: 4 passed.

Performance on MetaX MC550:

    pytest -s benchmark/test_fused_moe.py \
      -k qwen3_6_fused_moe_impl_gems_vs_vllm

Configuration: bf16, fixed seed, CUDA Graph mode, Qwen3.6 `p1024d1024`, `p4096d1024`, and `p32768d1024` scenarios. The test completed with 3 passed in 898.09 seconds. The 64K `p65536d1024` case and the 32K `p32768d1024` case have identical fused_moe shapes, so the 64K case is not benchmarked separately. The benchmark and correctness files are used for validation only and are not part of this code change.

## Performance Results

Speedup is calculated as vLLM latency divided by FlagGems latency. The table combines both Qwen3.6 intermediate sizes (`I=512` and `I=128`) across all three unique p/d scenarios and all 334 measured cases.

| Scope | Cases | Minimum Speedup | Maximum Speedup | Arithmetic Mean Speedup |
| --- | ---: | ---: | ---: | ---: |
| Qwen3.6 `p1024d1024`, `I=512` and `I=128` | 114 | 0.985x | 4.221x | 2.424x |
| Qwen3.6 `p4096d1024`, `I=512` and `I=128` | 114 | 0.989x | 4.225x | 2.413x |
| Qwen3.6 `p32768d1024`, `I=512` and `I=128` | 106 | 0.984x | 4.228x | 2.492x |
| **ALL Qwen3.6 real-shape cases and p/d scenarios** | **334** | **0.984x** | **4.228x** | **2.442x** |

Benchmark details:
[qwen3_6_real_shape_details.xlsx](https://github.com/user-attachments/files/30451346/qwen3_6_real_shape_details.xlsx)
