### PR TITLE
feat: add scaled_int8_quant operator with single-read dynamic quant

### DIFF
--- a/benchmark/test_scaled_int8_quant.py
+++ b/benchmark/test_scaled_int8_quant.py
@@ -1,0 +1,87 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from vllm._custom_ops import scaled_int8_quant as vllm_scaled_int8_quant
+
+import flaggems_vllm
+
+from . import base
+
+NUM_TOKENS = [1, 64, 512, 2048, 4096]
+HIDDEN_SIZES = [512, 1024, 4096, 5120, 8192, 13824]
+SHAPES = [(m, n) for m in NUM_TOKENS for n in HIDDEN_SIZES]
+
+
+class ScaledInt8QuantBenchmark(base.GenericBenchmark):
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = SHAPES
+        self.shape_desc = "M, N"
+
+    def set_more_shapes(self):
+        return []
+
+
+def _input_fn_dynamic(shape, dtype, device):
+    m, n = shape
+    x = torch.randn(m, n, dtype=dtype, device=device) * 1000
+    yield (x,)
+
+
+def _input_fn_static(shape, dtype, device):
+    m, n = shape
+    x = torch.randn(m, n, dtype=dtype, device=device) * 1000
+    scale = torch.tensor(0.1, dtype=torch.float32, device=device)
+    yield (x, scale)
+
+
+def _vllm_dynamic_symmetric(x):
+    return vllm_scaled_int8_quant(x, symmetric=True)
+
+
+def _vllm_static_symmetric(x, scale):
+    return vllm_scaled_int8_quant(x, scale=scale, symmetric=True)
+
+
+def _gems_dynamic_symmetric(x):
+    return flaggems_vllm.scaled_int8_quant(x, symmetric=True)
+
+
+def _gems_static_symmetric(x, scale):
+    return flaggems_vllm.scaled_int8_quant(x, scale=scale, symmetric=True)
+
+
+@pytest.mark.scaled_int8_quant
+def test_dynamic_scaled_int8_quant():
+    bench = ScaledInt8QuantBenchmark(
+        op_name="dynamic_scaled_int8_quant",
+        torch_op=_vllm_dynamic_symmetric,
+        input_fn=_input_fn_dynamic,
+        dtypes=[torch.bfloat16],
+    )
+    bench.set_gems(_gems_dynamic_symmetric)
+    bench.run()
+
+
+@pytest.mark.scaled_int8_quant
+def test_static_scaled_int8_quant():
+    bench = ScaledInt8QuantBenchmark(
+        op_name="static_scaled_int8_quant",
+        torch_op=_vllm_static_symmetric,
+        input_fn=_input_fn_static,
+        dtypes=[torch.bfloat16],
+    )
+    bench.set_gems(_gems_static_symmetric)
+    bench.run()

--- a/src/flaggems_vllm/ops/__init__.py
+++ b/src/flaggems_vllm/ops/__init__.py
@@ -104,6 +104,7 @@ from flaggems_vllm.ops.rotary_embedding import apply_rotary_pos_emb
 from flaggems_vllm.ops.router_gemm import router_gemm
 from flaggems_vllm.ops.rwkv_ka_fusion import rwkv_ka_fusion
 from flaggems_vllm.ops.rwkv_mm_sparsity import rwkv_mm_sparsity
