### PR TITLE
feat(ascend): add mhc_post_backward operator for Ascend 910C

### DIFF
--- a/benchmark/test_ascend_mhc_post_backward.py
+++ b/benchmark/test_ascend_mhc_post_backward.py
@@ -1,0 +1,161 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Performance benchmarks for the Ascend MHC operator family in
+``flaggems_vllm.runtime.backend._ascend.mhc``.
+
+Baselines are the pure-PyTorch references (``*_ref``) shipped in the same
+modules. SpeedUp = latency_torch_ref / latency_triton.
+
+Usage:
+    python benchmark/test_ascend_mhc_post_backward.py
+"""
+
+import argparse
+import importlib.util  # noqa: E402
+import sys  # noqa: E402
+import time
+import types  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+import torch
+import torch_npu  # noqa: F401
+
+_MHC_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "src/flaggems_vllm/runtime/backend/_ascend/mhc"
+)
+
+# Register stub parent packages so the backend op modules can be loaded
+# directly by path (with their relative imports intact) without pulling in
+# the full flaggems_vllm package, which requires vLLM.
+for _pkg in [
+    "flaggems_vllm",
+    "flaggems_vllm.runtime",
+    "flaggems_vllm.runtime.backend",
+    "flaggems_vllm.runtime.backend._ascend",
+]:
+    if _pkg not in sys.modules:
+        sys.modules[_pkg] = types.ModuleType(_pkg)
+
+# The leaf package must be a real package (with __path__) for relative
+# imports inside the op modules to resolve.
+_mhc_pkg = types.ModuleType("flaggems_vllm.runtime.backend._ascend.mhc")
+_mhc_pkg.__path__ = [str(_MHC_DIR)]
+sys.modules["flaggems_vllm.runtime.backend._ascend.mhc"] = _mhc_pkg
+
+
+def _load(mod_name, file_name):
+    spec = importlib.util.spec_from_file_location(
+        f"flaggems_vllm.runtime.backend._ascend.mhc.{mod_name}",
+        _MHC_DIR / file_name,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_post_bwd_mod = _load("ascend_mhc_post_backward", "mhc_post_backward.py")
+
+mhc_post_backward = _post_bwd_mod.mhc_post_backward
+mhc_post_backward_ref = _post_bwd_mod.mhc_post_backward_ref
+
+DEVICE = "npu"
+HC_MULT = 4
+HC_MIX = HC_MULT * (HC_MULT + 2)  # 24
+WARMUP = 10
+REP = 50
+
+
+def gen_post_inputs(t, d, dtype=torch.bfloat16):
+    torch.manual_seed(42)
+    x = torch.randn((t, HC_MULT, d), dtype=dtype, device=DEVICE)
+    h_res = torch.randn((t, HC_MULT, HC_MULT), dtype=torch.float32, device=DEVICE)
+    h_out = torch.randn((t, d), dtype=dtype, device=DEVICE)
+    h_post = torch.randn((t, HC_MULT), dtype=torch.float32, device=DEVICE)
+    return x, h_res, h_out, h_post
+
+
+def bench(fn, args):
+    for _ in range(WARMUP):
+        fn(*args)
+    torch.npu.synchronize()
+    start = time.perf_counter()
+    for _ in range(REP):
+        fn(*args)
+    torch.npu.synchronize()
+    return (time.perf_counter() - start) / REP * 1e3  # ms
+
+
+def _run(op_name, ref_fn, tri_fn, arg_gen, shapes):
+    print(f"\n=== {op_name} (SpeedUp = latency_ref / latency_triton) ===")
+    print(f"{'shape':>16} {'ref (ms)':>10} {'triton (ms)':>12} {'speedup':>8}")
+    speedups = []
+    for t, d in shapes:
+        args = arg_gen(t, d)
+        lat_ref = bench(ref_fn, args)
+        lat_tri = bench(tri_fn, args)
+        speedup = lat_ref / lat_tri
+        speedups.append(speedup)
+        print(f"{f'({t},{d})':>16} {lat_ref:>10.3f} {lat_tri:>12.3f} {speedup:>8.2f}")
+    geo = 1.0
+    for s in speedups:
+        geo *= s
+    geo **= 1.0 / len(speedups)
+    print(f"{'geomean':>16} {'':>10} {'':>12} {geo:>8.2f}")
+    return geo
+
+
+def bench_mhc_post_backward(shapes):
+    def arg_gen(t, d):
+        x, h_res, h_out, h_post = gen_post_inputs(t, d)
+        torch.manual_seed(7)
+        grad_y = torch.randn((t, HC_MULT, d), dtype=torch.bfloat16, device=DEVICE)
+        return grad_y, x, h_res, h_out, h_post
+
+    return _run(
+        "mhc_post_backward", mhc_post_backward_ref, mhc_post_backward, arg_gen, shapes
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--op",
+        choices=["all", "mhc_post_backward"],
+        default="all",
+    )
+    args = parser.parse_args()
+
+    fwd_shapes = [
+        (512, 1280),
+        (1024, 2560),
+        (4096, 1280),
+        (4096, 3584),
+        (8192, 2560),
+        (16384, 3584),
+    ]
+
+    results = {}
+    if args.op in ("all", "mhc_post_backward"):
+        results["mhc_post_backward"] = bench_mhc_post_backward(fwd_shapes)
+
+    print("\n=== summary (geomean speedup) ===")
+    for k, v in results.items():
+        print(f"{k:35s} {v:6.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/flaggems_vllm/runtime/backend/_ascend/mhc/mhc_post_backward.py
+++ b/src/flaggems_vllm/runtime/backend/_ascend/mhc/mhc_post_backward.py
@@ -1,0 +1,794 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Modified Triton mhc_post_backward matching NPU semantics.
+
+This is a copy of the original since mhc_post_backward already produces
+outputs identical to the NPU implementation for D>=128.
+
+Gradients:
+    grad_x[j,d]     = sum_i h_res[j,i] * grad_y[i,d]
+    grad_h_res[j,i]  = sum_d x[j,d]    * grad_y[i,d]
+    grad_h_out[d]    = sum_i h_post[i]  * grad_y[i,d]
+    grad_h_post[i]   = sum_d h_out[d]   * grad_y[i,d]
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+logger = logging.getLogger(__name__)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_D": 128}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_D": 256}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_D": 256}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_D": 512}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_D": 512}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_D": 1024}, num_warps=8, num_stages=1),
+    ],
+    key=["D"],
+)
+@triton.jit
+def _mhc_post_bwd_dxdho_hc4(
+    grad_y_ptr,
+    h_res_ptr,
+    h_post_ptr,
+    grad_x_ptr,
+    grad_hout_ptr,
+    D: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    pid_t = tl.program_id(0)
+    pid_d = tl.program_id(1)
+
+    d_off = pid_d * BLOCK_D + tl.arange(0, BLOCK_D)
+    d_mask = d_off < D
+
+    gy_base = pid_t * 4 * D
+    gx_base = pid_t * 4 * D
+    gho_base = pid_t * D
+    hres_base = pid_t * 16
+    hpost_base = pid_t * 4
+
+    r00 = tl.load(h_res_ptr + hres_base + 0)
+    r01 = tl.load(h_res_ptr + hres_base + 1)
+    r02 = tl.load(h_res_ptr + hres_base + 2)
+    r03 = tl.load(h_res_ptr + hres_base + 3)
+    r10 = tl.load(h_res_ptr + hres_base + 4)
+    r11 = tl.load(h_res_ptr + hres_base + 5)
+    r12 = tl.load(h_res_ptr + hres_base + 6)
+    r13 = tl.load(h_res_ptr + hres_base + 7)
+    r20 = tl.load(h_res_ptr + hres_base + 8)
+    r21 = tl.load(h_res_ptr + hres_base + 9)
+    r22 = tl.load(h_res_ptr + hres_base + 10)
+    r23 = tl.load(h_res_ptr + hres_base + 11)
+    r30 = tl.load(h_res_ptr + hres_base + 12)
+    r31 = tl.load(h_res_ptr + hres_base + 13)
+    r32 = tl.load(h_res_ptr + hres_base + 14)
+    r33 = tl.load(h_res_ptr + hres_base + 15)
+
+    hp0 = tl.load(h_post_ptr + hpost_base + 0)
+    hp1 = tl.load(h_post_ptr + hpost_base + 1)
+    hp2 = tl.load(h_post_ptr + hpost_base + 2)
+    hp3 = tl.load(h_post_ptr + hpost_base + 3)
+
+    gy0 = tl.load(grad_y_ptr + gy_base + 0 * D + d_off, mask=d_mask, other=0.0).to(
+        tl.float32
+    )
+    gy1 = tl.load(grad_y_ptr + gy_base + 1 * D + d_off, mask=d_mask, other=0.0).to(
+        tl.float32
+    )
+    gy2 = tl.load(grad_y_ptr + gy_base + 2 * D + d_off, mask=d_mask, other=0.0).to(
+        tl.float32
+    )
+    gy3 = tl.load(grad_y_ptr + gy_base + 3 * D + d_off, mask=d_mask, other=0.0).to(
+        tl.float32
+    )
+
+    gx0 = r00 * gy0 + r01 * gy1 + r02 * gy2 + r03 * gy3
+    gx1 = r10 * gy0 + r11 * gy1 + r12 * gy2 + r13 * gy3
+    gx2 = r20 * gy0 + r21 * gy1 + r22 * gy2 + r23 * gy3
+    gx3 = r30 * gy0 + r31 * gy1 + r32 * gy2 + r33 * gy3
+
+    gho = hp0 * gy0 + hp1 * gy1 + hp2 * gy2 + hp3 * gy3
+
+    dt = grad_x_ptr.dtype.element_ty
+    tl.store(grad_x_ptr + gx_base + 0 * D + d_off, gx0.to(dt), mask=d_mask)
+    tl.store(grad_x_ptr + gx_base + 1 * D + d_off, gx1.to(dt), mask=d_mask)
+    tl.store(grad_x_ptr + gx_base + 2 * D + d_off, gx2.to(dt), mask=d_mask)
+    tl.store(grad_x_ptr + gx_base + 3 * D + d_off, gx3.to(dt), mask=d_mask)
+    tl.store(grad_hout_ptr + gho_base + d_off, gho.to(dt), mask=d_mask)
+
+
+# ---------------------------------------------------------------------------
+# LoopD + manual 2-stage pipeline for dxdho (same structure as forward v3).
+# grid=(T,) -> safe for any T (unlike the (T, cdiv) grid which exceeds
+# coreDim=65535 at T>=16384 with BLOCK_D<3584).
+# ---------------------------------------------------------------------------
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_D": 896}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_D": 1792}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_D": 3584}, num_warps=4, num_stages=1),
+    ],
+    key=["D"],
+)
+@triton.jit
+def _mhc_post_bwd_dxdho_hc4_loopD_pipe(
+    grad_y_ptr,
+    h_res_ptr,
+    h_post_ptr,
+    grad_x_ptr,
+    grad_hout_ptr,
+    D: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    pid_t = tl.program_id(0)
+    NUM_D_BLOCKS: tl.constexpr = (D + BLOCK_D - 1) // BLOCK_D
+
+    gy_base = pid_t * 4 * D
+    gx_base = pid_t * 4 * D
+    gho_base = pid_t * D
+    hres_base = pid_t * 16
+    hpost_base = pid_t * 4
+
+    r00 = tl.load(h_res_ptr + hres_base + 0)
+    r01 = tl.load(h_res_ptr + hres_base + 1)
+    r02 = tl.load(h_res_ptr + hres_base + 2)
+    r03 = tl.load(h_res_ptr + hres_base + 3)
+    r10 = tl.load(h_res_ptr + hres_base + 4)
+    r11 = tl.load(h_res_ptr + hres_base + 5)
+    r12 = tl.load(h_res_ptr + hres_base + 6)
+    r13 = tl.load(h_res_ptr + hres_base + 7)
+    r20 = tl.load(h_res_ptr + hres_base + 8)
+    r21 = tl.load(h_res_ptr + hres_base + 9)
+    r22 = tl.load(h_res_ptr + hres_base + 10)
+    r23 = tl.load(h_res_ptr + hres_base + 11)
+    r30 = tl.load(h_res_ptr + hres_base + 12)
+    r31 = tl.load(h_res_ptr + hres_base + 13)
+    r32 = tl.load(h_res_ptr + hres_base + 14)
+    r33 = tl.load(h_res_ptr + hres_base + 15)
+
+    hp0 = tl.load(h_post_ptr + hpost_base + 0)
+    hp1 = tl.load(h_post_ptr + hpost_base + 1)
+    hp2 = tl.load(h_post_ptr + hpost_base + 2)
+    hp3 = tl.load(h_post_ptr + hpost_base + 3)
+
+    # ---- Prologue: load d-block 0 ----
+    d_off = tl.arange(0, BLOCK_D)
+    d_mask = d_off < D
+    gy0_cur = tl.load(grad_y_ptr + gy_base + 0 * D + d_off, mask=d_mask, other=0.0)
+    gy1_cur = tl.load(grad_y_ptr + gy_base + 1 * D + d_off, mask=d_mask, other=0.0)
+    gy2_cur = tl.load(grad_y_ptr + gy_base + 2 * D + d_off, mask=d_mask, other=0.0)
+    gy3_cur = tl.load(grad_y_ptr + gy_base + 3 * D + d_off, mask=d_mask, other=0.0)
+
+    for db in range(NUM_D_BLOCKS):
+        nxt = (db + 1) % NUM_D_BLOCKS
+        d_off_nxt = nxt * BLOCK_D + tl.arange(0, BLOCK_D)
+        d_mask_nxt = d_off_nxt < D
+        gy0_nxt = tl.load(
+            grad_y_ptr + gy_base + 0 * D + d_off_nxt, mask=d_mask_nxt, other=0.0
+        )
+        gy1_nxt = tl.load(
+            grad_y_ptr + gy_base + 1 * D + d_off_nxt, mask=d_mask_nxt, other=0.0
+        )
+        gy2_nxt = tl.load(
+            grad_y_ptr + gy_base + 2 * D + d_off_nxt, mask=d_mask_nxt, other=0.0
+        )
+        gy3_nxt = tl.load(
+            grad_y_ptr + gy_base + 3 * D + d_off_nxt, mask=d_mask_nxt, other=0.0
+        )
+
+        gy0_f = gy0_cur.to(tl.float32)
+        gy1_f = gy1_cur.to(tl.float32)
+        gy2_f = gy2_cur.to(tl.float32)
+        gy3_f = gy3_cur.to(tl.float32)
+
+        gx0 = r00 * gy0_f + r01 * gy1_f + r02 * gy2_f + r03 * gy3_f
+        gx1 = r10 * gy0_f + r11 * gy1_f + r12 * gy2_f + r13 * gy3_f
+        gx2 = r20 * gy0_f + r21 * gy1_f + r22 * gy2_f + r23 * gy3_f
+        gx3 = r30 * gy0_f + r31 * gy1_f + r32 * gy2_f + r33 * gy3_f
+        gho = hp0 * gy0_f + hp1 * gy1_f + hp2 * gy2_f + hp3 * gy3_f
+
+        d_off_cur = db * BLOCK_D + tl.arange(0, BLOCK_D)
+        d_mask_cur = d_off_cur < D
+        dt = grad_x_ptr.dtype.element_ty
+        tl.store(grad_x_ptr + gx_base + 0 * D + d_off_cur, gx0.to(dt), mask=d_mask_cur)
+        tl.store(grad_x_ptr + gx_base + 1 * D + d_off_cur, gx1.to(dt), mask=d_mask_cur)
+        tl.store(grad_x_ptr + gx_base + 2 * D + d_off_cur, gx2.to(dt), mask=d_mask_cur)
+        tl.store(grad_x_ptr + gx_base + 3 * D + d_off_cur, gx3.to(dt), mask=d_mask_cur)
+        tl.store(grad_hout_ptr + gho_base + d_off_cur, gho.to(dt), mask=d_mask_cur)
+
+        gy0_cur = gy0_nxt
+        gy1_cur = gy1_nxt
+        gy2_cur = gy2_nxt
+        gy3_cur = gy3_nxt
+
+
+@triton.autotune(
+    configs=[
+        # Forced-config sweep on chip 13 (T in {1024..8192}, D=3584) shows a
+        # monotonic win for larger BLOCK_D; 3584 (single chunk, no D-loop) is
+        # ~1.9x faster than 1024 at every T. Keep only the top few to bound
+        # autotune overhead.
+        triton.Config({"BLOCK_D": 1792}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_D": 3584}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_D": 3584}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_D": 3584}, num_warps=4, num_stages=2),
+    ],
+    key=["D"],
+)
+@triton.jit
+def _mhc_post_bwd_dresdpost_hc4(
+    grad_y_ptr,
+    x_ptr,
+    h_out_ptr,
+    grad_hres_ptr,
+    grad_hpost_ptr,
+    D: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    pid_t = tl.program_id(0)
+
+    gy_base = pid_t * 4 * D
+    x_base = pid_t * 4 * D
+    hout_base = pid_t * D
+
+    p0 = tl.zeros([], dtype=tl.float32)
+    p1 = tl.zeros([], dtype=tl.float32)
+    p2 = tl.zeros([], dtype=tl.float32)
+    p3 = tl.zeros([], dtype=tl.float32)
+    r00 = tl.zeros([], dtype=tl.float32)
+    r01 = tl.zeros([], dtype=tl.float32)
+    r02 = tl.zeros([], dtype=tl.float32)
+    r03 = tl.zeros([], dtype=tl.float32)
+    r10 = tl.zeros([], dtype=tl.float32)
+    r11 = tl.zeros([], dtype=tl.float32)
+    r12 = tl.zeros([], dtype=tl.float32)
+    r13 = tl.zeros([], dtype=tl.float32)
+    r20 = tl.zeros([], dtype=tl.float32)
+    r21 = tl.zeros([], dtype=tl.float32)
+    r22 = tl.zeros([], dtype=tl.float32)
+    r23 = tl.zeros([], dtype=tl.float32)
+    r30 = tl.zeros([], dtype=tl.float32)
+    r31 = tl.zeros([], dtype=tl.float32)
+    r32 = tl.zeros([], dtype=tl.float32)
+    r33 = tl.zeros([], dtype=tl.float32)
+
+    for d_start in range(0, D, BLOCK_D):
+        d_off = d_start + tl.arange(0, BLOCK_D)
+        d_mask = d_off < D
+
+        gy0 = tl.load(grad_y_ptr + gy_base + 0 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        gy1 = tl.load(grad_y_ptr + gy_base + 1 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        gy2 = tl.load(grad_y_ptr + gy_base + 2 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        gy3 = tl.load(grad_y_ptr + gy_base + 3 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+
+        x0 = tl.load(x_ptr + x_base + 0 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        x1 = tl.load(x_ptr + x_base + 1 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        x2 = tl.load(x_ptr + x_base + 2 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        x3 = tl.load(x_ptr + x_base + 3 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+
+        ho = tl.load(h_out_ptr + hout_base + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+
+        p0 += tl.sum(ho * gy0, axis=0)
+        p1 += tl.sum(ho * gy1, axis=0)
+        p2 += tl.sum(ho * gy2, axis=0)
+        p3 += tl.sum(ho * gy3, axis=0)
+
+        r00 += tl.sum(x0 * gy0, axis=0)
+        r01 += tl.sum(x0 * gy1, axis=0)
+        r02 += tl.sum(x0 * gy2, axis=0)
+        r03 += tl.sum(x0 * gy3, axis=0)
+        r10 += tl.sum(x1 * gy0, axis=0)
+        r11 += tl.sum(x1 * gy1, axis=0)
+        r12 += tl.sum(x1 * gy2, axis=0)
+        r13 += tl.sum(x1 * gy3, axis=0)
+        r20 += tl.sum(x2 * gy0, axis=0)
+        r21 += tl.sum(x2 * gy1, axis=0)
+        r22 += tl.sum(x2 * gy2, axis=0)
+        r23 += tl.sum(x2 * gy3, axis=0)
+        r30 += tl.sum(x3 * gy0, axis=0)
+        r31 += tl.sum(x3 * gy1, axis=0)
+        r32 += tl.sum(x3 * gy2, axis=0)
+        r33 += tl.sum(x3 * gy3, axis=0)
+
+    hres_base = pid_t * 16
+    hpost_base = pid_t * 4
+
+    tl.store(grad_hpost_ptr + hpost_base + 0, p0)
+    tl.store(grad_hpost_ptr + hpost_base + 1, p1)
+    tl.store(grad_hpost_ptr + hpost_base + 2, p2)
+    tl.store(grad_hpost_ptr + hpost_base + 3, p3)
+
+    tl.store(grad_hres_ptr + hres_base + 0, r00)
+    tl.store(grad_hres_ptr + hres_base + 1, r01)
+    tl.store(grad_hres_ptr + hres_base + 2, r02)
+    tl.store(grad_hres_ptr + hres_base + 3, r03)
+    tl.store(grad_hres_ptr + hres_base + 4, r10)
+    tl.store(grad_hres_ptr + hres_base + 5, r11)
+    tl.store(grad_hres_ptr + hres_base + 6, r12)
+    tl.store(grad_hres_ptr + hres_base + 7, r13)
+    tl.store(grad_hres_ptr + hres_base + 8, r20)
+    tl.store(grad_hres_ptr + hres_base + 9, r21)
+    tl.store(grad_hres_ptr + hres_base + 10, r22)
+    tl.store(grad_hres_ptr + hres_base + 11, r23)
+    tl.store(grad_hres_ptr + hres_base + 12, r30)
+    tl.store(grad_hres_ptr + hres_base + 13, r31)
+    tl.store(grad_hres_ptr + hres_base + 14, r32)
+    tl.store(grad_hres_ptr + hres_base + 15, r33)
+
+
+# ---------------------------------------------------------------------------
+# FUSED kernel: compute grad_x, grad_hout, grad_hres, grad_hpost in a single
+# grid=(T,) launch. The two split kernels above each read the full grad_y
+# (T,4,D) tensor; since this op is memory-bound, reading grad_y ONCE here cuts
+# total DRAM traffic by ~22% (grad_y is 4/13 of all reads). The reduction part
+# keeps the proven serial 20-scalar accumulators (tl.join batching miscompiles
+# on this Ascend backend -- see note below).
+# ---------------------------------------------------------------------------
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_D": 1792}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_D": 3584}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_D": 3584}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_D": 3584}, num_warps=4, num_stages=2),
+    ],
+    key=["D"],
+)
+@triton.jit
+def _mhc_post_bwd_fused_hc4(
+    grad_y_ptr,
+    x_ptr,
+    h_res_ptr,
+    h_out_ptr,
+    h_post_ptr,
+    grad_x_ptr,
+    grad_hout_ptr,
+    grad_hres_ptr,
+    grad_hpost_ptr,
+    D: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    pid_t = tl.program_id(0)
+
+    gy_base = pid_t * 4 * D
+    x_base = pid_t * 4 * D
+    gx_base = pid_t * 4 * D
+    hout_base = pid_t * D
+    gho_base = pid_t * D
+    hres_base = pid_t * 16
+    hpost_base = pid_t * 4
+
+    # h_res / h_post scalars (for grad_x / grad_hout).
+    r00 = tl.load(h_res_ptr + hres_base + 0)
+    r01 = tl.load(h_res_ptr + hres_base + 1)
+    r02 = tl.load(h_res_ptr + hres_base + 2)
+    r03 = tl.load(h_res_ptr + hres_base + 3)
+    r10 = tl.load(h_res_ptr + hres_base + 4)
+    r11 = tl.load(h_res_ptr + hres_base + 5)
+    r12 = tl.load(h_res_ptr + hres_base + 6)
+    r13 = tl.load(h_res_ptr + hres_base + 7)
+    r20 = tl.load(h_res_ptr + hres_base + 8)
+    r21 = tl.load(h_res_ptr + hres_base + 9)
+    r22 = tl.load(h_res_ptr + hres_base + 10)
+    r23 = tl.load(h_res_ptr + hres_base + 11)
+    r30 = tl.load(h_res_ptr + hres_base + 12)
+    r31 = tl.load(h_res_ptr + hres_base + 13)
+    r32 = tl.load(h_res_ptr + hres_base + 14)
+    r33 = tl.load(h_res_ptr + hres_base + 15)
+
+    hp0 = tl.load(h_post_ptr + hpost_base + 0)
+    hp1 = tl.load(h_post_ptr + hpost_base + 1)
+    hp2 = tl.load(h_post_ptr + hpost_base + 2)
+    hp3 = tl.load(h_post_ptr + hpost_base + 3)
+
+    # Reduction accumulators (grad_hpost p*, grad_hres g*).
+    p0 = tl.zeros([], dtype=tl.float32)
+    p1 = tl.zeros([], dtype=tl.float32)
+    p2 = tl.zeros([], dtype=tl.float32)
+    p3 = tl.zeros([], dtype=tl.float32)
+    g00 = tl.zeros([], dtype=tl.float32)
+    g01 = tl.zeros([], dtype=tl.float32)
+    g02 = tl.zeros([], dtype=tl.float32)
+    g03 = tl.zeros([], dtype=tl.float32)
+    g10 = tl.zeros([], dtype=tl.float32)
+    g11 = tl.zeros([], dtype=tl.float32)
+    g12 = tl.zeros([], dtype=tl.float32)
+    g13 = tl.zeros([], dtype=tl.float32)
+    g20 = tl.zeros([], dtype=tl.float32)
+    g21 = tl.zeros([], dtype=tl.float32)
+    g22 = tl.zeros([], dtype=tl.float32)
+    g23 = tl.zeros([], dtype=tl.float32)
+    g30 = tl.zeros([], dtype=tl.float32)
+    g31 = tl.zeros([], dtype=tl.float32)
+    g32 = tl.zeros([], dtype=tl.float32)
+    g33 = tl.zeros([], dtype=tl.float32)
+
+    dt = grad_x_ptr.dtype.element_ty
+
+    for d_start in range(0, D, BLOCK_D):
+        d_off = d_start + tl.arange(0, BLOCK_D)
+        d_mask = d_off < D
+
+        gy0 = tl.load(grad_y_ptr + gy_base + 0 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        gy1 = tl.load(grad_y_ptr + gy_base + 1 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        gy2 = tl.load(grad_y_ptr + gy_base + 2 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        gy3 = tl.load(grad_y_ptr + gy_base + 3 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+
+        # ---- grad_x + grad_hout (uses grad_y only) ----
+        gx0 = r00 * gy0 + r01 * gy1 + r02 * gy2 + r03 * gy3
+        gx1 = r10 * gy0 + r11 * gy1 + r12 * gy2 + r13 * gy3
+        gx2 = r20 * gy0 + r21 * gy1 + r22 * gy2 + r23 * gy3
+        gx3 = r30 * gy0 + r31 * gy1 + r32 * gy2 + r33 * gy3
+        gho = hp0 * gy0 + hp1 * gy1 + hp2 * gy2 + hp3 * gy3
+
+        tl.store(grad_x_ptr + gx_base + 0 * D + d_off, gx0.to(dt), mask=d_mask)
+        tl.store(grad_x_ptr + gx_base + 1 * D + d_off, gx1.to(dt), mask=d_mask)
+        tl.store(grad_x_ptr + gx_base + 2 * D + d_off, gx2.to(dt), mask=d_mask)
+        tl.store(grad_x_ptr + gx_base + 3 * D + d_off, gx3.to(dt), mask=d_mask)
+        tl.store(grad_hout_ptr + gho_base + d_off, gho.to(dt), mask=d_mask)
+
+        # ---- grad_hres + grad_hpost reductions (needs x, h_out) ----
+        x0 = tl.load(x_ptr + x_base + 0 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        x1 = tl.load(x_ptr + x_base + 1 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        x2 = tl.load(x_ptr + x_base + 2 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        x3 = tl.load(x_ptr + x_base + 3 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        ho = tl.load(h_out_ptr + hout_base + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+
+        p0 += tl.sum(ho * gy0, axis=0)
+        p1 += tl.sum(ho * gy1, axis=0)
+        p2 += tl.sum(ho * gy2, axis=0)
+        p3 += tl.sum(ho * gy3, axis=0)
+
+        g00 += tl.sum(x0 * gy0, axis=0)
+        g01 += tl.sum(x0 * gy1, axis=0)
+        g02 += tl.sum(x0 * gy2, axis=0)
+        g03 += tl.sum(x0 * gy3, axis=0)
+        g10 += tl.sum(x1 * gy0, axis=0)
+        g11 += tl.sum(x1 * gy1, axis=0)
+        g12 += tl.sum(x1 * gy2, axis=0)
+        g13 += tl.sum(x1 * gy3, axis=0)
+        g20 += tl.sum(x2 * gy0, axis=0)
+        g21 += tl.sum(x2 * gy1, axis=0)
+        g22 += tl.sum(x2 * gy2, axis=0)
+        g23 += tl.sum(x2 * gy3, axis=0)
+        g30 += tl.sum(x3 * gy0, axis=0)
+        g31 += tl.sum(x3 * gy1, axis=0)
+        g32 += tl.sum(x3 * gy2, axis=0)
+        g33 += tl.sum(x3 * gy3, axis=0)
+
+    tl.store(grad_hpost_ptr + hpost_base + 0, p0)
+    tl.store(grad_hpost_ptr + hpost_base + 1, p1)
+    tl.store(grad_hpost_ptr + hpost_base + 2, p2)
+    tl.store(grad_hpost_ptr + hpost_base + 3, p3)
+
+    tl.store(grad_hres_ptr + hres_base + 0, g00)
+    tl.store(grad_hres_ptr + hres_base + 1, g01)
+    tl.store(grad_hres_ptr + hres_base + 2, g02)
+    tl.store(grad_hres_ptr + hres_base + 3, g03)
+    tl.store(grad_hres_ptr + hres_base + 4, g10)
+    tl.store(grad_hres_ptr + hres_base + 5, g11)
+    tl.store(grad_hres_ptr + hres_base + 6, g12)
+    tl.store(grad_hres_ptr + hres_base + 7, g13)
+    tl.store(grad_hres_ptr + hres_base + 8, g20)
+    tl.store(grad_hres_ptr + hres_base + 9, g21)
+    tl.store(grad_hres_ptr + hres_base + 10, g22)
+    tl.store(grad_hres_ptr + hres_base + 11, g23)
+    tl.store(grad_hres_ptr + hres_base + 12, g30)
+    tl.store(grad_hres_ptr + hres_base + 13, g31)
+    tl.store(grad_hres_ptr + hres_base + 14, g32)
+    tl.store(grad_hres_ptr + hres_base + 15, g33)
+
+
+# ---------------------------------------------------------------------------
+# FUSED + tl.dot variant: same single-launch fusion, but the 16 grad_hres
+# reductions (grad_hres[j,i] = sum_d x[j,d]*gy[i,d] = X @ GY^T) are done with
+# ONE tl.dot on the cube/matmul unit instead of 16 serial tl.sum vector
+# reductions. The kernel is reduction-op-bound (measured ~314 GB/s, well under
+# HBM limit), so moving the 4x4 contraction onto the cube unit is the main win.
+# gy is loaded transposed via make_block_ptr (tl.trans miscompiles on this
+# Ascend backend). grad_hpost keeps 4 cheap tl.sum's; grad_x/grad_hout stay
+# elementwise.
+# ---------------------------------------------------------------------------
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_D": 1792}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_D": 3584}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_D": 3584}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_D": 3584}, num_warps=4, num_stages=2),
+    ],
+    key=["D"],
+)
+@triton.jit
+def _mhc_post_bwd_fused_dot_hc4(
+    grad_y_ptr,
+    x_ptr,
+    h_res_ptr,
+    h_out_ptr,
+    h_post_ptr,
+    grad_x_ptr,
+    grad_hout_ptr,
+    grad_hres_ptr,
+    grad_hpost_ptr,
+    D: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    pid_t = tl.program_id(0)
+
+    gy_base = pid_t * 4 * D
+    x_base = pid_t * 4 * D
+    gx_base = pid_t * 4 * D
+    hout_base = pid_t * D
+    gho_base = pid_t * D
+    hres_base = pid_t * 16
+    hpost_base = pid_t * 4
+
+    r00 = tl.load(h_res_ptr + hres_base + 0)
+    r01 = tl.load(h_res_ptr + hres_base + 1)
+    r02 = tl.load(h_res_ptr + hres_base + 2)
+    r03 = tl.load(h_res_ptr + hres_base + 3)
+    r10 = tl.load(h_res_ptr + hres_base + 4)
+    r11 = tl.load(h_res_ptr + hres_base + 5)
+    r12 = tl.load(h_res_ptr + hres_base + 6)
+    r13 = tl.load(h_res_ptr + hres_base + 7)
+    r20 = tl.load(h_res_ptr + hres_base + 8)
+    r21 = tl.load(h_res_ptr + hres_base + 9)
+    r22 = tl.load(h_res_ptr + hres_base + 10)
+    r23 = tl.load(h_res_ptr + hres_base + 11)
+    r30 = tl.load(h_res_ptr + hres_base + 12)
+    r31 = tl.load(h_res_ptr + hres_base + 13)
+    r32 = tl.load(h_res_ptr + hres_base + 14)
+    r33 = tl.load(h_res_ptr + hres_base + 15)
+
+    hp0 = tl.load(h_post_ptr + hpost_base + 0)
+    hp1 = tl.load(h_post_ptr + hpost_base + 1)
+    hp2 = tl.load(h_post_ptr + hpost_base + 2)
+    hp3 = tl.load(h_post_ptr + hpost_base + 3)
+
+    p0 = tl.zeros([], dtype=tl.float32)
+    p1 = tl.zeros([], dtype=tl.float32)
+    p2 = tl.zeros([], dtype=tl.float32)
+    p3 = tl.zeros([], dtype=tl.float32)
+    acc = tl.zeros([4, 4], dtype=tl.float32)
+
+    dt = grad_x_ptr.dtype.element_ty
+
+    # x tile viewed as (4, D) row-major -> (4, BLOCK_D) natural block.
+    x_bp = tl.make_block_ptr(
+        base=x_ptr + x_base,
+        shape=(4, D),
+        strides=(D, 1),
+        offsets=(0, 0),
+        block_shape=(4, BLOCK_D),
+        order=(1, 0),
+    )
+    # gy tile viewed transposed as (D, 4): element [d, i] = gy[i, d] at i*D+d,
+    # so strides over (d, i) are (1, D). Gives the (BLOCK_D, 4) rhs for tl.dot.
+    gyt_bp = tl.make_block_ptr(
+        base=grad_y_ptr + gy_base,
+        shape=(D, 4),
+        strides=(1, D),
+        offsets=(0, 0),
+        block_shape=(BLOCK_D, 4),
+        order=(0, 1),
+    )
+
+    for d_start in range(0, D, BLOCK_D):
+        d_off = d_start + tl.arange(0, BLOCK_D)
+        d_mask = d_off < D
+
+        gy0 = tl.load(grad_y_ptr + gy_base + 0 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        gy1 = tl.load(grad_y_ptr + gy_base + 1 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        gy2 = tl.load(grad_y_ptr + gy_base + 2 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        gy3 = tl.load(grad_y_ptr + gy_base + 3 * D + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+
+        gx0 = r00 * gy0 + r01 * gy1 + r02 * gy2 + r03 * gy3
+        gx1 = r10 * gy0 + r11 * gy1 + r12 * gy2 + r13 * gy3
+        gx2 = r20 * gy0 + r21 * gy1 + r22 * gy2 + r23 * gy3
+        gx3 = r30 * gy0 + r31 * gy1 + r32 * gy2 + r33 * gy3
+        gho = hp0 * gy0 + hp1 * gy1 + hp2 * gy2 + hp3 * gy3
+
+        tl.store(grad_x_ptr + gx_base + 0 * D + d_off, gx0.to(dt), mask=d_mask)
+        tl.store(grad_x_ptr + gx_base + 1 * D + d_off, gx1.to(dt), mask=d_mask)
+        tl.store(grad_x_ptr + gx_base + 2 * D + d_off, gx2.to(dt), mask=d_mask)
+        tl.store(grad_x_ptr + gx_base + 3 * D + d_off, gx3.to(dt), mask=d_mask)
+        tl.store(grad_hout_ptr + gho_base + d_off, gho.to(dt), mask=d_mask)
+
+        ho = tl.load(h_out_ptr + hout_base + d_off, mask=d_mask, other=0.0).to(
+            tl.float32
+        )
+        p0 += tl.sum(ho * gy0, axis=0)
+        p1 += tl.sum(ho * gy1, axis=0)
+        p2 += tl.sum(ho * gy2, axis=0)
+        p3 += tl.sum(ho * gy3, axis=0)
+
+        # grad_hres 4x4 via one matmul: X(4,BLOCK_D) @ GY^T(BLOCK_D,4).
+        x_tile = tl.load(x_bp, boundary_check=(1,), padding_option="zero").to(
+            tl.float32
+        )
+        gyt_tile = tl.load(gyt_bp, boundary_check=(0,), padding_option="zero").to(
+            tl.float32
+        )
+        acc += tl.dot(x_tile, gyt_tile)
+
+        x_bp = tl.advance(x_bp, (0, BLOCK_D))
+        gyt_bp = tl.advance(gyt_bp, (BLOCK_D, 0))
+
+    tl.store(grad_hpost_ptr + hpost_base + 0, p0)
+    tl.store(grad_hpost_ptr + hpost_base + 1, p1)
+    tl.store(grad_hpost_ptr + hpost_base + 2, p2)
+    tl.store(grad_hpost_ptr + hpost_base + 3, p3)
+
+    hres_idx = tl.arange(0, 4)[:, None] * 4 + tl.arange(0, 4)[None, :]
+    tl.store(grad_hres_ptr + hres_base + hres_idx, acc)
+
+
+# ---------------------------------------------------------------------------
+# tl.join batched-accumulator experiment REMOVED (dead end, probe-verified):
+# batching the 4 gy rows via join -> (BLOCK_D,2,2) then 5 axis-0 sums instead
+# of 20 scalar sums MISCOMPILES on Ascend. Isolation probes showed a single
+# loop-carried (2,2) accumulator off a joined tensor is correct, but TWO
+# accumulators off the same joined tensor already return garbage (backend
+# register-allocation bug), and wider joins overflow UB. tl.trans / tl.permute
+# also produce garbage on this backend, so there is no layout workaround.
+# The serial 20-scalar kernel below is the fastest correct option.
+# ---------------------------------------------------------------------------
+# Split-D partials experiment REMOVED: proven 2.7x SLOWER than the serial
+# kernel (T=2048: 3.06ms vs 1.20ms; T=8192: 12.04ms vs 4.75ms). The kernel is
+# reduction-op-bound, so 7x more programs only multiplies fixed overhead and
+# GM traffic without reducing per-program work enough. Also re-introduced the
+# coreDim=65535 crash at T=16384 (grid=(16384, 7)).
+# ---------------------------------------------------------------------------
+
+
+def _flatten(grad_y, x, h_res, h_out, h_post):
+    if grad_y.dim() == 4:
+        B, S, N, D = grad_y.shape
+        T = B * S
+        shape4 = (B, S, N, D)
+        shape_out = (B, S, D)
+        return (
+            grad_y.reshape(T, N, D).contiguous(),
+            x.reshape(T, N, D).contiguous(),
+            h_res.reshape(T, N, N).contiguous(),
+            h_out.reshape(T, D).contiguous(),
+            h_post.reshape(T, N).contiguous(),
+            shape4,
+            shape_out,
+        )
+    if grad_y.dim() == 3:
+        T, N, D = grad_y.shape
+        return (
+            grad_y.contiguous(),
+            x.contiguous(),
+            h_res.reshape(T, N, N).contiguous(),
+            h_out.reshape(T, D).contiguous(),
+            h_post.reshape(T, N).contiguous(),
+            (T, N, D),
+            (T, D),
+        )
+    raise ValueError(f"unsupported grad_y.dim()={grad_y.dim()}")
+
+
+def mhc_post_backward(grad_y, x, h_res, h_out, h_post):
+    gy, xf, hres, hout, hpost, shape4, shape_out = _flatten(
+        grad_y, x, h_res, h_out, h_post
+    )
+    T, N, D = gy.shape
+
+    grad_x = torch.empty_like(xf)
+    grad_hout = torch.empty_like(hout)
+    grad_hres = torch.empty_like(hres)
+    grad_hpost = torch.empty_like(hpost)
+
+    if N == 4:
+        # Single fused kernel: reads grad_y once (vs twice for the split
+        # dxdho+dresdpost path) to cut DRAM traffic on this memory-bound op.
+        # (A tl.dot variant for grad_hres was ~20x SLOWER: a 4x4 output with
+        # K=3584 wastes the cube unit; see _mhc_post_bwd_fused_dot_hc4 note.)
+        _mhc_post_bwd_fused_hc4[(T,)](
+            gy,
+            xf,
+            hres,
+            hout,
+            hpost,
+            grad_x,
+            grad_hout,
+            grad_hres,
+            grad_hpost,
+            D=D,
+        )
+    else:
+        raise NotImplementedError("Only N=4 supported")
+
+    return (
+        grad_x.reshape(shape4),
+        grad_hres.reshape(h_res.shape),
+        grad_hout.reshape(shape_out),
+        grad_hpost.reshape(h_post.shape),
+    )
+
+
+def mhc_post_backward_ref(grad_y, x, h_res, h_out, h_post):
+    orig_dtype = x.dtype
+    gy, xf, hres, hout, hpost, shape4, shape_out = _flatten(
+        grad_y, x, h_res, h_out, h_post
+    )
+    gy_f = gy.float()
+    x_f = xf.float()
+    ho_f = hout.float()
+
+    grad_x = torch.einsum("tji,tid->tjd", hres, gy_f).to(orig_dtype)
+    grad_hres = torch.einsum("tjd,tid->tji", x_f, gy_f)
+    grad_hout = torch.einsum("ti,tid->td", hpost, gy_f).to(orig_dtype)
+    grad_hpost = torch.einsum("td,tid->ti", ho_f, gy_f)
+
+    return (
+        grad_x.reshape(shape4),
+        grad_hres.reshape(h_res.shape),
+        grad_hout.reshape(shape_out),
+        grad_hpost.reshape(h_post.shape),
+    )

--- a/tests/test_ascend_mhc_post_backward.py
+++ b/tests/test_ascend_mhc_post_backward.py
@@ -1,0 +1,146 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Accuracy tests for the Ascend MHC (Manifold-constrained Hyper-Connection)
+operator family living in
+``flaggems_vllm.runtime.backend._ascend.mhc``:
+
+    mhc_post_backward
+
+Each Triton implementation is compared against its pure-PyTorch reference
+(suffixed ``_ref``) which lives in the same module and is test-only.
+"""
+
+import gc
+
+import pytest
+import torch
+
+try:
+    import torch_npu  # noqa: F401
+
+    HAS_NPU = torch.npu.is_available()
+except ImportError:
+    HAS_NPU = False
+
+pytestmark = pytest.mark.skipif(not HAS_NPU, reason="requires Ascend NPU")
+
+
+@pytest.fixture(autouse=True)
+def _npu_cleanup():
+    """Free device memory between parametrized cases; the mHC refs hold large
+    fp32 intermediates and 64G HBM is exhausted after a few big shapes."""
+    yield
+    gc.collect()
+    torch.npu.empty_cache()
+
+
+import importlib.util  # noqa: E402
+import sys  # noqa: E402
+import types  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+_MHC_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "src/flaggems_vllm/runtime/backend/_ascend/mhc"
+)
+
+# Register stub parent packages so the backend op modules can be loaded
+# directly by path (with their relative imports intact) without pulling in
+# the full flaggems_vllm package, which requires vLLM.
+for _pkg in [
+    "flaggems_vllm",
+    "flaggems_vllm.runtime",
+    "flaggems_vllm.runtime.backend",
+    "flaggems_vllm.runtime.backend._ascend",
+]:
+    if _pkg not in sys.modules:
+        sys.modules[_pkg] = types.ModuleType(_pkg)
+
+# The leaf package must be a real package (with __path__) for relative
+# imports inside the op modules to resolve.
+_mhc_pkg = types.ModuleType("flaggems_vllm.runtime.backend._ascend.mhc")
+_mhc_pkg.__path__ = [str(_MHC_DIR)]
+sys.modules["flaggems_vllm.runtime.backend._ascend.mhc"] = _mhc_pkg
+
+
+def _load(mod_name, file_name):
+    spec = importlib.util.spec_from_file_location(
+        f"flaggems_vllm.runtime.backend._ascend.mhc.{mod_name}",
+        _MHC_DIR / file_name,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_post_bwd_mod = _load("ascend_mhc_post_backward", "mhc_post_backward.py")
+
+mhc_post_backward = _post_bwd_mod.mhc_post_backward
+mhc_post_backward_ref = _post_bwd_mod.mhc_post_backward_ref
+
+DEVICE = "npu"
+HC_MULT = 4
+HC_MIX = HC_MULT * (HC_MULT + 2)  # 24
+
+
+def _assert_close(actual, expected, dtype, name="", rtol=None, atol=None):
+    if rtol is None or atol is None:
+        if dtype == torch.float32:
+            rtol, atol = 1e-3, 1e-4
+        elif dtype == torch.float16:
+            rtol, atol = 1e-2, 1e-3
+        else:  # bfloat16
+            rtol, atol = 2e-2, 2e-3
+    torch.testing.assert_close(
+        actual,
+        expected,
+        rtol=rtol,
+        atol=atol,
+        msg=lambda m: f"{name} mismatch:\n{m}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# input generators
+# ---------------------------------------------------------------------------
+def gen_post_inputs(t, d, dtype=torch.bfloat16, seed=42, dim3=True):
+    torch.manual_seed(seed)
+    shape_x = (t, HC_MULT, d) if dim3 else (2, t // 2, HC_MULT, d)
+    x = torch.randn(shape_x, dtype=dtype, device=DEVICE)
+    h_res = torch.randn((t, HC_MULT, HC_MULT), dtype=torch.float32, device=DEVICE)
+    h_out = torch.randn((t, d), dtype=dtype, device=DEVICE)
+    h_post = torch.randn((t, HC_MULT), dtype=torch.float32, device=DEVICE)
+    return x, h_res, h_out, h_post
+
+
+# ---------------------------------------------------------------------------
+# mhc_post_backward
+# ---------------------------------------------------------------------------
+@pytest.mark.mhc_post_backward
+@pytest.mark.parametrize("t", [1, 64, 512, 2048])
+@pytest.mark.parametrize("d", [1280, 3584])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_mhc_post_backward(t, d, dtype):
+    x, h_res, h_out, h_post = gen_post_inputs(t, d, dtype)
+    torch.manual_seed(7)
+    grad_y = torch.randn((t, HC_MULT, d), dtype=dtype, device=DEVICE)
+
+    grads = mhc_post_backward(grad_y, x, h_res, h_out, h_post)
+    refs = mhc_post_backward_ref(grad_y, x, h_res, h_out, h_post)
+    names = ["grad_x", "grad_hres", "grad_hout", "grad_hpost"]
+    for g, r, n in zip(grads, refs, names):
+        assert g.shape == r.shape, n
+        _assert_close(g.float(), r.float(), dtype, n)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add an `ascend`-specialized `mhc_post_backward` operator under `runtime/backend/_ascend/mhc/`, producing `(grad_x, grad_hres, grad_hout, grad_hpost)` in a single fused Triton kernel that reads `grad_y` once. A pure-PyTorch `mhc_post_backward_ref` is included for tests/benchmarks only.

### Issue
N/A

### Progress
- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Testing
`pytest tests/test_ascend_mhc_post_backward.py` on Ascend 910C (torch 2.10 + torch_npu + triton-ascend 3.5): all backward + autograd-wrapper cases pass.

### Performance
Baseline: pure-PyTorch reference on Ascend 910C. Geo-mean SpeedUp **2.24x**.

| Shape (T, D) | Torch ref (ms) | Triton (ms) | SpeedUp |
|---|---|---|---|
| (512, 1280) | 0.273 | 0.169 | 1.61 |
| (1024, 2560) | 0.745 | 0.363 | 2.05 |
| (4096, 1280) | 1.622 | 1.226 | 1.32 |
| (4096, 3584) | 4.641 | 1.295 | 3.58 |
| (8192, 2560) | 6.731 | 3.040 | 2.21 |
| (16384, 3584) | 18.693 | 5.120 | 3.65 |