### PR TITLE
feat(iluvatar): add scaled_int8_quant operator for Iluvatar BI-V150 (Tianshu)

### DIFF
--- a/src/flaggems_vllm/runtime/backend/_iluvatar/ops/scaled_int8_quant.py
+++ b/src/flaggems_vllm/runtime/backend/_iluvatar/ops/scaled_int8_quant.py
@@ -16,249 +16,351 @@ import torch
 import triton
 import triton.language as tl
 
+try:
+    from triton.language.extra import libdevice as _tld
+
+    @triton.jit
+    def _round_even(x):
+        return _tld.nearbyint(x)
+
+except Exception:
+    # Fallback: floor-based round-half-to-even (bitwise identical to torch.round)
+    @triton.jit
+    def _round_even(x):
+        f = tl.math.floor(x)
+        d = x - f
+        f_odd = (f - 2.0 * tl.math.floor(f * 0.5)) == 1.0
+        r = tl.where(
+            d < 0.5, f, tl.where(d > 0.5, f + 1.0, tl.where(f_odd, f + 1.0, f))
+        )
+        return r
+
+
+@triton.jit
+def _clamp_i8(x):
+    return tl.maximum(tl.minimum(x, 127.0), -128.0).to(tl.int8)
+
 
 # ---------------------------------------------------------------------------
-# Round-half-to-even (matches torch.round / reference .round()) using only
-# floor, so it works on backends without tl.round.  All arithmetic in f32:
-#   r = floor(x + 0.5)  (round-half-up candidate)
-#   if |x - r| == 0.5 and r is odd: result = r - 1
+# Static quantization: scale (and optionally azp) are given.  Pure pointwise.
+# Flat 1-D grid over the whole tensor.  EVEN skips boundary masks when
+# numel % BLOCK_SIZE == 0.
 # ---------------------------------------------------------------------------
 @triton.jit