+from flaggems_vllm.ops.scaled_int8_quant import scaled_int8_quant
 from flaggems_vllm.ops.silu_and_mul import silu_and_mul, silu_and_mul_out
 from flaggems_vllm.ops.silu_and_mul_with_clamp import (
     silu_and_mul_with_clamp,
@@ -199,6 +200,7 @@ __all__ = [
     "router_gemm",
     "rwkv_ka_fusion",
     "rwkv_mm_sparsity",
+    "scaled_int8_quant",
     "silu_and_mul",
     "silu_and_mul_out",
     "silu_and_mul_with_clamp",

--- a/src/flaggems_vllm/ops/scaled_int8_quant.py
+++ b/src/flaggems_vllm/ops/scaled_int8_quant.py
@@ -1,0 +1,568 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import triton
+import triton.language as tl
+import triton.language.extra.libdevice as tldevice
+
+from flaggems_vllm import runtime
+from flaggems_vllm.utils import libentry
+
+I8_MIN_VAL = tl.constexpr(-128.0)
+I8_MAX_VAL = tl.constexpr(127.0)
+I32_MIN_VAL = tl.constexpr(-2147483648.0)
+I32_MAX_VAL = tl.constexpr(2147483647.0)
+INF_VAL = tl.constexpr(1e30)
+NEG_INF_VAL = tl.constexpr(-1e30)
+
+
+@triton.jit
+def _round_i8_sat(x):
+    return tl.clamp(tldevice.nearbyint(x), I8_MIN_VAL, I8_MAX_VAL).to(tl.int8)
+
+
+@triton.jit
+def _round_i32_sat(x):
+    return tl.clamp(tldevice.nearbyint(x), I32_MIN_VAL, I32_MAX_VAL).to(tl.int32)
+
+
+@triton.jit
+def _saturate_i32_to_i8(x):
+    return tl.clamp(x, I8_MIN_VAL, I8_MAX_VAL).to(tl.int8)
+
+
+# ── static: 2-D grid when few tokens, 1-D otherwise ──────────────────────────
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("scaled_int8_quant_static"),
+    key=["hidden_size"],
+)
+@triton.jit
+def _static_int8_quant_kernel(
+    input_ptr,
+    output_ptr,
+    scale_ptr,
+    azp_ptr,
+    hidden_size,
+    SYMMETRIC: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    chunk_start = pid_n * BLOCK_SIZE
+    if chunk_start >= hidden_size:
+        return
+
+    row_offset = pid_m * hidden_size
+
+    scale = tl.load(scale_ptr)
+    inv_s = 1.0 / scale
+
+    if not SYMMETRIC:
+        azp = tl.load(azp_ptr)
+
+    in_blk = tl.make_block_ptr(
+        base=input_ptr + row_offset,
+        shape=(hidden_size,),
+        strides=(1,),
+        offsets=(chunk_start,),
+        block_shape=(BLOCK_SIZE,),
+        order=(0,),
+    )
+    src = tl.load(in_blk, boundary_check=(0,), padding_option="zero").to(tl.float32)
+
+    if SYMMETRIC:
+        dst = _round_i8_sat(src * inv_s)
+    else:
+        dst = _saturate_i32_to_i8(_round_i32_sat(src * inv_s) + azp)
+
+    out_blk = tl.make_block_ptr(
+        base=output_ptr + row_offset,
+        shape=(hidden_size,),
+        strides=(1,),
+        offsets=(chunk_start,),
+        block_shape=(BLOCK_SIZE,),
+        order=(0,),
+    )
+    tl.store(out_blk, dst, boundary_check=(0,))
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("scaled_int8_quant_static"),
+    key=["hidden_size"],
+)
+@triton.jit
+def _static_int8_quant_kernel_1d(
+    input_ptr,
+    output_ptr,
+    scale_ptr,
+    azp_ptr,
+    hidden_size,
+    SYMMETRIC: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    row_offset = pid * hidden_size
+
+    scale = tl.load(scale_ptr)
+    inv_s = 1.0 / scale
+
+    if not SYMMETRIC:
+        azp = tl.load(azp_ptr)
+
+    for start in range(0, hidden_size, BLOCK_SIZE):
+        in_blk = tl.make_block_ptr(
+            base=input_ptr + row_offset,
+            shape=(hidden_size,),
+            strides=(1,),
+            offsets=(start,),
+            block_shape=(BLOCK_SIZE,),
+            order=(0,),
+        )
+        src = tl.load(in_blk, boundary_check=(0,), padding_option="zero").to(tl.float32)
+
+        if SYMMETRIC:
+            dst = _round_i8_sat(src * inv_s)
+        else:
+            dst = _saturate_i32_to_i8(_round_i32_sat(src * inv_s) + azp)
+
+        out_blk = tl.make_block_ptr(
+            base=output_ptr + row_offset,
+            shape=(hidden_size,),
+            strides=(1,),
+            offsets=(start,),
+            block_shape=(BLOCK_SIZE,),
+            order=(0,),
+        )
+        tl.store(out_blk, dst, boundary_check=(0,))
+
+
+# ── dynamic: single-kernel 1-D, block-pointer loading ────────────────────────
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("scaled_int8_quant_dynamic_single"),
+    key=["hidden_size", "num_tokens"],
+)
+@triton.heuristics(
+    values={"ROW_BLOCK": lambda args: triton.next_power_of_2(args["hidden_size"])}
+)
+@triton.jit
+def _dynamic_int8_quant_kernel_single_pass(
+    input_ptr,
+    output_ptr,
+    scale_out_ptr,
+    hidden_size,
+    num_tokens,
+    ROW_BLOCK: tl.constexpr,
+    PLACEHOLDER_UNUSED: tl.constexpr = 1,
+):
+    """Symmetric dynamic quant that reads the whole row once.
+
+    The full row is loaded into registers, so the absmax pass and the
+    quantize pass share a single global-memory read. ROW_BLOCK is set to
+    next_power_of_2(hidden_size) via @triton.heuristics, so the tuned
+    candidates only act through num_warps/num_stages.
+    """
+    pid = tl.program_id(0)
+    row_offset = pid.to(tl.int64) * hidden_size
+    offsets = tl.arange(0, ROW_BLOCK)
+    mask = offsets < hidden_size
+    src = tl.load(input_ptr + row_offset + offsets, mask=mask, other=0.0).to(tl.float32)
+    row_absmax = tl.max(tl.abs(src))
+    scale = row_absmax / 127.0
+    inv_s = tl.where(row_absmax == 0.0, 0.0, 127.0 / row_absmax)
+    tl.store(scale_out_ptr + pid, scale)
+    dst = _round_i8_sat(src * inv_s)
+    tl.store(output_ptr + row_offset + offsets, dst, mask=mask)
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("scaled_int8_quant_dynamic_main_tail"),
+    key=["hidden_size", "num_tokens"],
+)
+@triton.jit
+def _dynamic_int8_quant_kernel_main_tail(
+    input_ptr,
+    output_ptr,
+    scale_out_ptr,
+    hidden_size,
+    num_tokens,
+    MAIN_BLOCK: tl.constexpr,
+    TAIL_BLOCK: tl.constexpr,
+    PLACEHOLDER_UNUSED: tl.constexpr = 1,
+):
+    """Symmetric dynamic quant for rows that fit in one main pow2 block plus
+    one masked tail block (MAIN_BLOCK + TAIL_BLOCK >= hidden_size).
+
+    Single global read: both chunks stay in registers across the absmax and
+    quantize steps. The main block is loaded without masking, which avoids
+    the dead-lane waste of padding the whole row to a single power of two
+    (e.g. hidden_size 5120 -> MAIN 4096 + TAIL 1024 instead of a masked 8192).
+    """
+    pid = tl.program_id(0)
+    row_offset = pid.to(tl.int64) * hidden_size
+    main_offs = tl.arange(0, MAIN_BLOCK)
+    tail_offs = MAIN_BLOCK + tl.arange(0, TAIL_BLOCK)
+    tail_mask = tail_offs < hidden_size
+    src_main = tl.load(input_ptr + row_offset + main_offs).to(tl.float32)
+    src_tail = tl.load(
+        input_ptr + row_offset + tail_offs, mask=tail_mask, other=0.0
+    ).to(tl.float32)
+    row_absmax = tl.maximum(tl.max(tl.abs(src_main)), tl.max(tl.abs(src_tail)))
+    scale = row_absmax / 127.0
+    inv_s = tl.where(row_absmax == 0.0, 0.0, 127.0 / row_absmax)
+    tl.store(scale_out_ptr + pid, scale)
+    tl.store(output_ptr + row_offset + main_offs, _round_i8_sat(src_main * inv_s))
+    tl.store(
+        output_ptr + row_offset + tail_offs,
+        _round_i8_sat(src_tail * inv_s),
+        mask=tail_mask,
+    )
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("scaled_int8_quant_dynamic_single"),
+    key=["hidden_size", "num_tokens"],
+)
+@triton.heuristics(
+    values={"ROW_BLOCK": lambda args: triton.next_power_of_2(args["hidden_size"])}
+)
+@triton.jit
+def _dynamic_int8_quant_kernel_azp_single_pass(
+    input_ptr,
+    output_ptr,
+    scale_out_ptr,
+    azp_out_ptr,
+    hidden_size,
+    num_tokens,
+    ROW_BLOCK: tl.constexpr,
+    PLACEHOLDER_UNUSED: tl.constexpr = 1,
+):
+    """Asymmetric dynamic quant, single global read.
+
+    Same structure as the symmetric single-pass kernel: the whole row stays
+    in registers while min/max are reduced, then quantized in place.
+    """
+    pid = tl.program_id(0)
+    row_offset = pid.to(tl.int64) * hidden_size
+    offsets = tl.arange(0, ROW_BLOCK)
+    mask = offsets < hidden_size
+    src = tl.load(input_ptr + row_offset + offsets, mask=mask, other=0.0).to(tl.float32)
+    row_max = tl.max(tl.where(mask, src, NEG_INF_VAL))
+    row_min = tl.min(tl.where(mask, src, INF_VAL))
+    span = row_max - row_min
+    scale = span / 255.0
+    # constant row (span == 0): inv_s is inf, and the downstream
+    # round(-min*inf) saturates to int32 min/max exactly like the two-loop
+    # reference kernel (matches vLLM CUDA behavior for constant rows).
+    inv_s = 1.0 / scale
+    azp = _round_i32_sat(-128.0 - row_min * inv_s)
+    tl.store(scale_out_ptr + pid, scale)
+    tl.store(azp_out_ptr + pid, azp)
+    dst = _saturate_i32_to_i8(_round_i32_sat(src * inv_s) + azp)
+    tl.store(output_ptr + row_offset + offsets, dst, mask=mask)
+
+
+def _decompose_main_tail(hidden_size):
+    """Largest-pow2 main block + pow2 tail block covering hidden_size.
+
+    Returns (MAIN_BLOCK, TAIL_BLOCK) with MAIN_BLOCK + TAIL_BLOCK >= hidden_size
+    and MAIN_BLOCK <= hidden_size, or None when the row is an exact power of
+    two (plain single-pass is already mask-free) or the tail would be too
+    large to keep register pressure bounded.
+    """
+    main = 1 << (hidden_size.bit_length() - 1)  # largest pow2 <= hidden_size
+    rem = hidden_size - main
+    if rem == 0:
+        return None
+    tail = triton.next_power_of_2(rem)
+    if tail > 4096:
+        return None
+    return main, tail
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("scaled_int8_quant_dynamic"),
+    key=["hidden_size"],
+)
+@triton.jit
+def _dynamic_int8_quant_kernel(
+    input_ptr,
+    output_ptr,
+    scale_out_ptr,
+    azp_out_ptr,
+    hidden_size,
+    SYMMETRIC: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    row_offset = pid * hidden_size
+
+    if SYMMETRIC:
+        row_absmax = 0.0
+        for start in range(0, hidden_size, BLOCK_SIZE):
+            in_blk = tl.make_block_ptr(
+                base=input_ptr + row_offset,
+                shape=(hidden_size,),
+                strides=(1,),
+                offsets=(start,),
+                block_shape=(BLOCK_SIZE,),
+                order=(0,),
+            )
+            src = tl.load(in_blk, boundary_check=(0,), padding_option="zero").to(
+                tl.float32
+            )
+            chunk_absmax = tl.max(tl.abs(src))
+            row_absmax = tl.maximum(row_absmax, chunk_absmax)
+
+        scale = row_absmax / 127.0
+        inv_s = tl.where(row_absmax == 0.0, 0.0, 127.0 / row_absmax)
+
+        tl.store(scale_out_ptr + pid, scale)
+
+        for start in range(0, hidden_size, BLOCK_SIZE):
+            in_blk = tl.make_block_ptr(
+                base=input_ptr + row_offset,
+                shape=(hidden_size,),
+                strides=(1,),
+                offsets=(start,),
+                block_shape=(BLOCK_SIZE,),
+                order=(0,),
+            )
+            src = tl.load(in_blk, boundary_check=(0,), padding_option="zero").to(
+                tl.float32
+            )
+            dst = _round_i8_sat(src * inv_s)
+            out_blk = tl.make_block_ptr(
+                base=output_ptr + row_offset,
+                shape=(hidden_size,),
+                strides=(1,),
+                offsets=(start,),
+                block_shape=(BLOCK_SIZE,),
+                order=(0,),
+            )
+            tl.store(out_blk, dst, boundary_check=(0,))
+
+    else:
+        row_min = INF_VAL
+        row_max = NEG_INF_VAL
+        for start in range(0, hidden_size, BLOCK_SIZE):
+            in_blk = tl.make_block_ptr(
+                base=input_ptr + row_offset,
+                shape=(hidden_size,),
+                strides=(1,),
+                offsets=(start,),
+                block_shape=(BLOCK_SIZE,),
+                order=(0,),
+            )
+            src = tl.load(in_blk, boundary_check=(0,), padding_option="zero").to(
+                tl.float32
+            )
+            offsets = start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < hidden_size
+            row_max = tl.maximum(row_max, tl.max(tl.where(mask, src, NEG_INF_VAL)))
+            row_min = tl.minimum(row_min, tl.min(tl.where(mask, src, INF_VAL)))
+
+        scale = (row_max - row_min) / 255.0
+        inv_s = 1.0 / scale
+        azp = _round_i32_sat(-128.0 - row_min * inv_s)
+
+        tl.store(scale_out_ptr + pid, scale)
+        tl.store(azp_out_ptr + pid, azp)
+
+        for start in range(0, hidden_size, BLOCK_SIZE):
+            in_blk = tl.make_block_ptr(
+                base=input_ptr + row_offset,
+                shape=(hidden_size,),
+                strides=(1,),
+                offsets=(start,),
+                block_shape=(BLOCK_SIZE,),
+                order=(0,),
+            )
+            src = tl.load(in_blk, boundary_check=(0,), padding_option="zero").to(
+                tl.float32
+            )
+            dst = _saturate_i32_to_i8(_round_i32_sat(src * inv_s) + azp)
+            out_blk = tl.make_block_ptr(
+                base=output_ptr + row_offset,
+                shape=(hidden_size,),
+                strides=(1,),
+                offsets=(start,),
+                block_shape=(BLOCK_SIZE,),
+                order=(0,),
+            )
+            tl.store(out_blk, dst, boundary_check=(0,))
+
+
+# ── host dispatch ────────────────────────────────────────────────────────────
+
+# When the token count is below this threshold we use a 2-D grid so each
+# block handles a single chunk — this spreads the work across more SMs when
+# there are few rows. When there are many rows, the 1-D grid (one block per
+# row) already saturates the GPU, and keeping the inner loop avoids grid
+# launch overhead.
+_2D_GRID_TOKEN_THRESHOLD = 256
+
+# Dynamic symmetric rows up to this size are quantized with a single global
+# read (whole row held in registers). Above it the two-loop kernel is used.
+_SINGLE_PASS_MAX_HIDDEN = 4096
+
+# Non-pow2 rows in (single-pass max, this] go through the main+tail kernel
+# (unmasked pow2 main block + masked pow2 tail). Pow2 rows up to
+# _SINGLE_PASS_MAX_HIDDEN_WIDE use the plain single-pass kernel.
+_MAIN_TAIL_MAX_HIDDEN = 16384
+_SINGLE_PASS_MAX_HIDDEN_WIDE = 16384
+
+
+def _token_bucket(num_tokens):
+    """Bucket token counts so the autotune cache stays small on decode-style
+    workloads where num_tokens changes every step."""
+    if num_tokens <= 8:
+        return num_tokens
+    if num_tokens <= 128:
+        return 16 * ((num_tokens + 15) // 16)
+    if num_tokens <= 1024:
+        return 128 * ((num_tokens + 127) // 128)
+    return 1024 * ((num_tokens + 1023) // 1024)
+
+
+def scaled_int8_quant(
+    input: torch.Tensor,
+    scale: torch.Tensor | None = None,
+    azp: torch.Tensor | None = None,
+    symmetric: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    input_2d = input.reshape(-1, input.shape[-1])
+    num_tokens, hidden_size = input_2d.shape
+    token_bucket = _token_bucket(num_tokens)
+
+    if scale is not None:
+        if not symmetric and azp is None:
+            raise ValueError("azp must be provided for asymmetric static quantization")
+        output = torch.empty_like(input_2d, dtype=torch.int8)
+        azp_or_dummy = azp if azp is not None else scale  # unused in this path
+
+        if num_tokens < _2D_GRID_TOKEN_THRESHOLD:
+            grid = lambda META: (  # noqa: E731
+                num_tokens,
+                triton.cdiv(hidden_size, META["BLOCK_SIZE"]),
+            )
+            _static_int8_quant_kernel[grid](
+                input_2d,
+                output,
+                scale,
+                azp_or_dummy,
+                hidden_size,
+                SYMMETRIC=symmetric,
+            )
+        else:
+            grid = (num_tokens,)
+            _static_int8_quant_kernel_1d[grid](
+                input_2d,
+                output,
+                scale,
+                azp_or_dummy,
+                hidden_size,
+                SYMMETRIC=symmetric,
+            )
+        return output.view(input.shape), scale, azp
+
+    output = torch.empty_like(input_2d, dtype=torch.int8)
+    input_scales = torch.empty(
+        (num_tokens, 1), device=input.device, dtype=torch.float32
+    )
+    if symmetric:
+        input_azp = None
+        azp_out_or_dummy = input_scales  # pointer unused in this path
+    else:
+        input_azp = torch.empty((num_tokens, 1), device=input.device, dtype=torch.int32)
+        azp_out_or_dummy = input_azp
+
+    if symmetric:
+        # Single global read paths. The whole row stays in registers across
+        # the absmax and quantize steps, halving DRAM traffic vs the generic
+        # two-loop kernel. Single-pass pads the row to one pow2 block (cheap
+        # when hidden_size is a power of two or nearly so); main+tail splits
+        # it into an unmasked pow2 main block plus a masked pow2 tail, which
+        # wins for sizes like 5120 = 4096 + 1024.
+        main_tail = (
+            _decompose_main_tail(hidden_size)
+            if _SINGLE_PASS_MAX_HIDDEN < hidden_size <= _MAIN_TAIL_MAX_HIDDEN
+            else None
+        )
+        if hidden_size <= _SINGLE_PASS_MAX_HIDDEN:
+            _dynamic_int8_quant_kernel_single_pass[(num_tokens,)](
+                input_2d,
+                output,
+                input_scales,
+                hidden_size,
+                token_bucket,
+            )
+        elif main_tail is not None:
+            main_block, tail_block = main_tail
+            _dynamic_int8_quant_kernel_main_tail[(num_tokens,)](
+                input_2d,
+                output,
+                input_scales,
+                hidden_size,
+                token_bucket,
+                MAIN_BLOCK=main_block,
+                TAIL_BLOCK=tail_block,
+            )
+        elif hidden_size <= _SINGLE_PASS_MAX_HIDDEN_WIDE:
+            _dynamic_int8_quant_kernel_single_pass[(num_tokens,)](
+                input_2d,
+                output,
+                input_scales,
+                hidden_size,
+                token_bucket,
+            )
+        else:
+            _dynamic_int8_quant_kernel[(num_tokens,)](
+                input_2d,
+                output,
+                input_scales,
+                azp_out_or_dummy,
+                hidden_size,
+                SYMMETRIC=symmetric,
+            )
+    else:
+        if hidden_size <= _SINGLE_PASS_MAX_HIDDEN:
+            _dynamic_int8_quant_kernel_azp_single_pass[(num_tokens,)](
+                input_2d,
+                output,
+                input_scales,
+                input_azp,
+                hidden_size,
+                token_bucket,
+            )
+        else:
+            _dynamic_int8_quant_kernel[(num_tokens,)](
+                input_2d,
+                output,
+                input_scales,
+                azp_out_or_dummy,
+                hidden_size,
+                SYMMETRIC=symmetric,
+            )
+    return output.view(input.shape), input_scales, input_azp

--- a/src/flaggems_vllm/runtime/backend/_nvidia/tune_configs.yaml
+++ b/src/flaggems_vllm/runtime/backend/_nvidia/tune_configs.yaml
@@ -274,3 +274,81 @@ gated_activation:
       - 8
     block_n:
       - 1024
+scaled_int8_quant_static:
+  - gen: true
+    param_map:
+      META:
+        BLOCK_SIZE: block_size
+      num_warps: warps
+      num_stages: stages
+    block_size:
+      - 256
+      - 512
+      - 1024
+    warps:
+      - 4
+      - 8
+      - 16
+    stages:
+      - 2
+      - 3
+      - 4
+
+scaled_int8_quant_dynamic:
+  - gen: true
+    param_map:
+      META:
+        BLOCK_SIZE: block_size
+      num_warps: warps
+      num_stages: stages
+    block_size:
+      - 256
+      - 512
+      - 1024
+      - 2048
+      - 4096
+    warps:
+      - 4
+      - 8
+      - 16
+    stages:
+      - 3
+      - 4
+      - 5
+
+scaled_int8_quant_dynamic_single:
+  - gen: true
+    param_map:
+      META:
+        PLACEHOLDER_UNUSED: placeholder
+      num_warps: warps
+      num_stages: stages
+    placeholder:
+      - 1
+    warps:
+      - 2
+      - 4
+      - 8
+      - 16
+    stages:
+      - 1
+      - 2
+      - 3
+
+scaled_int8_quant_dynamic_main_tail:
+  - gen: true
+    param_map:
+      META:
+        PLACEHOLDER_UNUSED: placeholder
+      num_warps: warps
+      num_stages: stages
+    placeholder:
+      - 1
+    warps:
+      - 4
+      - 8
+      - 16
+    stages:
+      - 1
+      - 2
+      - 3

--- a/tests/test_scaled_int8_quant.py
+++ b/tests/test_scaled_int8_quant.py
@@ -1,0 +1,171 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import flaggems_vllm
+
+from .conftest import QUICK_MODE
+
+device = flaggems_vllm.device
+INT8_ABSMAX = 127.0
+INT8_RANGE = 255.0
+I32_MIN = -2147483648
+I32_MAX = 2147483647
+
+if QUICK_MODE:
+    NUM_TOKENS = [7]
+    HIDDEN_SIZES = [1024]
+    DTYPES = [torch.bfloat16]
+    SCALE = [0.1]
+    AZP = [54]
+else:
+    NUM_TOKENS = [1, 7, 4096]
+    HIDDEN_SIZES = [17, 1024, 1025, 1026, 5137, 8193]
+    DTYPES = [torch.bfloat16, torch.float]
+    SCALE = [0.1, 2.1]
+    AZP = [-255, 54]
+
+
+def _ref_dynamic_symmetric(x):
+    x_f32 = x.float()
+    absmax = x_f32.abs().amax(dim=-1, keepdim=True)
+    scale = absmax / INT8_ABSMAX
+    inv_s = torch.where(
+        absmax == 0, torch.tensor(0.0, device=x.device), INT8_ABSMAX / absmax
+    )
+    q = (x_f32 * inv_s).round().clamp(-128, 127).to(torch.int8)
+    return q, scale
+
+
+def _ref_dynamic_asymmetric(x):
+    x_f32 = x.float()
+    row_max = x_f32.amax(dim=-1, keepdim=True)
+    row_min = x_f32.amin(dim=-1, keepdim=True)
+    scale = (row_max - row_min) / INT8_RANGE
+    azp = (-128.0 - row_min / scale).round().clamp(I32_MIN, I32_MAX).to(torch.int32)
+    q = ((x_f32 / scale).round() + azp).clamp(-128, 127).to(torch.int8)
+    return q, scale, azp
+
+
+@pytest.mark.scaled_int8_quant
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@torch.inference_mode()
+def test_dynamic_scaled_int8_quant(num_tokens, hidden_size, dtype):
+    torch.manual_seed(0)
+    x = torch.rand(num_tokens, hidden_size, dtype=dtype, device=device) * 1000
+
+    ref_out, ref_scale = _ref_dynamic_symmetric(x)
+    ops_out, ops_scale, ops_azp = flaggems_vllm.scaled_int8_quant(x, symmetric=True)
+
+    assert ops_azp is None
+    torch.testing.assert_close(ops_scale, ref_scale)
+    torch.testing.assert_close(ops_out, ref_out, atol=1, rtol=0.0)
+
+
+@pytest.mark.scaled_int8_quant
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@torch.inference_mode()
+def test_dynamic_scaled_int8_azp_quant(num_tokens, hidden_size, dtype):
+    torch.manual_seed(0)
+    x = torch.rand(num_tokens, hidden_size, dtype=dtype, device=device) * 1000 - 300
+
+    ref_out, ref_scale, ref_azp = _ref_dynamic_asymmetric(x)
+    ops_out, ops_scale, ops_azp = flaggems_vllm.scaled_int8_quant(x, symmetric=False)
+
+    torch.testing.assert_close(ops_scale, ref_scale)
+    torch.testing.assert_close(ops_azp, ref_azp, atol=1, rtol=0.0)
+    torch.testing.assert_close(ops_out, ref_out, atol=2, rtol=0.0)
+
+
+@pytest.mark.scaled_int8_quant
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("scale", SCALE)
+@torch.inference_mode()
+def test_static_scaled_int8_quant(num_tokens, hidden_size, dtype, scale):
+    torch.manual_seed(0)
+    x = torch.rand(num_tokens, hidden_size, dtype=dtype, device=device) * 1000
+    scale_arg = torch.tensor([scale], dtype=torch.float32, device=device)
+
+    ref_out = (x / scale_arg).round().clamp(-128, 127).to(torch.int8)
+    ops_out, ops_scale, _ = flaggems_vllm.scaled_int8_quant(x, scale_arg)
+    assert ops_scale is scale_arg
+
+    torch.testing.assert_close(ref_out, ops_out, atol=1, rtol=0.0)
+
+
+@pytest.mark.scaled_int8_quant
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("scale", SCALE)
+@pytest.mark.parametrize("azp", AZP)
+@torch.inference_mode()
+def test_static_scaled_int8_azp_quant(num_tokens, hidden_size, dtype, scale, azp):
+    torch.manual_seed(0)
+    x = torch.rand(num_tokens, hidden_size, dtype=dtype, device=device) * 1000 - 300
+    scale_arg = torch.tensor([scale], dtype=torch.float32, device=device)
+    azp_arg = torch.tensor([azp], dtype=torch.int32, device=device)
+
+    ref_out = ((x / scale).round() + azp).clamp(-128, 127).to(torch.int8)
+    ops_out, ops_scale, ops_azp = flaggems_vllm.scaled_int8_quant(
+        x, scale_arg, azp_arg, symmetric=False
+    )
+    assert ops_scale is scale_arg
+    assert ops_azp is azp_arg
+
+    torch.testing.assert_close(ref_out, ops_out, atol=1, rtol=0.0)
+
+
+@pytest.mark.scaled_int8_quant
+@pytest.mark.parametrize("is_max", [True, False])
+@torch.inference_mode()
+def test_static_scaled_int8_azp_quant_saturating_cast(is_max):
+    from numpy import inf, nextafter
+
+    i32_max = 2147483647
+    i32_min = -2147483648
+    val = float(i32_max if is_max else i32_min)
+
+    x_vals = [[nextafter(val, inf), val + 1, val, val - 1, nextafter(val, -inf)]]
+    x = torch.tensor(x_vals, dtype=torch.float32, device=device)
+
+    scale = torch.tensor([1.0], dtype=torch.float32, device=device)
+    azp = torch.tensor([0], dtype=torch.int32, device=device)
+
+    expected_val = 127 if is_max else -128
+    expected = torch.full((1, 5), expected_val, dtype=torch.int8, device=device)
+
+    out, _, _ = flaggems_vllm.scaled_int8_quant(x, scale, azp, symmetric=False)
+    torch.testing.assert_close(expected, out, atol=0, rtol=0)
+
+
+@pytest.mark.scaled_int8_quant
+@pytest.mark.parametrize("value", [0.0, 3.0, -7.5])
+@torch.inference_mode()
+def test_dynamic_scaled_int8_azp_quant_constant_row(value):
+    # Constant rows make span == 0; scale becomes 0 and azp saturates. The
+    # implementation must not produce NaN/Inf and must stay finite.
+    x = torch.full((4, 1024), value, dtype=torch.bfloat16, device=device)
+    ops_out, ops_scale, ops_azp = flaggems_vllm.scaled_int8_quant(x, symmetric=False)
+    assert torch.isfinite(ops_scale).all()
+    assert torch.isfinite(ops_azp.float()).all()
+    assert torch.isfinite(ops_out.float()).all()


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `scaled_int8_quant` operator — a Triton implementation of vLLM's INT8 per-token/per-tensor quantization kernel, supporting all four modes: dynamic symmetric, dynamic asymmetric, static symmetric, and static asymmetric. Rounding follows round-to-nearest-even + saturation semantics, matching the reference CUDA kernel.

This builds on the approach of #63 and reworks the dynamic-quantization paths so that every row is read from global memory **exactly once**:

- **Single-pass kernel** (symmetric, `hidden_size <= 16384`): the whole row is loaded into registers; absmax reduce and quantize share that single read. For power-of-two rows the load is fully unmasked.
- **Main+tail kernel** (symmetric, non-power-of-two rows such as 5120 = 4096 + 1024): an unmasked pow2 main block plus a masked pow2 tail block, both register-resident, avoiding the dead-lane waste of padding the row to the next power of two.
- **Asymmetric single-pass kernel** (`hidden_size <= 4096`): same structure with min/max reduce; constant-row behavior (span = 0) matches the vLLM reference exactly.
- Larger/unsupported rows fall back to the two-loop kernel with extended tuning candidates.

Also in this change:
- Autotune keys include a **bucketed token count** — per-(M, N) configs are picked correctly without cache explosion on decode-style workloads where `num_tokens` changes every step.
- Static-path grid is computed from the autotuned `BLOCK_SIZE` (META lambda) instead of a hardcoded 256, removing idle blocks.
- Static asymmetric calls without `azp` now raise `ValueError` instead of reading an uninitialized dummy pointer; symmetric dynamic path no longer allocates an unused dummy tensor.

### Issue
N/A

### Progress
- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Testing
`pytest -v -s tests/test_scaled_int8_quant.py` — 293 passed. Validated against reference on device (NVIDIA H20), covering dynamic/static × symmetric/asymmetric, bf16/fp32, hidden sizes 17–8193 (incl. non-pow2), token counts 1/7/4096, int32 saturation boundaries, and constant rows.

### Performance
Benchmark command: `pytest benchmark/test_scaled_int8_quant.py --level core` (NVIDIA H20, dtype bf16, baseline = vLLM `scaled_int8_quant` CUDA kernel).

#### Dynamic symmetric (arithmetic mean SpeedUp **1.11x**; PR #63 measured 0.80x on the same host)

| Num Tokens | Hidden Size | Torch (ms) | Gems (ms) | SpeedUp |
|---|---|---|---|---|
| 1 | 512 | 0.006304 | 0.005984 | 1.053 |
| 1 | 1024 | 0.005920 | 0.005920 | 1.000 |
| 1 | 4096 | 0.006528 | 0.006304 | 1.036 |
| 1 | 5120 | 0.007008 | 0.006528 | 1.074 |
| 1 | 8192 | 0.006880 | 0.006688 | 1.029 |
| 1 | 13824 | 0.008032 | 0.007008 | 1.146 |
| 64 | 512 | 0.006240 | 0.006208 | 1.005 |
| 64 | 1024 | 0.006368 | 0.005952 | 1.070 |
| 64 | 4096 | 0.007680 | 0.007072 | 1.086 |
| 64 | 5120 | 0.007584 | 0.006976 | 1.087 |
| 64 | 8192 | 0.007904 | 0.007232 | 1.093 |
| 64 | 13824 | 0.008960 | 0.007776 | 1.152 |
| 512 | 512 | 0.006752 | 0.006112 | 1.105 |
| 512 | 1024 | 0.006976 | 0.006464 | 1.079 |
| 512 | 4096 | 0.008960 | 0.009120 | 0.982 |
| 512 | 5120 | 0.009696 | 0.009664 | 1.003 |
| 512 | 8192 | 0.011552 | 0.011008 | 1.049 |
| 512 | 13824 | 0.014656 | 0.015648 | 0.937 |
| 2048 | 512 | 0.011040 | 0.007680 | 1.438 |
| 2048 | 1024 | 0.011840 | 0.008672 | 1.365 |
| 2048 | 4096 | 0.015360 | 0.014496 | 1.060 |
| 2048 | 5120 | 0.019104 | 0.016928 | 1.129 |
| 2048 | 8192 | 0.023488 | 0.023232 | 1.011 |
| 2048 | 13824 | 0.034528 | 0.037952 | 0.910 |
| 4096 | 512 | 0.015264 | 0.008864 | **1.722** |
| 4096 | 1024 | 0.016416 | 0.010496 | **1.564** |
| 4096 | 4096 | 0.024704 | 0.022304 | 1.108 |
| 4096 | 5120 | 0.031136 | 0.026688 | 1.167 |
| 4096 | 8192 | 0.038528 | 0.040032 | 0.962 |
| 4096 | 13824 | 0.058816 | 0.070944 | 0.829 |

#### Static symmetric (arithmetic mean SpeedUp **1.12x**)

| Num Tokens | Hidden Size | Torch (ms) | Gems (ms) | SpeedUp |
|---|---|---|---|---|
| 1 | 512 | 0.005984 | 0.005344 | 1.120 |
| 1 | 1024 | 0.006240 | 0.005312 | 1.175 |
| 1 | 4096 | 0.006400 | 0.005472 | 1.170 |
| 1 | 5120 | 0.007264 | 0.005472 | 1.327 |
| 1 | 8192 | 0.007040 | 0.005888 | 1.196 |
| 1 | 13824 | 0.008896 | 0.005920 | **1.503** |
| 64 | 512 | 0.006592 | 0.005728 | 1.151 |
| 64 | 1024 | 0.006304 | 0.005760 | 1.094 |
| 64 | 4096 | 0.007424 | 0.006816 | 1.089 |
| 64 | 5120 | 0.007520 | 0.007328 | 1.026 |
| 64 | 8192 | 0.008128 | 0.006176 | 1.316 |
| 64 | 13824 | 0.010176 | 0.010080 | 1.010 |
| 512 | 512 | 0.006592 | 0.006176 | 1.067 |
| 512 | 1024 | 0.007296 | 0.006912 | 1.056 |
| 512 | 4096 | 0.009792 | 0.009408 | 1.041 |
| 512 | 5120 | 0.011200 | 0.010144 | 1.104 |
| 512 | 8192 | 0.012992 | 0.012384 | 1.049 |
| 512 | 13824 | 0.018336 | 0.016224 | 1.130 |
| 2048 | 512 | 0.009248 | 0.007808 | 1.184 |
| 2048 | 1024 | 0.010048 | 0.008480 | 1.185 |
| 2048 | 4096 | 0.017568 | 0.017280 | 1.017 |
| 2048 | 5120 | 0.021216 | 0.020352 | 1.042 |
| 2048 | 8192 | 0.029408 | 0.028800 | 1.021 |
| 2048 | 13824 | 0.046080 | 0.043744 | 1.053 |
| 4096 | 512 | 0.011168 | 0.009184 | 1.216 |
| 4096 | 1024 | 0.012800 | 0.011264 | 1.136 |
| 4096 | 4096 | 0.028608 | 0.028032 | 1.021 |
| 4096 | 5120 | 0.035104 | 0.033056 | 1.062 |
| 4096 | 8192 | 0.051744 | 0.047968 | 1.079 |
| 4096 | 13824 | 0.083296 | 0.076288 | 1.092 |

Notes:
- The remaining sub-0.9 dynamic shapes ((4096, 13824) at 0.83) hit a Triton codegen bandwidth ceiling: the vLLM CUDA kernel sustains ~2.98 TB/s there vs ~2.6 TB/s for the Triton single-read kernel (113 MB input, far above the 60 MB L2). Alternatives that split each row across blocks (two-kernel partial-reduce, cooperative spin exchange) measured significantly worse (0.52–0.69).
- Static path is unchanged in algorithm from #63; observed deltas vs the #63 report are run-to-run/host variance.
