### PR TITLE
feat: add scaled_int8_quant operator

### DIFF
--- a/accuracy_result.json
+++ b/accuracy_result.json
@@ -29589,5 +29589,10215 @@
       "parallel_nsa"
     ],
     "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-512-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-512-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-512-7]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-512-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "benchmark/test_scaled_int8_quant_perf.py::test_dynamic_scaled_int8_quant_perf": {
+    "params": {},
+    "result": null,
+    "opname": [
+      "scaled_int8_quant"
+    ]
+  },
+  "benchmark/test_scaled_int8_quant_perf.py::test_static_scaled_int8_quant_perf": {
+    "params": {},
+    "result": null,
+    "opname": [
+      "scaled_int8_quant"
+    ]
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-64-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-64-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-64-64]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-64-512]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-64-2048]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-512-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-512-64]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-512-512]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-512-2048]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-1024-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-1024-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-1024-64]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-1024-512]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-1024-2048]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-4096-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-4096-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-4096-64]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-4096-512]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-4096-2048]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-5137-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-5137-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-5137-64]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-5137-512]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-5137-2048]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-8193-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-8193-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-8193-64]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-8193-512]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype0-8193-2048]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-64-1]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-64-7]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-64-64]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-64-512]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-64-2048]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-512-1]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-512-7]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-512-64]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-512-512]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-512-2048]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-1024-1]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-1024-7]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-1024-64]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-1024-512]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-1024-2048]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-4096-1]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-4096-7]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-4096-64]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-4096-512]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-4096-2048]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-5137-1]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-5137-7]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-5137-64]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-5137-512]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-5137-2048]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-8193-1]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-8193-7]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-8193-64]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-8193-512]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_symmetric[dtype1-8193-2048]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-64-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-64-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-64-64]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-64-512]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-64-2048]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-512-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-512-64]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-512-512]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-512-2048]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-1024-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-1024-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-1024-64]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-1024-512]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-1024-2048]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-4096-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-4096-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-4096-64]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-4096-512]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-4096-2048]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-5137-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-5137-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-5137-64]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-5137-512]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-5137-2048]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-8193-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-8193-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-8193-64]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-8193-512]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype0-8193-2048]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-64-1]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-64-7]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-64-64]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-64-512]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-64-2048]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-512-1]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-512-7]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-512-64]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-512-512]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-512-2048]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-1024-1]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-1024-7]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-1024-64]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-1024-512]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-1024-2048]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-4096-1]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-4096-7]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-4096-64]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-4096-512]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-4096-2048]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-5137-1]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-5137-7]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-5137-64]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-5137-512]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-5137-2048]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-8193-1]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-8193-7]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-8193-64]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-8193-512]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant_asymmetric[dtype1-8193-2048]": {
+    "params": {
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-64-1]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-64-7]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-64-64]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-64-512]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-64-2048]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-512-1]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-512-64]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-512-512]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-512-2048]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-1024-1]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-1024-7]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-1024-64]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-1024-512]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-1024-2048]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-4096-1]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-4096-7]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-4096-64]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-4096-512]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-4096-2048]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-5137-1]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-5137-7]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-5137-64]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-5137-512]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-5137-2048]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-8193-1]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-8193-7]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-8193-64]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-8193-512]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype0-8193-2048]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-64-1]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-64-7]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-64-64]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-64-512]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-64-2048]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-512-1]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-512-7]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-512-64]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-512-512]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-512-2048]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-1024-1]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-1024-7]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-1024-64]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-1024-512]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-1024-2048]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-4096-1]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-4096-7]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-4096-64]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-4096-512]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-4096-2048]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-5137-1]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-5137-7]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-5137-64]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-5137-512]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-5137-2048]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-8193-1]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-8193-7]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-8193-64]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-8193-512]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[0.1-dtype1-8193-2048]": {
+    "params": {
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-64-1]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-64-7]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-64-64]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-64-512]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-64-2048]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-512-1]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-512-7]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-512-64]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-512-512]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-512-2048]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-1024-1]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-1024-7]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-1024-64]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-1024-512]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-1024-2048]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-4096-1]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-4096-7]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-4096-64]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-4096-512]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-4096-2048]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-5137-1]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-5137-7]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-5137-64]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-5137-512]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-5137-2048]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-8193-1]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-8193-7]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-8193-64]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-8193-512]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype0-8193-2048]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-64-1]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-64-7]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-64-64]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-64-512]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-64-2048]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-512-1]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-512-7]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-512-64]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-512-512]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-512-2048]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-1024-1]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-1024-7]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-1024-64]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-1024-512]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-1024-2048]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-4096-1]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-4096-7]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-4096-64]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-4096-512]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-4096-2048]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-5137-1]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-5137-7]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-5137-64]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-5137-512]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-5137-2048]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-8193-1]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-8193-7]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-8193-64]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-8193-512]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_symmetric[2.1-dtype1-8193-2048]": {
+    "params": {
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-64-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-64-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-64-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-64-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-64-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-512-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-512-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-512-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-512-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-1024-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-1024-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-1024-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-1024-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-1024-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-4096-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-4096-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-4096-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-4096-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-4096-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-5137-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-5137-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-5137-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-5137-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-5137-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-8193-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-8193-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-8193-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-8193-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype0-8193-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-64-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-64-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-64-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-64-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-64-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-512-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-512-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-512-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-512-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-512-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-1024-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-1024-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-1024-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-1024-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-1024-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-4096-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-4096-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-4096-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-4096-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-4096-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-5137-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-5137-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-5137-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-5137-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-5137-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-8193-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-8193-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-8193-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-8193-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-0.1-dtype1-8193-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-64-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-64-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-64-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-64-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-64-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-512-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-512-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-512-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-512-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-512-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-1024-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-1024-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-1024-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-1024-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-1024-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-4096-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-4096-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-4096-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-4096-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-4096-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-5137-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-5137-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-5137-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-5137-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-5137-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-8193-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-8193-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-8193-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-8193-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype0-8193-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-64-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-64-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-64-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-64-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-64-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-512-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-512-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-512-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-512-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-512-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-1024-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-1024-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-1024-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-1024-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-1024-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-4096-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-4096-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-4096-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-4096-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-4096-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-5137-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-5137-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-5137-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-5137-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-5137-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-8193-1]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-8193-7]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-8193-64]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-8193-512]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[0-2.1-dtype1-8193-2048]": {
+    "params": {
+      "azp_val": 0,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-64-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-64-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-64-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-64-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-64-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-512-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-512-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-512-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-512-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-512-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-1024-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-1024-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-1024-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-1024-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-1024-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-4096-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-4096-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-4096-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-4096-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-4096-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-5137-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-5137-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-5137-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-5137-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-5137-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-8193-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-8193-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-8193-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-8193-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype0-8193-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-64-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-64-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-64-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-64-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-64-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-512-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-512-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-512-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-512-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-512-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-1024-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-1024-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-1024-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-1024-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-1024-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-4096-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-4096-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-4096-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-4096-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-4096-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-5137-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-5137-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-5137-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-5137-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-5137-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-8193-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-8193-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-8193-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-8193-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-0.1-dtype1-8193-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 0.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-64-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-64-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-64-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-64-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-64-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 64,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-512-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-512-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-512-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-512-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-512-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 512,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-1024-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-1024-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-1024-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-1024-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-1024-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-4096-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-4096-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-4096-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-4096-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-4096-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 4096,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-5137-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-5137-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-5137-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-5137-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-5137-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-8193-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-8193-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-8193-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-8193-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype0-8193-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-64-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-64-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-64-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-64-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-64-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 64,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-512-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-512-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-512-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-512-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-512-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 512,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-1024-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-1024-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-1024-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-1024-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-1024-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 1024,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-4096-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-4096-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-4096-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-4096-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-4096-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 4096,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-5137-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-5137-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-5137-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-5137-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-5137-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 5137,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-8193-1]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-8193-7]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-8193-64]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 64
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-8193-512]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 512
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant_asymmetric[127-2.1-dtype1-8193-2048]": {
+    "params": {
+      "azp_val": 127,
+      "scale_val": 2.1,
+      "dtype": "torch.float16",
+      "hidden_size": 8193,
+      "num_tokens": 2048
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-17-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-17-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-17-4096]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-1024-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-1024-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-1024-4096]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-1025-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-1025-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-1025-4096]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-1026-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-1026-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-1026-4096]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-5137-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-5137-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-5137-4096]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-8193-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-8193-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype0-8193-4096]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-17-1]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-17-7]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-17-4096]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-1024-1]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-1024-7]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-1024-4096]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-1025-1]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-1025-7]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-1025-4096]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-1026-1]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-1026-7]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-1026-4096]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-5137-1]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-5137-7]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-5137-4096]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-8193-1]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-8193-7]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_quant[dtype1-8193-4096]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-17-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-17-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-17-4096]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-1024-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-1024-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-1024-4096]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-1025-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-1025-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-1025-4096]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-1026-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-1026-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-1026-4096]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-5137-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-5137-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-5137-4096]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-8193-1]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-8193-7]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype0-8193-4096]": {
+    "params": {
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-17-1]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-17-7]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-17-4096]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-1024-1]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-1024-7]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-1024-4096]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-1025-1]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-1025-7]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-1025-4096]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-1026-1]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-1026-7]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-1026-4096]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-5137-1]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-5137-7]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-5137-4096]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-8193-1]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-8193-7]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_dynamic_scaled_int8_azp_quant[dtype1-8193-4096]": {
+    "params": {
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-17-1]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-17-7]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-17-4096]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-1024-1]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-1024-7]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-1024-4096]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-1025-1]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-1025-7]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-1025-4096]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-1026-1]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-1026-7]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-1026-4096]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-5137-1]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-5137-7]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-5137-4096]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-8193-1]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-8193-7]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype0-8193-4096]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-17-1]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-17-7]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-17-4096]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-1024-1]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-1024-7]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-1024-4096]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-1025-1]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-1025-7]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-1025-4096]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-1026-1]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-1026-7]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-1026-4096]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-5137-1]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-5137-7]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-5137-4096]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-8193-1]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-8193-7]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[0.1-dtype1-8193-4096]": {
+    "params": {
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-17-1]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-17-7]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-17-4096]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-1024-1]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-1024-7]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-1024-4096]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-1025-1]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-1025-7]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-1025-4096]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-1026-1]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-1026-7]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-1026-4096]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-5137-1]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-5137-7]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-5137-4096]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-8193-1]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-8193-7]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype0-8193-4096]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-17-1]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-17-7]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-17-4096]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-1024-1]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-1024-7]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-1024-4096]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-1025-1]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-1025-7]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-1025-4096]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-1026-1]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-1026-7]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-1026-4096]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-5137-1]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-5137-7]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-5137-4096]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-8193-1]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-8193-7]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_quant[2.1-dtype1-8193-4096]": {
+    "params": {
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-17-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-17-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-17-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-1024-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-1024-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-1024-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-1025-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-1025-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-1025-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-1026-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-1026-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-1026-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-5137-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-5137-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-5137-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-8193-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-8193-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype0-8193-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-17-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-17-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-17-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-1024-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-1024-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-1024-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-1025-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-1025-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-1025-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-1026-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-1026-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-1026-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-5137-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-5137-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-5137-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-8193-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-8193-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-0.1-dtype1-8193-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-17-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-17-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-17-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-1024-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-1024-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-1024-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-1025-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-1025-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-1025-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-1026-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-1026-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-1026-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-5137-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-5137-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-5137-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-8193-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-8193-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype0-8193-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-17-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-17-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-17-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-1024-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-1024-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-1024-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-1025-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-1025-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-1025-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-1026-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-1026-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-1026-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-5137-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-5137-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-5137-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-8193-1]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-8193-7]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[-255-2.1-dtype1-8193-4096]": {
+    "params": {
+      "azp": -255,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-17-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-17-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-17-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-1024-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-1024-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-1024-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-1025-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-1025-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-1025-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-1026-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-1026-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-1026-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-5137-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-5137-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-5137-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-8193-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-8193-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype0-8193-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-17-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-17-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-17-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-1024-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-1024-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-1024-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-1025-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-1025-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-1025-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-1026-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-1026-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-1026-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-5137-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-5137-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-5137-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-8193-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-8193-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-0.1-dtype1-8193-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 0.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-17-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-17-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-17-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 17,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-1024-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-1024-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-1024-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1024,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-1025-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-1025-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-1025-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1025,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-1026-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-1026-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-1026-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 1026,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-5137-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-5137-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-5137-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 5137,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-8193-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-8193-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype0-8193-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.bfloat16",
+      "hidden_size": 8193,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-17-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-17-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-17-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 17,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-1024-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-1024-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-1024-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1024,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-1025-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-1025-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-1025-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1025,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-1026-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-1026-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-1026-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 1026,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-5137-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-5137-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-5137-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 5137,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-8193-1]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 1
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-8193-7]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 7
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant[54-2.1-dtype1-8193-4096]": {
+    "params": {
+      "azp": 54,
+      "scale": 2.1,
+      "dtype": "torch.float32",
+      "hidden_size": 8193,
+      "num_tokens": 4096
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant_saturating_cast[True]": {
+    "params": {
+      "is_max": true
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
+  },
+  "tests/test_scaled_int8_quant.py::test_static_scaled_int8_azp_quant_saturating_cast[False]": {
+    "params": {
+      "is_max": false
+    },
+    "result": "passed",
+    "opname": [
+      "scaled_int8_quant"
+    ],
+    "reason": null
   }
 }