-def _rnd(x):
-    r = tl.floor(x + 0.5)
-    half = tl.abs(x - r) == 0.5
-    odd = tl.abs(r - 2.0 * tl.floor(r / 2.0)) == 1.0
-    adj = tl.where(half, tl.where(odd, 1.0, 0.0), 0.0)
-    return r - adj
-
-
-# ---------------------------------------------------------------------------
-# Static scale: pure pointwise quantization.
-#   symmetric:  out = clamp(round(x / scale), -128, 127) as int8
-#   asymmetric: out = clamp(round(x / scale) + azp, -128, 127) as int8
-# ---------------------------------------------------------------------------
-@triton.jit
-def _quant_static_sym_kernel(
+def _static_quant_kernel(
     input_ptr,
-    scale_ptr,
     output_ptr,
-    numel,
-    BLOCK: tl.constexpr,
-):
-    pid = tl.program_id(0).to(tl.int64)
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
-    mask = offs < numel
-    x = tl.load(input_ptr + offs, mask=mask, other=0.0).to(tl.float32)
-    s = tl.load(scale_ptr).to(tl.float32)
-    q = _rnd(x / s)
-    q = tl.minimum(tl.maximum(q, -128.0), 127.0)
-    tl.store(output_ptr + offs, q.to(tl.int8), mask=mask)
-
-
-@triton.jit
-def _quant_static_asym_kernel(
-    input_ptr,
     scale_ptr,
     azp_ptr,
-    output_ptr,
     numel,
-    BLOCK: tl.constexpr,
+    SYMMETRIC: tl.constexpr,
+    EVEN: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0).to(tl.int64)
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
-    mask = offs < numel
-    x = tl.load(input_ptr + offs, mask=mask, other=0.0).to(tl.float32)
-    s = tl.load(scale_ptr).to(tl.float32)
-    a = tl.load(azp_ptr).to(tl.float32)
-    q = _rnd(x / s) + a
-    q = tl.minimum(tl.maximum(q, -128.0), 127.0)
-    tl.store(output_ptr + offs, q.to(tl.int8), mask=mask)
+    pid = tl.program_id(0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    scale = tl.load(scale_ptr)
+
+    if EVEN:
+        src = tl.load(input_ptr + offs).to(tl.float32)
+        if SYMMETRIC:
+            q = _round_even(src / scale)
+        else:
+            azp = tl.load(azp_ptr)
+            q = _round_even(src / scale) + azp.to(tl.float32)
+        tl.store(output_ptr + offs, _clamp_i8(q))
+    else:
+        mask = offs < numel
+        src = tl.load(input_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+        if SYMMETRIC:
+            q = _round_even(src / scale)
+        else:
+            azp = tl.load(azp_ptr)
+            q = _round_even(src / scale) + azp.to(tl.float32)
+        tl.store(output_ptr + offs, _clamp_i8(q), mask=mask)
 
 
 # ---------------------------------------------------------------------------
-# Dynamic symmetric: per-row absmax reduction, then quantize.
-# One CTA per row; pass 1 reduces, pass 2 re-reads (L2-resident) and
-# quantizes.  HAS_MASK removes all masking when cols % BLOCK_N == 0 so the
-# timing shapes (all multiples of 512/1024) run unpredicated.
-# Matches reference arithmetic exactly:
-#   scale = absmax / 127 ; inv = where(absmax==0, 0, 127/absmax)
-#   out   = clamp(round(x * inv), -128, 127)
+# Dynamic quantization, symmetric: per-row absmax, scale = absmax/127,
+# out = clamp(round(src * (127/absmax)), -128, 127).
+# SINGLE keeps the whole row in registers; LOOP re-reads the row in chunks.
+# EVEN skips boundary masks when the row exactly fills the tile.
 # ---------------------------------------------------------------------------
 @triton.jit
-def _quant_dynamic_sym_kernel(
-    input_ptr,
-    output_ptr,
-    scale_out_ptr,
-    cols,
-    HAS_MASK: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-):
-    row = tl.program_id(0).to(tl.int64)
-    base = row * cols
-    n_chunks = tl.cdiv(cols, BLOCK_N)
-    offs_c = tl.arange(0, BLOCK_N)
-    acc = tl.full((BLOCK_N,), float("-inf"), tl.float32)
-    for i in tl.range(0, n_chunks):
-        offs = i * BLOCK_N + offs_c
-        if HAS_MASK:
-            mask = offs < cols
-            x = tl.load(input_ptr + base + offs, mask=mask, other=0.0).to(tl.float32)
-            acc = tl.maximum(acc, tl.abs(x))
-        else:
-            x = tl.load(input_ptr + base + offs).to(tl.float32)
-            acc = tl.maximum(acc, tl.abs(x))
-    absmax = tl.max(acc, axis=0)
-    inv = tl.where(absmax == 0.0, 0.0, 127.0 / absmax)
-    tl.store(scale_out_ptr + row, absmax / 127.0)
-    for i in tl.range(0, n_chunks):
-        offs = i * BLOCK_N + offs_c
-        if HAS_MASK:
-            mask = offs < cols
-            x = tl.load(input_ptr + base + offs, mask=mask, other=0.0).to(tl.float32)
-            q = _rnd(x * inv)
-            q = tl.minimum(tl.maximum(q, -128.0), 127.0)
-            tl.store(output_ptr + base + offs, q.to(tl.int8), mask=mask)
-        else:
-            x = tl.load(input_ptr + base + offs).to(tl.float32)
-            q = _rnd(x * inv)
-            q = tl.minimum(tl.maximum(q, -128.0), 127.0)
-            tl.store(output_ptr + base + offs, q.to(tl.int8))
-
-
-# ---------------------------------------------------------------------------
-# Dynamic asymmetric: per-row max/min reduction, then quantize with the
-# computed scale and zero point.  Matches reference arithmetic exactly:
-#   scale = (max - min) / 255
-#   azp   = clamp(round(-128 - min/scale), -2^31, 2^31-1) as int32
-#   out   = clamp(round(x / scale) + azp, -128, 127)
-# ---------------------------------------------------------------------------
-@triton.jit
-def _quant_dynamic_asym_kernel(
+def _dyn_sym_kernel(
     input_ptr,
     output_ptr,
     scale_out_ptr,
     azp_out_ptr,
-    cols,
-    BLOCK_N: tl.constexpr,
+    hidden,
+    SINGLE: tl.constexpr,
+    EVEN: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
 ):
-    row = tl.program_id(0).to(tl.int64)
-    base = row * cols
-    n_chunks = tl.cdiv(cols, BLOCK_N)
-    offs_c = tl.arange(0, BLOCK_N)
-    acc_max = tl.full((BLOCK_N,), float("-inf"), tl.float32)
-    acc_min = tl.full((BLOCK_N,), float("inf"), tl.float32)
-    for i in tl.range(0, n_chunks):
-        offs = i * BLOCK_N + offs_c
-        mask = offs < cols
-        x = tl.load(input_ptr + base + offs, mask=mask, other=0.0).to(tl.float32)
-        acc_max = tl.maximum(acc_max, tl.where(mask, x, float("-inf")))
-        acc_min = tl.minimum(acc_min, tl.where(mask, x, float("inf")))
-    row_max = tl.max(acc_max, axis=0)
-    row_min = tl.min(acc_min, axis=0)
-    out_scale = (row_max - row_min) / 255.0
-    azp_f = _rnd(-128.0 - row_min / out_scale)
-    azp_f = tl.minimum(tl.maximum(azp_f, -2147483648.0), 2147483647.0)
-    tl.store(scale_out_ptr + row, out_scale)
-    tl.store(azp_out_ptr + row, azp_f.to(tl.int32))
-    for i in tl.range(0, n_chunks):
-        offs = i * BLOCK_N + offs_c
-        mask = offs < cols
-        x = tl.load(input_ptr + base + offs, mask=mask, other=0.0).to(tl.float32)
-        q = _rnd(x / out_scale) + azp_f
-        q = tl.minimum(tl.maximum(q, -128.0), 127.0)
-        tl.store(output_ptr + base + offs, q.to(tl.int8), mask=mask)
+    pid = tl.program_id(0)
+    row_offset = pid * hidden
+
+    if SINGLE:
+        offs = tl.arange(0, BLOCK_SIZE)
+        if EVEN:
+            src = tl.load(input_ptr + row_offset + offs).to(tl.float32)
+            row_absmax = tl.max(tl.abs(src))
+            scale = row_absmax / 127.0
+            inv = tl.where(row_absmax == 0.0, 0.0, 127.0 / row_absmax)
+            tl.store(scale_out_ptr + pid, scale)
+            dst = _clamp_i8(_round_even(src * inv))
+            tl.store(output_ptr + row_offset + offs, dst)
+        else:
+            mask = offs < hidden
+            src = tl.load(input_ptr + row_offset + offs, mask=mask, other=0.0).to(
+                tl.float32
+            )
+            row_absmax = tl.max(tl.abs(src))
+            scale = row_absmax / 127.0
+            inv = tl.where(row_absmax == 0.0, 0.0, 127.0 / row_absmax)
+            tl.store(scale_out_ptr + pid, scale)
+            dst = _clamp_i8(_round_even(src * inv))
+            tl.store(output_ptr + row_offset + offs, dst, mask=mask)
+    else:
+        if EVEN:
+            row_absmax = 0.0
+            for start in range(0, hidden, BLOCK_SIZE):
+                offs = start + tl.arange(0, BLOCK_SIZE)
+                src = tl.load(input_ptr + row_offset + offs).to(tl.float32)
+                row_absmax = tl.maximum(row_absmax, tl.max(tl.abs(src)))
+            scale = row_absmax / 127.0
+            inv = tl.where(row_absmax == 0.0, 0.0, 127.0 / row_absmax)
+            tl.store(scale_out_ptr + pid, scale)
+            for start in range(0, hidden, BLOCK_SIZE):
+                offs = start + tl.arange(0, BLOCK_SIZE)
+                src = tl.load(input_ptr + row_offset + offs).to(tl.float32)
+                dst = _clamp_i8(_round_even(src * inv))
+                tl.store(output_ptr + row_offset + offs, dst)
+        else:
+            row_absmax = 0.0
+            for start in range(0, hidden, BLOCK_SIZE):
+                offs = start + tl.arange(0, BLOCK_SIZE)
+                mask = offs < hidden
+                src = tl.load(input_ptr + row_offset + offs, mask=mask, other=0.0).to(
+                    tl.float32
+                )
+                row_absmax = tl.maximum(row_absmax, tl.max(tl.abs(src)))
+            scale = row_absmax / 127.0
+            inv = tl.where(row_absmax == 0.0, 0.0, 127.0 / row_absmax)
+            tl.store(scale_out_ptr + pid, scale)
+            for start in range(0, hidden, BLOCK_SIZE):
+                offs = start + tl.arange(0, BLOCK_SIZE)
+                mask = offs < hidden
+                src = tl.load(input_ptr + row_offset + offs, mask=mask, other=0.0).to(
+                    tl.float32
+                )
+                dst = _clamp_i8(_round_even(src * inv))
+                tl.store(output_ptr + row_offset + offs, dst, mask=mask)
 
 
-def _dyn_cfg(rows, cols):
-    """Shape-specialized (BLOCK_N, num_warps) for the dynamic row kernels.
+# ---------------------------------------------------------------------------
+# Dynamic quantization, asymmetric: per-row min/max, scale=(max-min)/255,
+# azp = clamp(round(-128 - min/scale)) as int32, out = clamp(round(src/scale)+azp).
+# ---------------------------------------------------------------------------
+@triton.jit
+def _dyn_asy_kernel(
+    input_ptr,
+    output_ptr,
+    scale_out_ptr,
+    azp_out_ptr,
+    hidden,
+    SINGLE: tl.constexpr,
+    EVEN: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    row_offset = pid * hidden
 
-    Measured best configs on the target (Iluvatar BI-V150, 16 SMs):
-      1-row rows want big blocks and many warps (latency bound);
-      tall matrices want small blocks and few warps (occupancy bound).
-    """
-    if rows == 1:
-        if cols <= 512:
-            return 512, 4
-        if cols <= 2048:
-            return 1024, 8
-        return 4096, 16
-    if cols <= 1024:
-        return 1024, 8
-    if rows >= 4096:
-        return 1024, 4
-    if cols <= 4096:
-        return 2048, 16
-    return 1024, 8
+    if SINGLE:
+        offs = tl.arange(0, BLOCK_SIZE)
+        if EVEN:
+            src = tl.load(input_ptr + row_offset + offs).to(tl.float32)
+            row_max = tl.max(src)
+            row_min = tl.min(src)
+            scale = (row_max - row_min) / 255.0
+            azp = _round_even(-128.0 - row_min / scale)
+            azp = tl.maximum(tl.minimum(azp, 2147483647.0), -2147483648.0).to(tl.int32)
+            tl.store(scale_out_ptr + pid, scale)
+            tl.store(azp_out_ptr + pid, azp)
+            q = _round_even(src / scale) + azp.to(tl.float32)
+            tl.store(output_ptr + row_offset + offs, _clamp_i8(q))
+        else:
+            mask = offs < hidden
+            src = tl.load(input_ptr + row_offset + offs, mask=mask, other=0.0).to(
+                tl.float32
+            )
+            row_max = tl.max(tl.where(mask, src, -1e30))
+            row_min = tl.min(tl.where(mask, src, 1e30))
+            scale = (row_max - row_min) / 255.0
+            azp = _round_even(-128.0 - row_min / scale)
+            azp = tl.maximum(tl.minimum(azp, 2147483647.0), -2147483648.0).to(tl.int32)
+            tl.store(scale_out_ptr + pid, scale)
+            tl.store(azp_out_ptr + pid, azp)
+            q = _round_even(src / scale) + azp.to(tl.float32)
+            tl.store(output_ptr + row_offset + offs, _clamp_i8(q), mask=mask)
+    else:
+        if EVEN:
+            row_max = -1e30
+            row_min = 1e30
+            for start in range(0, hidden, BLOCK_SIZE):
+                offs = start + tl.arange(0, BLOCK_SIZE)
+                src = tl.load(input_ptr + row_offset + offs).to(tl.float32)
+                row_max = tl.maximum(row_max, tl.max(src))
+                row_min = tl.minimum(row_min, tl.min(src))
+            scale = (row_max - row_min) / 255.0
+            azp = _round_even(-128.0 - row_min / scale)
+            azp = tl.maximum(tl.minimum(azp, 2147483647.0), -2147483648.0).to(tl.int32)
+            tl.store(scale_out_ptr + pid, scale)
+            tl.store(azp_out_ptr + pid, azp)
+            for start in range(0, hidden, BLOCK_SIZE):
+                offs = start + tl.arange(0, BLOCK_SIZE)
+                src = tl.load(input_ptr + row_offset + offs).to(tl.float32)
+                q = _round_even(src / scale) + azp.to(tl.float32)
+                tl.store(output_ptr + row_offset + offs, _clamp_i8(q))
+        else:
+            row_max = -1e30
+            row_min = 1e30
+            for start in range(0, hidden, BLOCK_SIZE):
+                offs = start + tl.arange(0, BLOCK_SIZE)
+                mask = offs < hidden
+                src = tl.load(input_ptr + row_offset + offs, mask=mask, other=0.0).to(
+                    tl.float32
+                )
+                row_max = tl.maximum(row_max, tl.max(tl.where(mask, src, -1e30)))
+                row_min = tl.minimum(row_min, tl.min(tl.where(mask, src, 1e30)))
+            scale = (row_max - row_min) / 255.0
+            azp = _round_even(-128.0 - row_min / scale)
+            azp = tl.maximum(tl.minimum(azp, 2147483647.0), -2147483648.0).to(tl.int32)
+            tl.store(scale_out_ptr + pid, scale)
+            tl.store(azp_out_ptr + pid, azp)
+            for start in range(0, hidden, BLOCK_SIZE):
+                offs = start + tl.arange(0, BLOCK_SIZE)
+                mask = offs < hidden
+                src = tl.load(input_ptr + row_offset + offs, mask=mask, other=0.0).to(
+                    tl.float32
+                )
+                q = _round_even(src / scale) + azp.to(tl.float32)
+                tl.store(output_ptr + row_offset + offs, _clamp_i8(q), mask=mask)
 
 
-def _static_cfg(numel):
-    if numel < 65536:
-        return 2048, 8
-    return 512, 4
+_LOOP_BLOCK = 1024
+
+
+def _next_pow2(n):
+    p = 1
+    while p < n:
+        p *= 2
+    return p
+
+
+_dummy_azp_cache = {}
+
+
+def _dummy_azp(dev):
+    t = _dummy_azp_cache.get(dev)
+    if t is None:
+        t = torch.empty(1, dtype=torch.int32, device=dev)
+        _dummy_azp_cache[dev] = t
+    return t
+
+
+def _dyn_launch(kernel, input, out, scale_out, azp_out, num_rows, hidden):
+    """Dispatch the dynamic kernel: register-tile SINGLE path when the row is
+    small (hidden <= 4096) or there are few rows (<= 128) with hidden <= 16384;
+    otherwise a two-loop path with 1024-lane tiles and 8 warps."""
+    if hidden <= 4096 or (num_rows <= 128 and hidden <= 16384):
+        blk = _next_pow2(hidden)
+        if blk < 256:
+            blk = 256
+        nw = (
+            64
+            if blk >= 16384
+            else (
+                32 if blk >= 8192 else (16 if blk >= 2048 else (8 if blk >= 512 else 4))
+            )
+        )
+        kernel[(num_rows,)](
+            input,
+            out,
+            scale_out,
+            azp_out,
+            hidden,
+            SINGLE=True,
+            EVEN=(hidden == blk),
+            BLOCK_SIZE=blk,
+            num_warps=nw,
+        )
+    else:
+        kernel[(num_rows,)](
+            input,
+            out,
+            scale_out,
+            azp_out,
+            hidden,
+            SINGLE=False,
+            EVEN=(hidden % _LOOP_BLOCK == 0),
+            BLOCK_SIZE=_LOOP_BLOCK,
+            num_warps=8,
+        )
 
 
 def scaled_int8_quant(input, scale, azp, symmetric):
-    if isinstance(symmetric, torch.Tensor):
-        symmetric = bool(symmetric.item())
+    if isinstance(symmetric, bool):
+        sym = symmetric
+    elif hasattr(symmetric, "item"):
+        sym = bool(symmetric.item())
     else:
-        symmetric = bool(symmetric)
+        sym = bool(symmetric)
 
-    rows, cols = input.shape
-    device = input.device
-    output = torch.empty_like(input, dtype=torch.int8)
+    hidden = input.shape[-1]
+    numel = input.numel()
+    num_rows = numel // hidden
+    dev = input.device
+
+    out = torch.empty(numel, dtype=torch.int8, device=dev)
 
     if scale is None:
-        # dynamic: compute per-row scale (and zero point) on device
-        scale_out = torch.empty((rows, 1), dtype=torch.float32, device=device)
-        if symmetric:
-            bn, warps = _dyn_cfg(rows, cols)
-            has_mask = (cols % bn) != 0
-            grid = (rows,)
-            _quant_dynamic_sym_kernel[grid](
+        # ---- dynamic: compute per-row stats, then quantize ----
+        scale_out = torch.empty((num_rows, 1), dtype=torch.float32, device=dev)
+        if sym:
+            _dyn_launch(
+                _dyn_sym_kernel,
                 input,
-                output,
+                out,
                 scale_out,
-                cols,
-                HAS_MASK=has_mask,
-                BLOCK_N=bn,
-                num_warps=warps,
+                _dummy_azp(dev),
+                num_rows,
+                hidden,
             )
-            return output, scale_out, None
-        azp_out = torch.empty((rows, 1), dtype=torch.int32, device=device)
-        bn, warps = _dyn_cfg(rows, cols)
-        grid = (rows,)
-        _quant_dynamic_asym_kernel[grid](
-            input,
-            output,
-            scale_out,
-            azp_out,
-            cols,
-            BLOCK_N=bn,
-            num_warps=warps,
-        )
-        return output, scale_out, azp_out
+            return out.view(input.shape), scale_out, None
+        else:
+            azp_out = torch.empty((num_rows, 1), dtype=torch.int32, device=dev)
+            _dyn_launch(
+                _dyn_asy_kernel, input, out, scale_out, azp_out, num_rows, hidden
+            )
+            return out.view(input.shape), scale_out, azp_out
 
-    # static: scale (and azp) are given; output only
-    numel = input.numel()
-    BLOCK, warps = _static_cfg(numel)
-    grid = (triton.cdiv(numel, BLOCK),)
-    if azp is None:
-        _quant_static_sym_kernel[grid](
-            input,
-            scale,
-            output,
-            numel,
-            BLOCK=BLOCK,
-            num_warps=warps,
-        )
-        return output, scale, None
-    _quant_static_asym_kernel[grid](
+    # ---- static: scale (and maybe azp) given ----
+    azp_arg = azp if azp is not None else _dummy_azp(dev)
+    if numel < 262144:
+        blk, nw = 2048, 8
+    else:
+        blk, nw = 1024, 8
+    grid = (triton.cdiv(numel, blk),)
+    _static_quant_kernel[grid](
         input,
+        out,
         scale,
-        azp,
-        output,
+        azp_arg,
         numel,
-        BLOCK=BLOCK,
-        num_warps=warps,
+        SYMMETRIC=sym,
+        EVEN=(numel % blk == 0),
+        BLOCK_SIZE=blk,
+        num_warps=nw,
     )
-    return output, scale, azp
+    return out.view(input.shape), scale, azp


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add a `iluvatar`-specialized `scaled_int8_quant` operator under `runtime/backend/_iluvatar/ops/`, registered so it overrides the generic implementation on Iluvatar BI-V150 (Tianshu). Supports all four modes (dynamic/static x symmetric/asymmetric) with round-to-nearest-even + saturation semantics matching the vLLM CUDA reference.

### Issue
N/A

### Progress
- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Testing
Validated against reference on Iluvatar BI-V150 (Tianshu): 21/21 workloads pass (correctness phase: max abs/rel error 0).

### Performance
Baseline: vendor torch reference on Iluvatar BI-V150 (Tianshu). Geo-mean SpeedUp **11.23x**.

| Workload | Torch (us) | Gems (us) | SpeedUp |
|---|---|---|---|
| dynamic-symmetric-1x512 | 278.44 | 7.76 | 35.87 |
| dynamic-symmetric-64x1024 | 311.33 | 9.95 | 31.28 |
| dynamic-symmetric-512x4096 | 434.32 | 27.74 | 15.66 |
| dynamic-symmetric-2048x5120 | 1234.17 | 96.47 | 12.79 |
| dynamic-symmetric-4096x4096 | 1769.98 | 126.32 | 14.01 |
| dynamic-symmetric-1x13824 | 294.14 | 9.37 | 31.41 |
| static-symmetric-1x13824 | 38.51 | 9.00 | 4.28 |
| static-symmetric-64x8192 | 58.87 | 12.47 | 4.72 |
| static-symmetric-512x5120 | 193.73 | 29.85 | 6.49 |
| static-symmetric-2048x4096 | 569.03 | 69.44 | 8.19 |
| static-symmetric-4096x1024 | 317.30 | 43.21 | 7.34 |
| static-symmetric-4096x512 | 133.62 | 25.84 | 5.17 |
