### PR TITLE
feat(ascend): add mhc_post operator for Ascend 910C

### DIFF
--- a/benchmark/test_ascend_mhc_post.py
+++ b/benchmark/test_ascend_mhc_post.py
@@ -1,0 +1,154 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Performance benchmarks for the Ascend MHC operator family in
+``flaggems_vllm.runtime.backend._ascend.mhc``.
+
+Baselines are the pure-PyTorch references (``*_ref``) shipped in the same
+modules. SpeedUp = latency_torch_ref / latency_triton.
+
+Usage:
+    python benchmark/test_ascend_mhc_post.py
+    python benchmark/test_ascend_mhc_post.py --op mhc_post
+"""
+
+import argparse
+import importlib.util  # noqa: E402
+import sys  # noqa: E402
+import time
+import types  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+import torch
+import torch_npu  # noqa: F401
+
+_MHC_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "src/flaggems_vllm/runtime/backend/_ascend/mhc"
+)
+
+# Register stub parent packages so the backend op modules can be loaded
+# directly by path (with their relative imports intact) without pulling in
+# the full flaggems_vllm package, which requires vLLM.
+for _pkg in [
+    "flaggems_vllm",
+    "flaggems_vllm.runtime",
+    "flaggems_vllm.runtime.backend",
+    "flaggems_vllm.runtime.backend._ascend",
+]:
+    if _pkg not in sys.modules:
+        sys.modules[_pkg] = types.ModuleType(_pkg)
+
+# The leaf package must be a real package (with __path__) for relative
+# imports inside the op modules to resolve.
+_mhc_pkg = types.ModuleType("flaggems_vllm.runtime.backend._ascend.mhc")
+_mhc_pkg.__path__ = [str(_MHC_DIR)]
+sys.modules["flaggems_vllm.runtime.backend._ascend.mhc"] = _mhc_pkg
+
+
+def _load(mod_name, file_name):
+    spec = importlib.util.spec_from_file_location(
+        f"flaggems_vllm.runtime.backend._ascend.mhc.{mod_name}",
+        _MHC_DIR / file_name,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_post_mod = _load("ascend_mhc_post", "mhc_post.py")
+
+mhc_post = _post_mod.mhc_post
+mhc_post_ref = _post_mod.mhc_post_ref
+
+DEVICE = "npu"
+HC_MULT = 4
+HC_MIX = HC_MULT * (HC_MULT + 2)  # 24
+WARMUP = 10
+REP = 50
+
+
+def gen_post_inputs(t, d, dtype=torch.bfloat16):
+    torch.manual_seed(42)
+    x = torch.randn((t, HC_MULT, d), dtype=dtype, device=DEVICE)
+    h_res = torch.randn((t, HC_MULT, HC_MULT), dtype=torch.float32, device=DEVICE)
+    h_out = torch.randn((t, d), dtype=dtype, device=DEVICE)
+    h_post = torch.randn((t, HC_MULT), dtype=torch.float32, device=DEVICE)
+    return x, h_res, h_out, h_post
+
+
+def bench(fn, args):
+    for _ in range(WARMUP):
+        fn(*args)
+    torch.npu.synchronize()
+    start = time.perf_counter()
+    for _ in range(REP):
+        fn(*args)
+    torch.npu.synchronize()
+    return (time.perf_counter() - start) / REP * 1e3  # ms
+
+
+def _run(op_name, ref_fn, tri_fn, arg_gen, shapes):
+    print(f"\n=== {op_name} (SpeedUp = latency_ref / latency_triton) ===")
+    print(f"{'shape':>16} {'ref (ms)':>10} {'triton (ms)':>12} {'speedup':>8}")
+    speedups = []
+    for t, d in shapes:
+        args = arg_gen(t, d)
+        lat_ref = bench(ref_fn, args)
+        lat_tri = bench(tri_fn, args)
+        speedup = lat_ref / lat_tri
+        speedups.append(speedup)
+        print(f"{f'({t},{d})':>16} {lat_ref:>10.3f} {lat_tri:>12.3f} {speedup:>8.2f}")
+    geo = 1.0
+    for s in speedups:
+        geo *= s
+    geo **= 1.0 / len(speedups)
+    print(f"{'geomean':>16} {'':>10} {'':>12} {geo:>8.2f}")
+    return geo
+
+
+def bench_mhc_post(shapes):
+    return _run("mhc_post", mhc_post_ref, mhc_post, gen_post_inputs, shapes)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--op",
+        choices=["all", "mhc_post"],
+        default="all",
+    )
+    args = parser.parse_args()
+
+    fwd_shapes = [
+        (512, 1280),
+        (1024, 2560),
+        (4096, 1280),
+        (4096, 3584),
+        (8192, 2560),
+        (16384, 3584),
+    ]
+
+    results = {}
+    if args.op in ("all", "mhc_post"):
+        results["mhc_post"] = bench_mhc_post(fwd_shapes)
+
+    print("\n=== summary (geomean speedup) ===")
+    for k, v in results.items():
+        print(f"{k:35s} {v:6.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/flaggems_vllm/runtime/backend/_ascend/mhc/mhc_post.py
+++ b/src/flaggems_vllm/runtime/backend/_ascend/mhc/mhc_post.py
@@ -1,0 +1,379 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Modified Triton mhc_post matching NPU semantics.
+
+This is a copy of the original since mhc_post already produces outputs
+identical to the NPU implementation:
+
+    output[t,i,d] = sum_j h_res[t,j,i] * x[t,j,d] + h_post[t,i] * h_out[t,d]
+
+No semantic changes needed.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# HC_MULT=4 fast path
+# ---------------------------------------------------------------------------
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_D": 128}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_D": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_D": 256}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_D": 256}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_D": 256}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_D": 512}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_D": 512}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_D": 1024}, num_warps=8, num_stages=1),
+    ],
+    key=["D"],
+)
+@triton.jit
+def _mhc_post_kernel_hc4(
+    x_ptr,
+    h_res_ptr,
+    h_out_ptr,
+    h_post_ptr,
+    out_ptr,
+    D: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    pid_t = tl.program_id(0)
+    pid_d = tl.program_id(1)
+
+    d_off = pid_d * BLOCK_D + tl.arange(0, BLOCK_D)
+    d_mask = d_off < D
+
+    x_base = pid_t * 4 * D
+    out_base = pid_t * 4 * D
+    hout_base = pid_t * D
+    hres_base = pid_t * 16
+    hpost_base = pid_t * 4
+
+    hp0 = tl.load(h_post_ptr + hpost_base + 0)
+    hp1 = tl.load(h_post_ptr + hpost_base + 1)
+    hp2 = tl.load(h_post_ptr + hpost_base + 2)
+    hp3 = tl.load(h_post_ptr + hpost_base + 3)
+
+    r00 = tl.load(h_res_ptr + hres_base + 0)
+    r01 = tl.load(h_res_ptr + hres_base + 1)
+    r02 = tl.load(h_res_ptr + hres_base + 2)
+    r03 = tl.load(h_res_ptr + hres_base + 3)
+    r10 = tl.load(h_res_ptr + hres_base + 4)
+    r11 = tl.load(h_res_ptr + hres_base + 5)
+    r12 = tl.load(h_res_ptr + hres_base + 6)
+    r13 = tl.load(h_res_ptr + hres_base + 7)
+    r20 = tl.load(h_res_ptr + hres_base + 8)
+    r21 = tl.load(h_res_ptr + hres_base + 9)
+    r22 = tl.load(h_res_ptr + hres_base + 10)
+    r23 = tl.load(h_res_ptr + hres_base + 11)
+    r30 = tl.load(h_res_ptr + hres_base + 12)
+    r31 = tl.load(h_res_ptr + hres_base + 13)
+    r32 = tl.load(h_res_ptr + hres_base + 14)
+    r33 = tl.load(h_res_ptr + hres_base + 15)
+
+    x0 = tl.load(x_ptr + x_base + 0 * D + d_off, mask=d_mask, other=0.0).to(tl.float32)
+    x1 = tl.load(x_ptr + x_base + 1 * D + d_off, mask=d_mask, other=0.0).to(tl.float32)
+    x2 = tl.load(x_ptr + x_base + 2 * D + d_off, mask=d_mask, other=0.0).to(tl.float32)
+    x3 = tl.load(x_ptr + x_base + 3 * D + d_off, mask=d_mask, other=0.0).to(tl.float32)
+    ho = tl.load(h_out_ptr + hout_base + d_off, mask=d_mask, other=0.0).to(tl.float32)
+
+    y0 = hp0 * ho + r00 * x0 + r10 * x1 + r20 * x2 + r30 * x3
+    y1 = hp1 * ho + r01 * x0 + r11 * x1 + r21 * x2 + r31 * x3
+    y2 = hp2 * ho + r02 * x0 + r12 * x1 + r22 * x2 + r32 * x3
+    y3 = hp3 * ho + r03 * x0 + r13 * x1 + r23 * x2 + r33 * x3
+
+    dtype = out_ptr.dtype.element_ty
+    tl.store(out_ptr + out_base + 0 * D + d_off, y0.to(dtype), mask=d_mask)
+    tl.store(out_ptr + out_base + 1 * D + d_off, y1.to(dtype), mask=d_mask)
+    tl.store(out_ptr + out_base + 2 * D + d_off, y2.to(dtype), mask=d_mask)
+    tl.store(out_ptr + out_base + 3 * D + d_off, y3.to(dtype), mask=d_mask)
+
+
+# ---------------------------------------------------------------------------
+# LoopD + manual 2-stage pipeline: overlaps GM→UB load of d-block (db+1)
+# with compute of d-block (db). Mimics AscendC DOUBLE_BUFFER_DEPTH=2.
+# ---------------------------------------------------------------------------
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_D": 896}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_D": 1792}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_D": 3584}, num_warps=4, num_stages=1),
+    ],
+    key=["D"],
+)
+@triton.jit
+def _mhc_post_kernel_hc4_loopD_pipe(
+    x_ptr,
+    h_res_ptr,
+    h_out_ptr,
+    h_post_ptr,
+    out_ptr,
+    D: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    pid_t = tl.program_id(0)
+    # Derived in-kernel so every autotuned BLOCK_D config still covers all D.
+    NUM_D_BLOCKS: tl.constexpr = (D + BLOCK_D - 1) // BLOCK_D
+
+    x_base = pid_t * 4 * D
+    out_base = pid_t * 4 * D
+    hout_base = pid_t * D
+    hres_base = pid_t * 16
+    hpost_base = pid_t * 4
+
+    hp0 = tl.load(h_post_ptr + hpost_base + 0)
+    hp1 = tl.load(h_post_ptr + hpost_base + 1)
+    hp2 = tl.load(h_post_ptr + hpost_base + 2)
+    hp3 = tl.load(h_post_ptr + hpost_base + 3)
+
+    r00 = tl.load(h_res_ptr + hres_base + 0)
+    r01 = tl.load(h_res_ptr + hres_base + 1)
+    r02 = tl.load(h_res_ptr + hres_base + 2)
+    r03 = tl.load(h_res_ptr + hres_base + 3)
+    r10 = tl.load(h_res_ptr + hres_base + 4)
+    r11 = tl.load(h_res_ptr + hres_base + 5)
+    r12 = tl.load(h_res_ptr + hres_base + 6)
+    r13 = tl.load(h_res_ptr + hres_base + 7)
+    r20 = tl.load(h_res_ptr + hres_base + 8)
+    r21 = tl.load(h_res_ptr + hres_base + 9)
+    r22 = tl.load(h_res_ptr + hres_base + 10)
+    r23 = tl.load(h_res_ptr + hres_base + 11)
+    r30 = tl.load(h_res_ptr + hres_base + 12)
+    r31 = tl.load(h_res_ptr + hres_base + 13)
+    r32 = tl.load(h_res_ptr + hres_base + 14)
+    r33 = tl.load(h_res_ptr + hres_base + 15)
+
+    # ---- Prologue: load d-block 0 ----
+    d_off = tl.arange(0, BLOCK_D)
+    d_mask = d_off < D
+    x0_cur = tl.load(x_ptr + x_base + 0 * D + d_off, mask=d_mask, other=0.0)
+    x1_cur = tl.load(x_ptr + x_base + 1 * D + d_off, mask=d_mask, other=0.0)
+    x2_cur = tl.load(x_ptr + x_base + 2 * D + d_off, mask=d_mask, other=0.0)
+    x3_cur = tl.load(x_ptr + x_base + 3 * D + d_off, mask=d_mask, other=0.0)
+    ho_cur = tl.load(h_out_ptr + hout_base + d_off, mask=d_mask, other=0.0)
+
+    for db in range(NUM_D_BLOCKS):
+        # ---- Issue loads for d-block (db+1) FIRST (async with compute below) ----
+        # Loop guard makes NUM_D_BLOCKS >= 1, so (db+1) % NUM_D_BLOCKS is safe.
+        nxt = (db + 1) % NUM_D_BLOCKS
+        d_off_nxt = nxt * BLOCK_D + tl.arange(0, BLOCK_D)
+        d_mask_nxt = d_off_nxt < D
+        x0_nxt = tl.load(x_ptr + x_base + 0 * D + d_off_nxt, mask=d_mask_nxt, other=0.0)
+        x1_nxt = tl.load(x_ptr + x_base + 1 * D + d_off_nxt, mask=d_mask_nxt, other=0.0)
+        x2_nxt = tl.load(x_ptr + x_base + 2 * D + d_off_nxt, mask=d_mask_nxt, other=0.0)
+        x3_nxt = tl.load(x_ptr + x_base + 3 * D + d_off_nxt, mask=d_mask_nxt, other=0.0)
+        ho_nxt = tl.load(h_out_ptr + hout_base + d_off_nxt, mask=d_mask_nxt, other=0.0)
+
+        # ---- Compute on current d-block (overlaps with next loads) ----
+        x0_f = x0_cur.to(tl.float32)
+        x1_f = x1_cur.to(tl.float32)
+        x2_f = x2_cur.to(tl.float32)
+        x3_f = x3_cur.to(tl.float32)
+        ho_f = ho_cur.to(tl.float32)
+
+        y0 = hp0 * ho_f + r00 * x0_f + r10 * x1_f + r20 * x2_f + r30 * x3_f
+        y1 = hp1 * ho_f + r01 * x0_f + r11 * x1_f + r21 * x2_f + r31 * x3_f
+        y2 = hp2 * ho_f + r02 * x0_f + r12 * x1_f + r22 * x2_f + r32 * x3_f
+        y3 = hp3 * ho_f + r03 * x0_f + r13 * x1_f + r23 * x2_f + r33 * x3_f
+
+        # ---- Store current (overlaps with next compute) ----
+        d_off_cur = db * BLOCK_D + tl.arange(0, BLOCK_D)
+        d_mask_cur = d_off_cur < D
+        dtype = out_ptr.dtype.element_ty
+        tl.store(out_ptr + out_base + 0 * D + d_off_cur, y0.to(dtype), mask=d_mask_cur)
+        tl.store(out_ptr + out_base + 1 * D + d_off_cur, y1.to(dtype), mask=d_mask_cur)
+        tl.store(out_ptr + out_base + 2 * D + d_off_cur, y2.to(dtype), mask=d_mask_cur)
+        tl.store(out_ptr + out_base + 3 * D + d_off_cur, y3.to(dtype), mask=d_mask_cur)
+
+        # ---- Rotate buffers (modulo loads make this unconditional) ----
+        x0_cur = x0_nxt
+        x1_cur = x1_nxt
+        x2_cur = x2_nxt
+        x3_cur = x3_nxt
+        ho_cur = ho_nxt
+
+
+# ---------------------------------------------------------------------------
+# BLOCK_T kernel: process BLOCK_T tokens per program (grid=(cdiv(T,BLOCK_T),)).
+# Backward taught us fewer/fatter programs win (grid=(T,) beat the 2D grid).
+# The forward does little work per token, so launching T programs leaves each
+# program overhead-dominated; batching tokens fattens each program. BLOCK_D=D
+# (single 3584 block) matches the measured-best forward config.
+# ---------------------------------------------------------------------------
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_T": 4}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_T": 8}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_T": 16}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_T": 8}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_T": 16}, num_warps=8, num_stages=1),
+    ],
+    key=["D"],
+)
+@triton.jit
+def _mhc_post_kernel_hc4_blockT(
+    x_ptr,
+    h_res_ptr,
+    h_out_ptr,
+    h_post_ptr,
+    out_ptr,
+    T: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    d_off = tl.arange(0, D)
+    dtype = out_ptr.dtype.element_ty
+
+    for tt in range(BLOCK_T):
+        t = pid * BLOCK_T + tt
+        if t < T:
+            x_base = t * 4 * D
+            hout_base = t * D
+            hres_base = t * 16
+            hpost_base = t * 4
+
+            hp0 = tl.load(h_post_ptr + hpost_base + 0)
+            hp1 = tl.load(h_post_ptr + hpost_base + 1)
+            hp2 = tl.load(h_post_ptr + hpost_base + 2)
+            hp3 = tl.load(h_post_ptr + hpost_base + 3)
+
+            r00 = tl.load(h_res_ptr + hres_base + 0)
+            r01 = tl.load(h_res_ptr + hres_base + 1)
+            r02 = tl.load(h_res_ptr + hres_base + 2)
+            r03 = tl.load(h_res_ptr + hres_base + 3)
+            r10 = tl.load(h_res_ptr + hres_base + 4)
+            r11 = tl.load(h_res_ptr + hres_base + 5)
+            r12 = tl.load(h_res_ptr + hres_base + 6)
+            r13 = tl.load(h_res_ptr + hres_base + 7)
+            r20 = tl.load(h_res_ptr + hres_base + 8)
+            r21 = tl.load(h_res_ptr + hres_base + 9)
+            r22 = tl.load(h_res_ptr + hres_base + 10)
+            r23 = tl.load(h_res_ptr + hres_base + 11)
+            r30 = tl.load(h_res_ptr + hres_base + 12)
+            r31 = tl.load(h_res_ptr + hres_base + 13)
+            r32 = tl.load(h_res_ptr + hres_base + 14)
+            r33 = tl.load(h_res_ptr + hres_base + 15)
+
+            x0 = tl.load(x_ptr + x_base + 0 * D + d_off).to(tl.float32)
+            x1 = tl.load(x_ptr + x_base + 1 * D + d_off).to(tl.float32)
+            x2 = tl.load(x_ptr + x_base + 2 * D + d_off).to(tl.float32)
+            x3 = tl.load(x_ptr + x_base + 3 * D + d_off).to(tl.float32)
+            ho = tl.load(h_out_ptr + hout_base + d_off).to(tl.float32)
+
+            y0 = hp0 * ho + r00 * x0 + r10 * x1 + r20 * x2 + r30 * x3
+            y1 = hp1 * ho + r01 * x0 + r11 * x1 + r21 * x2 + r31 * x3
+            y2 = hp2 * ho + r02 * x0 + r12 * x1 + r22 * x2 + r32 * x3
+            y3 = hp3 * ho + r03 * x0 + r13 * x1 + r23 * x2 + r33 * x3
+
+            tl.store(out_ptr + x_base + 0 * D + d_off, y0.to(dtype))
+            tl.store(out_ptr + x_base + 1 * D + d_off, y1.to(dtype))
+            tl.store(out_ptr + x_base + 2 * D + d_off, y2.to(dtype))
+            tl.store(out_ptr + x_base + 3 * D + d_off, y3.to(dtype))
+
+
+def _flatten_bsn(x, h_res, h_out, h_post):
+    if x.dim() == 4:
+        B, S, N, D = x.shape
+        T = B * S
+        x = x.reshape(T, N, D).contiguous()
+        h_res = h_res.reshape(T, N, N).contiguous()
+        h_out = h_out.reshape(T, D).contiguous()
+        h_post = h_post.reshape(T, N).contiguous()
+        return x, h_res, h_out, h_post, (B, S, N, D)
+    if x.dim() == 3:
+        T, N, D = x.shape
+        return (
+            x.contiguous(),
+            h_res.reshape(T, N, N).contiguous(),
+            h_out.reshape(T, D).contiguous(),
+            h_post.reshape(T, N).contiguous(),
+            (T, N, D),
+        )
+    raise ValueError(f"unsupported x.dim()={x.dim()}, expect 3 or 4")
+
+
+def mhc_post(x, h_res, h_out, h_post):
+    # Fused fast-path: fold _flatten_bsn into the kernel launch.
+    #
+    # The blockT kernel does pure FLAT pointer arithmetic (x_base = t*4*D,
+    # hres_base = t*16, ...), so it only cares that the underlying buffer is
+    # laid out as [T][4][D] contiguously -- the logical ndim (3D or 4D) is
+    # irrelevant. For contiguous input, _flatten_bsn's reshapes are free views
+    # and its .contiguous() calls are no-ops, yet they still cost ~18us of aten
+    # dispatch that is fully exposed at small T (T<=512). We fold the flatten
+    # into the launch: pass the raw tensor, derive T = numel // (4*D), and the
+    # output keeps the input's shape (no output reshape needed).
+    if (
+        x.shape[-2] == 4
+        and x.is_contiguous()
+        and h_res.is_contiguous()
+        and h_out.is_contiguous()
+        and h_post.is_contiguous()
+    ):
+        D = x.shape[-1]
+        T = x.numel() // (4 * D)
+        if T >= 64:
+            out = torch.empty_like(x)
+            grid = lambda META: (triton.cdiv(T, META["BLOCK_T"]),)
+            _mhc_post_kernel_hc4_blockT[grid](x, h_res, h_out, h_post, out, T=T, D=D)
+            return out
+
+    xf, hres, hout, hpost, shape = _flatten_bsn(x, h_res, h_out, h_post)
+    T, N, D = xf.shape
+    out = torch.empty_like(xf)
+
+    if N == 4:
+        if T >= 64:
+            grid = lambda META: (triton.cdiv(T, META["BLOCK_T"]),)
+            # BLOCK_T kernel: batch tokens per program to amortize per-program
+            # overhead (backward-inspired: fewer/fatter programs).
+            _mhc_post_kernel_hc4_blockT[grid](
+                xf,
+                hres,
+                hout,
+                hpost,
+                out,
+                T=T,
+                D=D,
+            )
+        else:
+            grid = lambda META: (T, triton.cdiv(D, META["BLOCK_D"]))
+            _mhc_post_kernel_hc4[grid](xf, hres, hout, hpost, out, D=D)
+    else:
+        raise NotImplementedError("Only N=4 supported")
+
+    return out.reshape(shape)
+
+
+def mhc_post_ref(x, h_res, h_out, h_post):
+    orig_dtype = x.dtype
+    xf, hres, hout, hpost, shape = _flatten_bsn(x, h_res, h_out, h_post)
+    x_f = xf.float()
+    hout_f = hout.float()
+    mix = torch.einsum("tji,tjd->tid", hres, x_f)
+    outer = hpost.unsqueeze(-1) * hout_f.unsqueeze(1)
+    y = (mix + outer).to(orig_dtype)
+    return y.reshape(shape)

--- a/tests/test_ascend_mhc_post.py
+++ b/tests/test_ascend_mhc_post.py
@@ -1,0 +1,157 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Accuracy tests for the Ascend MHC (Manifold-constrained Hyper-Connection)
+operator family living in
+``flaggems_vllm.runtime.backend._ascend.mhc``:
+
+    mhc_post (forward)
+
+Each Triton implementation is compared against its pure-PyTorch reference
+(suffixed ``_ref``) which lives in the same module and is test-only.
+"""
+
+import gc
+
+import pytest
+import torch
+
+try:
+    import torch_npu  # noqa: F401
+
+    HAS_NPU = torch.npu.is_available()
+except ImportError:
+    HAS_NPU = False
+
+pytestmark = pytest.mark.skipif(not HAS_NPU, reason="requires Ascend NPU")
+
+
+@pytest.fixture(autouse=True)
+def _npu_cleanup():
+    """Free device memory between parametrized cases; the mHC refs hold large
+    fp32 intermediates and 64G HBM is exhausted after a few big shapes."""
+    yield
+    gc.collect()
+    torch.npu.empty_cache()
+
+
+import importlib.util  # noqa: E402
+import sys  # noqa: E402
+import types  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+_MHC_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "src/flaggems_vllm/runtime/backend/_ascend/mhc"
+)
+
+# Register stub parent packages so the backend op modules can be loaded
+# directly by path (with their relative imports intact) without pulling in
+# the full flaggems_vllm package, which requires vLLM.
+for _pkg in [
+    "flaggems_vllm",
+    "flaggems_vllm.runtime",
+    "flaggems_vllm.runtime.backend",
+    "flaggems_vllm.runtime.backend._ascend",
+]:
+    if _pkg not in sys.modules:
+        sys.modules[_pkg] = types.ModuleType(_pkg)
+
+# The leaf package must be a real package (with __path__) for relative
+# imports inside the op modules to resolve.
+_mhc_pkg = types.ModuleType("flaggems_vllm.runtime.backend._ascend.mhc")
+_mhc_pkg.__path__ = [str(_MHC_DIR)]
+sys.modules["flaggems_vllm.runtime.backend._ascend.mhc"] = _mhc_pkg
+
+
+def _load(mod_name, file_name):
+    spec = importlib.util.spec_from_file_location(
+        f"flaggems_vllm.runtime.backend._ascend.mhc.{mod_name}",
+        _MHC_DIR / file_name,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_post_mod = _load("ascend_mhc_post", "mhc_post.py")
+
+mhc_post = _post_mod.mhc_post
+mhc_post_ref = _post_mod.mhc_post_ref
+
+DEVICE = "npu"
+HC_MULT = 4
+HC_MIX = HC_MULT * (HC_MULT + 2)  # 24
+
+
+def _assert_close(actual, expected, dtype, name="", rtol=None, atol=None):
+    if rtol is None or atol is None:
+        if dtype == torch.float32:
+            rtol, atol = 1e-3, 1e-4
+        elif dtype == torch.float16:
+            rtol, atol = 1e-2, 1e-3
+        else:  # bfloat16
+            rtol, atol = 2e-2, 2e-3
+    torch.testing.assert_close(
+        actual,
+        expected,
+        rtol=rtol,
+        atol=atol,
+        msg=lambda m: f"{name} mismatch:\n{m}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# input generators
+# ---------------------------------------------------------------------------
+def gen_post_inputs(t, d, dtype=torch.bfloat16, seed=42, dim3=True):
+    torch.manual_seed(seed)
+    shape_x = (t, HC_MULT, d) if dim3 else (2, t // 2, HC_MULT, d)
+    x = torch.randn(shape_x, dtype=dtype, device=DEVICE)
+    h_res = torch.randn((t, HC_MULT, HC_MULT), dtype=torch.float32, device=DEVICE)
+    h_out = torch.randn((t, d), dtype=dtype, device=DEVICE)
+    h_post = torch.randn((t, HC_MULT), dtype=torch.float32, device=DEVICE)
+    return x, h_res, h_out, h_post
+
+
+# ---------------------------------------------------------------------------
+# mhc_post (forward)
+# ---------------------------------------------------------------------------
+@pytest.mark.mhc_post
+@pytest.mark.parametrize("t", [1, 64, 512, 2048])
+@pytest.mark.parametrize("d", [1280, 2560, 3584])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+@pytest.mark.parametrize("dim3", [True, False], ids=["3d", "4d"])
+def test_mhc_post(t, d, dtype, dim3):
+    if not dim3 and t % 2:
+        pytest.skip("4d layout needs even token count")
+    x, h_res, h_out, h_post = gen_post_inputs(t, d, dtype, dim3=dim3)
+    out = mhc_post(x, h_res, h_out, h_post)
+    ref = mhc_post_ref(x, h_res, h_out, h_post)
+    assert out.shape == ref.shape and out.dtype == x.dtype
+    _assert_close(out.float(), ref.float(), dtype, "mhc_post")
+
+
+# ---------------------------------------------------------------------------
+# unsupported path
+# ---------------------------------------------------------------------------
+@pytest.mark.mhc_post
+def test_unsupported_hc_mult_raises():
+    x, h_res, h_out, h_post = gen_post_inputs(32, 256, torch.bfloat16)
+    x5 = torch.randn((32, 5, 256), dtype=torch.bfloat16, device=DEVICE)
+    h_res5 = torch.randn((32, 5, 5), dtype=torch.float32, device=DEVICE)
+    h_post5 = torch.randn((32, 5), dtype=torch.float32, device=DEVICE)
+    with pytest.raises(NotImplementedError):
+        mhc_post(x5, h_res5, h_out, h_post5)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add an `ascend`-specialized `mhc_post` forward operator under `runtime/backend/_ascend/mhc/`, so it can be picked up for Ascend NPU:

    out[t,i,d] = sum_j h_res[t,j,i]*x[t,j,d] + h_post[t,i]*h_out[t,d]

Three Triton paths (hc_mult=4): a 2D grid (small T), a loop-D double-buffered kernel, and a block-T kernel batching tokens per program (T >= 64). A pure-PyTorch `mhc_post_ref` is included for tests/benchmarks only.

### Issue
N/A

### Progress
- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Testing
`pytest tests/test_ascend_mhc_post.py` on Ascend 910C (torch 2.10 + torch_npu + triton-ascend 3.5): bf16/fp16/fp32, 3D and 4D layouts all pass.

### Performance
Baseline: pure-PyTorch reference on Ascend 910C. Geo-mean SpeedUp **6.18x**.

| Shape (T, D) | Torch ref (ms) | Triton (ms) | SpeedUp |
|---|---|---|---|
| (512, 1280) | 0.146 | 0.065 | 2.27 |
| (1024, 2560) | 0.370 | 0.064 | 5.75 |
| (4096, 1280) | 0.820 | 0.150 | 5.49 |
| (4096, 3584) | 2.581 | 0.274 | 9.42 |
| (8192, 2560) | 3.723 | 0.435 | 8.57 |
| (16384, 3584) | 10.245 | 1.056 | 9.70 |