--- a/benchmark/test_scaled_int8_quant.py
+++ b/benchmark/test_scaled_int8_quant.py
@@ -1,0 +1,87 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from vllm._custom_ops import scaled_int8_quant as vllm_scaled_int8_quant
+
+import flaggems_vllm
+
+from . import base
+
+NUM_TOKENS = [1, 64, 512, 2048, 4096]
+HIDDEN_SIZES = [512, 1024, 4096, 5120, 8192, 13824]
+SHAPES = [(m, n) for m in NUM_TOKENS for n in HIDDEN_SIZES]
+
+
+class ScaledInt8QuantBenchmark(base.GenericBenchmark):
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = SHAPES
+        self.shape_desc = "M, N"
+
+    def set_more_shapes(self):
+        return []
+
+
+def _input_fn_dynamic(shape, dtype, device):
+    m, n = shape
+    x = torch.randn(m, n, dtype=dtype, device=device) * 1000
+    yield (x,)
+
+
+def _input_fn_static(shape, dtype, device):
+    m, n = shape
+    x = torch.randn(m, n, dtype=dtype, device=device) * 1000
+    scale = torch.tensor(0.1, dtype=torch.float32, device=device)
+    yield (x, scale)
+
+
+def _vllm_dynamic_symmetric(x):
+    return vllm_scaled_int8_quant(x, symmetric=True)
+
+
+def _vllm_static_symmetric(x, scale):
+    return vllm_scaled_int8_quant(x, scale=scale, symmetric=True)
+
+
+def _gems_dynamic_symmetric(x):
+    return flaggems_vllm.scaled_int8_quant(x, symmetric=True)
+
+
+def _gems_static_symmetric(x, scale):
+    return flaggems_vllm.scaled_int8_quant(x, scale=scale, symmetric=True)
+
+
+@pytest.mark.scaled_int8_quant
+def test_dynamic_scaled_int8_quant():
+    bench = ScaledInt8QuantBenchmark(
+        op_name="dynamic_scaled_int8_quant",
+        torch_op=_vllm_dynamic_symmetric,
+        input_fn=_input_fn_dynamic,
+        dtypes=[torch.bfloat16],
+    )
+    bench.set_gems(_gems_dynamic_symmetric)
+    bench.run()
+
+
+@pytest.mark.scaled_int8_quant
+def test_static_scaled_int8_quant():
+    bench = ScaledInt8QuantBenchmark(
+        op_name="static_scaled_int8_quant",
+        torch_op=_vllm_static_symmetric,
+        input_fn=_input_fn_static,
+        dtypes=[torch.bfloat16],
+    )
+    bench.set_gems(_gems_static_symmetric)
+    bench.run()

