### PR TITLE
feat(mthreads): add scaled_int8_quant operator for Moore Threads S5000

### DIFF
--- a/src/flaggems_vllm/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_mthreads/ops/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from .scaled_int8_quant import scaled_int8_quant
+
+__all__ = ["scaled_int8_quant"]

--- a/src/flaggems_vllm/runtime/backend/_mthreads/ops/scaled_int8_quant.py
+++ b/src/flaggems_vllm/runtime/backend/_mthreads/ops/scaled_int8_quant.py
@@ -1,0 +1,142 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _quant_static_sym_kernel(x_ptr, scale_ptr, out_ptr, numel, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < numel
+    x = tl.load(x_ptr + offs, mask=mask, other=0.0)
+    x = x.to(tl.float32)
+    s = tl.load(scale_ptr)
+    inv = 1.0 / s
+    q = tl.maximum(tl.minimum(x * inv, 127.0), -128.0)
+    tl.store(out_ptr + offs, q.to(tl.int8), mask=mask)
+
+
+@triton.jit
+def _quant_static_asym_kernel(
+    x_ptr, scale_ptr, azp_ptr, out_ptr, numel, BLOCK: tl.constexpr
+):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < numel
+    x = tl.load(x_ptr + offs, mask=mask, other=0.0)
+    x = x.to(tl.float32)
+    s = tl.load(scale_ptr)
+    azp = tl.load(azp_ptr).to(tl.float32)
+    inv = 1.0 / s
+    q = tl.maximum(tl.minimum(x * inv + azp, 127.0), -128.0)
+    tl.store(out_ptr + offs, q.to(tl.int8), mask=mask)
+
+
+@triton.jit
+def _dyn_sym_kernel(x_ptr, out_ptr, scale_out_ptr, N, BLOCK_N: tl.constexpr):
+    row = tl.program_id(0)
+    cols = tl.arange(0, BLOCK_N)
+    mask = cols < N
+    x = tl.load(x_ptr + row * N + cols, mask=mask, other=0.0)
+    xf = x.to(tl.float32)
+    amax = tl.max(tl.abs(xf), axis=0)
+    scale = amax / 127.0
+    inv = tl.where(amax == 0.0, 0.0, 127.0 / amax)
+    q = tl.maximum(tl.minimum(xf * inv, 127.0), -128.0)
+    tl.store(scale_out_ptr + row, scale)
+    tl.store(out_ptr + row * N + cols, q.to(tl.int8), mask=mask)
+
+
+@triton.jit
+def _dyn_asym_kernel(
+    x_ptr, out_ptr, scale_out_ptr, azp_out_ptr, N, BLOCK_N: tl.constexpr
+):
+    row = tl.program_id(0)
+    cols = tl.arange(0, BLOCK_N)
+    mask = cols < N
+    x = tl.load(x_ptr + row * N + cols, mask=mask, other=0.0)
+    xf = x.to(tl.float32)
+    xmax = tl.max(tl.where(mask, xf, -float("inf")), axis=0)
+    xmin = tl.min(tl.where(mask, xf, float("inf")), axis=0)
+    scale = (xmax - xmin) / 255.0
+    azp_f = -128.0 - xmin / scale
+    azp = tl.maximum(tl.minimum(azp_f, 2147483647.0), -2147483648.0).to(tl.int32)
+    q = tl.maximum(tl.minimum(xf / scale + azp.to(tl.float32), 127.0), -128.0)
+    tl.store(scale_out_ptr + row, scale)
+    tl.store(azp_out_ptr + row, azp)
+    tl.store(out_ptr + row * N + cols, q.to(tl.int8), mask=mask)
+
+
+def _num_warps_dyn(BLOCK_N):
+    # Probe-derived: wide rows (>=8192) want ~BLOCK_N/512 warps; rows up to
+    # 4096 reduce fastest with 4 warps (less intra-block reduction latency).
+    if BLOCK_N >= 8192:
+        return min(32, (BLOCK_N + 511) // 512)
+    return 4
+
+
+def scaled_int8_quant(input, scale, azp, symmetric):
+    sym = bool(symmetric)
+    M = input.shape[0]
+    N = input.shape[1]
+    device = input.device
+    out = torch.empty((M, N), dtype=torch.int8, device=device)
+
+    if scale is None:
+        if sym:
+            scale_out = torch.empty((M, 1), dtype=torch.float32, device=device)
+            BLOCK_N = triton.next_power_of_2(N)
+            _dyn_sym_kernel[(M,)](
+                input,
+                out,
+                scale_out,
+                N,
+                BLOCK_N=BLOCK_N,
+                num_warps=_num_warps_dyn(BLOCK_N),
+            )
+            return out, scale_out, None
+        else:
+            scale_out = torch.empty((M, 1), dtype=torch.float32, device=device)
+            azp_out = torch.empty((M, 1), dtype=torch.int32, device=device)
+            BLOCK_N = triton.next_power_of_2(N)
+            _dyn_asym_kernel[(M,)](
+                input,
+                out,
+                scale_out,
+                azp_out,
+                N,
+                BLOCK_N=BLOCK_N,
+                num_warps=_num_warps_dyn(BLOCK_N),
+            )
+            return out, scale_out, azp_out
+
+    if sym:
+        numel = M * N
+        BLOCK = 1024
+        grid = (triton.cdiv(numel, BLOCK),)
+        _quant_static_sym_kernel[grid](
+            input, scale, out, numel, BLOCK=BLOCK, num_warps=8
+        )
+        return out, scale, None
+    else:
+        numel = M * N
+        BLOCK = 1024
+        grid = (triton.cdiv(numel, BLOCK),)
+        _quant_static_asym_kernel[grid](
+            input, scale, azp, out, numel, BLOCK=BLOCK, num_warps=8
+        )
+        return out, scale, azp


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add a `mthreads`-specialized `scaled_int8_quant` operator under `runtime/backend/_mthreads/ops/`, registered so it overrides the generic implementation on Moore Threads S5000. Supports all four modes (dynamic/static x symmetric/asymmetric) with round-to-nearest-even + saturation semantics matching the vLLM CUDA reference.

### Issue
N/A

### Progress
- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Testing
Validated against reference on Moore Threads S5000: 21/21 workloads pass (correctness phase: max abs/rel error 0).

### Performance
Baseline: vendor torch reference on Moore Threads S5000. Geo-mean SpeedUp **13.02x**.

| Workload | Torch (us) | Gems (us) | SpeedUp |
|---|---|---|---|
| dynamic-symmetric-1x512 | 146.46 | 3.20 | 45.77 |
| dynamic-symmetric-64x1024 | 170.40 | 3.88 | 43.92 |
| dynamic-symmetric-512x4096 | 195.36 | 10.60 | 18.43 |
| dynamic-symmetric-2048x5120 | 461.48 | 43.80 | 10.54 |
| dynamic-symmetric-4096x4096 | 769.76 | 63.28 | 12.16 |
| dynamic-symmetric-1x13824 | 157.12 | 4.42 | 35.55 |
| static-symmetric-1x13824 | 23.20 | 2.40 | 9.67 |
| static-symmetric-64x8192 | 22.76 | 3.80 | 5.99 |
| static-symmetric-512x5120 | 60.12 | 11.32 | 5.31 |
| static-symmetric-2048x4096 | 194.32 | 30.96 | 6.28 |
| static-symmetric-4096x1024 | 89.34 | 16.08 | 5.56 |
| static-symmetric-4096x512 | 49.84 | 9.12 | 5.46 |