--- a/src/flaggems_vllm/ops/__init__.py
+++ b/src/flaggems_vllm/ops/__init__.py
@@ -104,6 +104,7 @@ from flaggems_vllm.ops.rotary_embedding import apply_rotary_pos_emb
 from flaggems_vllm.ops.router_gemm import router_gemm
 from flaggems_vllm.ops.rwkv_ka_fusion import rwkv_ka_fusion
 from flaggems_vllm.ops.rwkv_mm_sparsity import rwkv_mm_sparsity
+from flaggems_vllm.ops.scaled_int8_quant import scaled_int8_quant
 from flaggems_vllm.ops.silu_and_mul import silu_and_mul, silu_and_mul_out
 from flaggems_vllm.ops.silu_and_mul_with_clamp import (
     silu_and_mul_with_clamp,
@@ -198,6 +199,7 @@ __all__ = [
     "router_gemm",
     "rwkv_ka_fusion",
     "rwkv_mm_sparsity",
+    "scaled_int8_quant",
     "silu_and_mul",
     "silu_and_mul_out",
     "silu_and_mul_with_clamp",

--- a/src/flaggems_vllm/ops/scaled_int8_quant.py
+++ b/src/flaggems_vllm/ops/scaled_int8_quant.py
@@ -1,0 +1,343 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import triton
+import triton.language as tl
+import triton.language.extra.libdevice as tldevice
+
+from flaggems_vllm import runtime
+from flaggems_vllm.utils import libentry
+
+I8_MIN_VAL = tl.constexpr(-128.0)
+I8_MAX_VAL = tl.constexpr(127.0)
+I32_MIN_VAL = tl.constexpr(-2147483648.0)
+I32_MAX_VAL = tl.constexpr(2147483647.0)
+INF_VAL = tl.constexpr(1e30)
+NEG_INF_VAL = tl.constexpr(-1e30)
+
+
+@triton.jit
+def _round_i8_sat(x):
+    return tl.clamp(tldevice.nearbyint(x), I8_MIN_VAL, I8_MAX_VAL).to(tl.int8)
+
+
+@triton.jit
+def _round_i32_sat(x):
+    return tl.clamp(tldevice.nearbyint(x), I32_MIN_VAL, I32_MAX_VAL).to(tl.int32)
+
+
+@triton.jit
+def _saturate_i32_to_i8(x):
+    return tl.clamp(x, I8_MIN_VAL, I8_MAX_VAL).to(tl.int8)
+
+
+# ── static: 2-D grid when few tokens, 1-D otherwise ──────────────────────────
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("scaled_int8_quant_static"),
+    key=["hidden_size"],
+)
+@triton.jit
+def _static_int8_quant_kernel(
+    input_ptr,
+    output_ptr,
+    scale_ptr,
+    azp_ptr,
+    hidden_size,
+    SYMMETRIC: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    chunk_start = pid_n * BLOCK_SIZE
+    if chunk_start >= hidden_size:
+        return
+
+    row_offset = pid_m * hidden_size
+
+    scale = tl.load(scale_ptr)
+    inv_s = 1.0 / scale
+
+    if not SYMMETRIC:
+        azp = tl.load(azp_ptr)
+
+    in_blk = tl.make_block_ptr(
+        base=input_ptr + row_offset,
+        shape=(hidden_size,),
+        strides=(1,),
+        offsets=(chunk_start,),
+        block_shape=(BLOCK_SIZE,),
+        order=(0,),
+    )
+    src = tl.load(in_blk, boundary_check=(0,), padding_option="zero").to(tl.float32)
+
+    if SYMMETRIC:
+        dst = _round_i8_sat(src * inv_s)
+    else:
+        dst = _saturate_i32_to_i8(_round_i32_sat(src * inv_s) + azp)
+
+    out_blk = tl.make_block_ptr(
+        base=output_ptr + row_offset,
+        shape=(hidden_size,),
+        strides=(1,),
+        offsets=(chunk_start,),
+        block_shape=(BLOCK_SIZE,),
+        order=(0,),
+    )
+    tl.store(out_blk, dst, boundary_check=(0,))
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("scaled_int8_quant_static"),
+    key=["hidden_size"],
+)
+@triton.jit
+def _static_int8_quant_kernel_1d(
+    input_ptr,
+    output_ptr,
+    scale_ptr,
+    azp_ptr,
+    hidden_size,
+    SYMMETRIC: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    row_offset = pid * hidden_size
+
+    scale = tl.load(scale_ptr)
+    inv_s = 1.0 / scale
+
+    if not SYMMETRIC:
+        azp = tl.load(azp_ptr)
+
+    for start in range(0, hidden_size, BLOCK_SIZE):
+        in_blk = tl.make_block_ptr(
+            base=input_ptr + row_offset,
+            shape=(hidden_size,),
+            strides=(1,),
+            offsets=(start,),
+            block_shape=(BLOCK_SIZE,),
+            order=(0,),
+        )
+        src = tl.load(in_blk, boundary_check=(0,), padding_option="zero").to(tl.float32)
+
+        if SYMMETRIC:
+            dst = _round_i8_sat(src * inv_s)
+        else:
+            dst = _saturate_i32_to_i8(_round_i32_sat(src * inv_s) + azp)
+
+        out_blk = tl.make_block_ptr(
+            base=output_ptr + row_offset,
+            shape=(hidden_size,),
+            strides=(1,),
+            offsets=(start,),
+            block_shape=(BLOCK_SIZE,),
+            order=(0,),
+        )
+        tl.store(out_blk, dst, boundary_check=(0,))
+
+
+# ── dynamic: single-kernel 1-D, block-pointer loading ────────────────────────
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("scaled_int8_quant_dynamic"),
+    key=["hidden_size"],
+)
+@triton.jit
+def _dynamic_int8_quant_kernel(
+    input_ptr,
+    output_ptr,
+    scale_out_ptr,
+    azp_out_ptr,
+    hidden_size,
+    SYMMETRIC: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    row_offset = pid * hidden_size
+
+    if SYMMETRIC:
+        row_absmax = 0.0
+        for start in range(0, hidden_size, BLOCK_SIZE):
+            in_blk = tl.make_block_ptr(
+                base=input_ptr + row_offset,
+                shape=(hidden_size,),
+                strides=(1,),
+                offsets=(start,),
+                block_shape=(BLOCK_SIZE,),
+                order=(0,),
+            )
+            src = tl.load(in_blk, boundary_check=(0,), padding_option="zero").to(
+                tl.float32
+            )
+            chunk_absmax = tl.max(tl.abs(src))
+            row_absmax = tl.maximum(row_absmax, chunk_absmax)
+
+        scale = row_absmax / 127.0
+        inv_s = tl.where(row_absmax == 0.0, 0.0, 127.0 / row_absmax)
+
+        tl.store(scale_out_ptr + pid, scale)
+
+        for start in range(0, hidden_size, BLOCK_SIZE):
+            in_blk = tl.make_block_ptr(
+                base=input_ptr + row_offset,
+                shape=(hidden_size,),
+                strides=(1,),
+                offsets=(start,),
+                block_shape=(BLOCK_SIZE,),
+                order=(0,),
+            )
+            src = tl.load(in_blk, boundary_check=(0,), padding_option="zero").to(
+                tl.float32
+            )
+            dst = _round_i8_sat(src * inv_s)
+            out_blk = tl.make_block_ptr(
+                base=output_ptr + row_offset,
+                shape=(hidden_size,),
+                strides=(1,),
+                offsets=(start,),
+                block_shape=(BLOCK_SIZE,),
+                order=(0,),
+            )
+            tl.store(out_blk, dst, boundary_check=(0,))
+
+    else:
+        row_min = INF_VAL
+        row_max = NEG_INF_VAL
+        for start in range(0, hidden_size, BLOCK_SIZE):
+            in_blk = tl.make_block_ptr(
+                base=input_ptr + row_offset,
+                shape=(hidden_size,),
+                strides=(1,),
+                offsets=(start,),
+                block_shape=(BLOCK_SIZE,),
+                order=(0,),
+            )
+            src = tl.load(in_blk, boundary_check=(0,), padding_option="zero").to(
+                tl.float32
+            )
+            offsets = start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < hidden_size
+            row_max = tl.maximum(row_max, tl.max(tl.where(mask, src, NEG_INF_VAL)))
+            row_min = tl.minimum(row_min, tl.min(tl.where(mask, src, INF_VAL)))
+
+        scale = (row_max - row_min) / 255.0
+        inv_s = 1.0 / scale
+        azp = _round_i32_sat(-128.0 - row_min * inv_s)
+
+        tl.store(scale_out_ptr + pid, scale)
+        tl.store(azp_out_ptr + pid, azp)
+
+        for start in range(0, hidden_size, BLOCK_SIZE):
+            in_blk = tl.make_block_ptr(
+                base=input_ptr + row_offset,
+                shape=(hidden_size,),
+                strides=(1,),
+                offsets=(start,),
+                block_shape=(BLOCK_SIZE,),
+                order=(0,),
+            )
+            src = tl.load(in_blk, boundary_check=(0,), padding_option="zero").to(
+                tl.float32
+            )
+            dst = _saturate_i32_to_i8(_round_i32_sat(src * inv_s) + azp)
+            out_blk = tl.make_block_ptr(
+                base=output_ptr + row_offset,
+                shape=(hidden_size,),
+                strides=(1,),
+                offsets=(start,),
+                block_shape=(BLOCK_SIZE,),
+                order=(0,),
+            )
+            tl.store(out_blk, dst, boundary_check=(0,))
+
+
+# ── host dispatch ────────────────────────────────────────────────────────────
+
+# When the token count is below this threshold we use a 2-D grid so each
+# block handles a single chunk — this spreads the work across more SMs when
+# there are few rows. When there are many rows, the 1-D grid (one block per
+# row) already saturates the GPU, and keeping the inner loop avoids grid
+# launch overhead.
+_2D_GRID_TOKEN_THRESHOLD = 256
+
+
+def scaled_int8_quant(
+    input: torch.Tensor,
+    scale: torch.Tensor | None = None,
+    azp: torch.Tensor | None = None,
+    symmetric: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    input_2d = input.reshape(-1, input.shape[-1])
+    num_tokens, hidden_size = input_2d.shape
+
+    if scale is not None:
+        output = torch.empty_like(input_2d, dtype=torch.int8)
+        azp_or_dummy = (
+            azp
+            if azp is not None
+            else torch.empty(1, dtype=torch.int32, device=input.device)
+        )
+
+        if num_tokens < _2D_GRID_TOKEN_THRESHOLD:
+            max_chunks = triton.cdiv(hidden_size, 256)
+            grid = (num_tokens, max_chunks)
+            _static_int8_quant_kernel[grid](
+                input_2d,
+                output,
+                scale,
+                azp_or_dummy,
+                hidden_size,
+                SYMMETRIC=symmetric,
+            )
+        else:
+            grid = (num_tokens,)
+            _static_int8_quant_kernel_1d[grid](
+                input_2d,
+                output,
+                scale,
+                azp_or_dummy,
+                hidden_size,
+                SYMMETRIC=symmetric,
+            )
+        return output.view(input.shape), scale, azp
+
+    output = torch.empty_like(input_2d, dtype=torch.int8)
+    input_scales = torch.empty(
+        (num_tokens, 1), device=input.device, dtype=torch.float32
+    )
+    if symmetric:
+        input_azp = None
+        azp_out_or_dummy = torch.empty(
+            (num_tokens, 1), device=input.device, dtype=torch.int32
+        )
+    else:
+        input_azp = torch.empty((num_tokens, 1), device=input.device, dtype=torch.int32)
+        azp_out_or_dummy = input_azp
+
+    _dynamic_int8_quant_kernel[(num_tokens,)](
+        input_2d,
+        output,
+        input_scales,
+        azp_out_or_dummy,
+        hidden_size,
+        SYMMETRIC=symmetric,
+    )
+    return output.view(input.shape), input_scales, input_azp

--- a/src/flaggems_vllm/runtime/backend/_nvidia/tune_configs.yaml
+++ b/src/flaggems_vllm/runtime/backend/_nvidia/tune_configs.yaml
@@ -274,3 +274,43 @@ gated_activation:
       - 8
     block_n:
       - 1024
+
+scaled_int8_quant_static:
+  - gen: true
+    param_map:
+      META:
+        BLOCK_SIZE: block_size
+      num_warps: warps
+      num_stages: stages
+    block_size:
+      - 256
+      - 512
+      - 1024
+    warps:
+      - 4
+      - 8
+      - 16
+    stages:
+      - 2
+      - 3
+      - 4
+
+scaled_int8_quant_dynamic:
+  - gen: true
+    param_map:
+      META:
+        BLOCK_SIZE: block_size
+      num_warps: warps
+      num_stages: stages
+    block_size:
+      - 256
+      - 512
+      - 1024
+    warps:
+      - 4
+      - 8
+      - 16
+    stages:
+      - 3
+      - 4
+      - 5

--- a/tests/test_scaled_int8_quant.py
+++ b/tests/test_scaled_int8_quant.py
@@ -1,0 +1,158 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import flaggems_vllm
+
+from .conftest import QUICK_MODE
+
+device = flaggems_vllm.device
+INT8_ABSMAX = 127.0
+INT8_RANGE = 255.0
+I32_MIN = -2147483648
+I32_MAX = 2147483647
+
+if QUICK_MODE:
+    NUM_TOKENS = [7]
+    HIDDEN_SIZES = [1024]
+    DTYPES = [torch.bfloat16]
+    SCALE = [0.1]
+    AZP = [54]
+else:
+    NUM_TOKENS = [1, 7, 4096]
+    HIDDEN_SIZES = [17, 1024, 1025, 1026, 5137, 8193]
+    DTYPES = [torch.bfloat16, torch.float]
+    SCALE = [0.1, 2.1]
+    AZP = [-255, 54]
+
+
+def _ref_dynamic_symmetric(x):
+    x_f32 = x.float()
+    absmax = x_f32.abs().amax(dim=-1, keepdim=True)
+    scale = absmax / INT8_ABSMAX
+    inv_s = torch.where(
+        absmax == 0, torch.tensor(0.0, device=x.device), INT8_ABSMAX / absmax
+    )
+    q = (x_f32 * inv_s).round().clamp(-128, 127).to(torch.int8)
+    return q, scale
+
+
+def _ref_dynamic_asymmetric(x):
+    x_f32 = x.float()
+    row_max = x_f32.amax(dim=-1, keepdim=True)
+    row_min = x_f32.amin(dim=-1, keepdim=True)
+    scale = (row_max - row_min) / INT8_RANGE
+    azp = (-128.0 - row_min / scale).round().clamp(I32_MIN, I32_MAX).to(torch.int32)
+    q = ((x_f32 / scale).round() + azp).clamp(-128, 127).to(torch.int8)
+    return q, scale, azp
+
+
+@pytest.mark.scaled_int8_quant
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@torch.inference_mode()
+def test_dynamic_scaled_int8_quant(num_tokens, hidden_size, dtype):
+    torch.manual_seed(0)
+    x = torch.rand(num_tokens, hidden_size, dtype=dtype, device=device) * 1000
+
+    ref_out, ref_scale = _ref_dynamic_symmetric(x)
+    ops_out, ops_scale, ops_azp = flaggems_vllm.scaled_int8_quant(x, symmetric=True)
+
+    assert ops_azp is None
+    torch.testing.assert_close(ops_scale, ref_scale)
+    torch.testing.assert_close(ops_out, ref_out, atol=1, rtol=0.0)
+
+
+@pytest.mark.scaled_int8_quant
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@torch.inference_mode()
+def test_dynamic_scaled_int8_azp_quant(num_tokens, hidden_size, dtype):
+    torch.manual_seed(0)
+    x = torch.rand(num_tokens, hidden_size, dtype=dtype, device=device) * 1000 - 300
+
+    ref_out, ref_scale, ref_azp = _ref_dynamic_asymmetric(x)
+    ops_out, ops_scale, ops_azp = flaggems_vllm.scaled_int8_quant(x, symmetric=False)
+
+    torch.testing.assert_close(ops_scale, ref_scale)
+    torch.testing.assert_close(ops_azp, ref_azp, atol=1, rtol=0.0)
+    torch.testing.assert_close(ops_out, ref_out, atol=2, rtol=0.0)
+
+
+@pytest.mark.scaled_int8_quant
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("scale", SCALE)
+@torch.inference_mode()
+def test_static_scaled_int8_quant(num_tokens, hidden_size, dtype, scale):
+    torch.manual_seed(0)
+    x = torch.rand(num_tokens, hidden_size, dtype=dtype, device=device) * 1000
+    scale_arg = torch.tensor([scale], dtype=torch.float32, device=device)
+
+    ref_out = (x / scale_arg).round().clamp(-128, 127).to(torch.int8)
+    ops_out, ops_scale, _ = flaggems_vllm.scaled_int8_quant(x, scale_arg)
+    assert ops_scale is scale_arg
+
+    torch.testing.assert_close(ref_out, ops_out, atol=1, rtol=0.0)
+
+
+@pytest.mark.scaled_int8_quant
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("scale", SCALE)
+@pytest.mark.parametrize("azp", AZP)
+@torch.inference_mode()
+def test_static_scaled_int8_azp_quant(num_tokens, hidden_size, dtype, scale, azp):
+    torch.manual_seed(0)
+    x = torch.rand(num_tokens, hidden_size, dtype=dtype, device=device) * 1000 - 300
+    scale_arg = torch.tensor([scale], dtype=torch.float32, device=device)
+    azp_arg = torch.tensor([azp], dtype=torch.int32, device=device)
+
+    ref_out = ((x / scale).round() + azp).clamp(-128, 127).to(torch.int8)
+    ops_out, ops_scale, ops_azp = flaggems_vllm.scaled_int8_quant(
+        x, scale_arg, azp_arg, symmetric=False
+    )
+    assert ops_scale is scale_arg
+    assert ops_azp is azp_arg
+
+    torch.testing.assert_close(ref_out, ops_out, atol=1, rtol=0.0)
+
+
+@pytest.mark.scaled_int8_quant
+@pytest.mark.parametrize("is_max", [True, False])
+@torch.inference_mode()
+def test_static_scaled_int8_azp_quant_saturating_cast(is_max):
+    from numpy import inf, nextafter
+
+    i32_max = 2147483647
+    i32_min = -2147483648
+    val = float(i32_max if is_max else i32_min)
+
+    x_vals = [[nextafter(val, inf), val + 1, val, val - 1, nextafter(val, -inf)]]
+    x = torch.tensor(x_vals, dtype=torch.float32, device=device)
+
+    scale = torch.tensor([1.0], dtype=torch.float32, device=device)
+    azp = torch.tensor([0], dtype=torch.int32, device=device)
+
+    expected_val = 127 if is_max else -128
+    expected = torch.full((1, 5), expected_val, dtype=torch.int8, device=device)
+
+    out, _, _ = flaggems_vllm.scaled_int8_quant(x, scale, azp, symmetric=False)
+    torch.testing.assert_close(expected, out, atol=0, rtol=0)


### PR DESCRIPTION
<!--
 Copyright 2026 FlagOS Contributors

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->

### PR Category
Operator

### Type of Change
New Feature

### Description
Add `scaled_int8_quant` operator — a Triton implementation of vLLM's INT8 per-token/per-tensor quantization kernel. Supports four modes: dynamic symmetric, dynamic asymmetric, static symmetric, and static asymmetric. Rounding follows round-to-nearest-even + saturation semantics, matching the reference CUDA kernel.

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

Benchmark ref — vLLM `scaled_int8_quant` CUDA kernel. Device — CUDA SM90. Dtype — bfloat16. 30 shape combinations per test (5 token counts × 6 hidden sizes).

**Static quantization** (avg SpeedUp 1.10x):

| Num Tokens | Hidden Size | Torch (ms) | Gems (ms) | SpeedUp |
|---|---|---|---|---|
| 1 | 512 | 0.005568 | 0.004992 | 1.115 |
| 1 | 1024 | 0.005728 | 0.004992 | 1.147 |
| 1 | 4096 | 0.005952 | 0.005344 | 1.114 |
| 1 | 5120 | 0.006528 | 0.005120 | 1.275 |
| 1 | 8192 | 0.006656 | 0.005152 | 1.292 |
| 1 | 13824 | 0.008512 | 0.005216 | **1.632** |
| 64 | 512 | 0.005824 | 0.005312 | 1.096 |
| 64 | 1024 | 0.005888 | 0.005440 | 1.082 |
| 64 | 4096 | 0.006176 | 0.005856 | 1.055 |
| 64 | 5120 | 0.007264 | 0.006464 | 1.124 |
| 64 | 8192 | 0.007616 | 0.006304 | **1.208** |
| 64 | 13824 | 0.009856 | 0.007776 | **1.267** |
| 512 | 512 | 0.006560 | 0.006208 | 1.057 |
| 512 | 1024 | 0.006912 | 0.006304 | 1.096 |
| 512 | 4096 | 0.009280 | 0.008928 | 1.039 |
| 512 | 5120 | 0.010624 | 0.009888 | 1.074 |
| 512 | 8192 | 0.012736 | 0.011936 | 1.067 |
| 512 | 13824 | 0.017728 | 0.016448 | 1.078 |
| 2048 | 512 | 0.009216 | 0.007488 | 1.231 |
| 2048 | 1024 | 0.010080 | 0.008480 | 1.189 |
| 2048 | 4096 | 0.017248 | 0.017760 | 0.971 |
| 2048 | 5120 | 0.021248 | 0.020736 | 1.025 |
| 2048 | 8192 | 0.029312 | 0.029920 | 0.980 |
| 2048 | 13824 | 0.045728 | 0.045984 | 0.994 |
| 4096 | 512 | 0.010880 | 0.009216 | 1.181 |
| 4096 | 1024 | 0.012704 | 0.011008 | 1.154 |
| 4096 | 4096 | 0.028256 | 0.028832 | 0.980 |
| 4096 | 5120 | 0.034784 | 0.034464 | 1.009 |
| 4096 | 8192 | 0.051168 | 0.050016 | 1.023 |
| 4096 | 13824 | 0.082592 | 0.078528 | 1.052 |

**Dynamic quantization** (avg SpeedUp 0.81x):

| Num Tokens | Hidden Size | Torch (ms) | Gems (ms) | SpeedUp |
|---|---|---|---|---|
| 1 | 512 | 0.005344 | 0.005344 | 1.000 |
| 1 | 1024 | 0.005888 | 0.005312 | 1.108 |
| 1 | 4096 | 0.006016 | 0.007424 | 0.810 |
| 1 | 5120 | 0.006528 | 0.008256 | 0.791 |
| 1 | 8192 | 0.006720 | 0.010464 | 0.642 |
| 1 | 13824 | 0.007712 | 0.014944 | 0.516 |
| 64 | 512 | 0.005920 | 0.005600 | 1.057 |
| 64 | 1024 | 0.006176 | 0.005888 | 1.049 |
| 64 | 4096 | 0.006272 | 0.008576 | 0.731 |
| 64 | 5120 | 0.006880 | 0.009024 | 0.762 |
| 64 | 8192 | 0.007392 | 0.011232 | 0.658 |
| 64 | 13824 | 0.009120 | 0.016704 | 0.546 |
| 512 | 512 | 0.006432 | 0.006240 | 1.031 |
| 512 | 1024 | 0.006880 | 0.006816 | 1.009 |
| 512 | 4096 | 0.008928 | 0.010976 | 0.813 |
| 512 | 5120 | 0.009536 | 0.012256 | 0.778 |
| 512 | 8192 | 0.011360 | 0.016352 | 0.695 |
| 512 | 13824 | 0.014848 | 0.024480 | 0.607 |
| 2048 | 512 | 0.010528 | 0.008192 | 1.285 |
| 2048 | 1024 | 0.011008 | 0.011296 | 0.975 |
| 2048 | 4096 | 0.015488 | 0.025728 | 0.602 |
| 2048 | 5120 | 0.019904 | 0.030624 | 0.650 |
| 2048 | 8192 | 0.024160 | 0.045056 | 0.536 |
| 2048 | 13824 | 0.037024 | 0.072896 | 0.508 |
| 4096 | 512 | 0.014976 | 0.010912 | 1.372 |
| 4096 | 1024 | 0.015904 | 0.016288 | 0.976 |
| 4096 | 4096 | 0.025280 | 0.043392 | 0.583 |
| 4096 | 5120 | 0.032768 | 0.052000 | 0.630 |
| 4096 | 8192 | 0.040224 | 0.077280 | 0.520 |
| 4096 | 13824 | 0.062816 | 0.128256 | 0.490 |
