### PR TITLE
[KMCompiler] perf-opt grouped_topk for DeepSeek-v3.2

### DIFF
--- a/benchmark/base.py
+++ b/benchmark/base.py
@@ -306,14 +306,22 @@ class Benchmark:
             end = time.time()
             latency = (end - start) / n_rep * 1000
         elif Config.mode == consts.BenchMode.KERNEL:
-            do_bench = triton.testing.do_bench
-            latency = do_bench(
-                fn,
-                warmup=Config.warm_up,
-                rep=Config.repetition,
-                return_mode="median",
-                grad_to_none=xs if self.is_backward else None,
-            )
+            if vendor_name == "ascend":
+                do_bench = triton.backends.ascend.testing.do_bench_npu
+                latency = do_bench(
+                    fn,
+                    warmup=Config.warm_up,
+                    active=Config.repetition,
+                )
+            else:
+                do_bench = triton.testing.do_bench
+                latency = do_bench(
+                    fn,
+                    warmup=Config.warm_up,
+                    rep=Config.repetition,
+                    return_mode="median",
+                    grad_to_none=xs if self.is_backward else None,
+                )
         elif Config.mode == consts.BenchMode.WRAPPER:
             n_warm, n_rep = get_iter_count(fn)
             for i in range(n_warm):

--- a/benchmark/base.py
+++ b/benchmark/base.py
@@ -310,8 +310,9 @@ class Benchmark:
                 do_bench = triton.backends.ascend.testing.do_bench_npu
                 latency = do_bench(
                     fn,
-                    warmup=Config.warm_up,
-                    active=Config.repetition,
+                    # do_bench_npu requires iterations, rather than duration
+                    # warmup=Config.warm_up,
+                    # active=Config.repetition,
                 )
             else:
                 do_bench = triton.testing.do_bench

--- a/benchmark/base.py
+++ b/benchmark/base.py
@@ -54,6 +54,30 @@ else:
         pass
 
 
+def get_iter_count(fn):
+    if Config.mode == consts.BenchMode.OPERATOR:
+        torch_device_fn.synchronize()
+        start = time.time()
+        for _ in range(5):
+            fn()
+        torch_device_fn.synchronize()
+        end = time.time()
+        latency = (end - start) / 5 * 1000
+    elif Config.mode == consts.BenchMode.WRAPPER:
+        torch_device_fn.synchronize()
+        start = time.time()
+        for _ in range(5):
+            fn()
+        end = time.time()
+        torch_device_fn.synchronize()
+        latency = (end - start) / 5 * 1000
+    else:
+        raise ValueError("Unsupport Benchmark Mode.")
+    return max(1, int(Config.warm_up / latency)), max(
+        1, int(Config.repetition / latency)
+    )
+
+
 class Benchmark:
     device: str = device
     DEFAULT_METRICS = consts.DEFAULT_METRICS
@@ -271,15 +295,16 @@ class Benchmark:
                 (out,), xs, grad_outputs=(dout,), retain_graph=True
             )
         if Config.mode == consts.BenchMode.OPERATOR:
-            for i in range(Config.warm_up):
+            n_warm, n_rep = get_iter_count(fn)
+            for i in range(n_warm):
                 fn()
             torch_device_fn.synchronize()
             start = time.time()
-            for i in range(Config.repetition):
+            for i in range(n_rep):
                 fn()
             torch_device_fn.synchronize()
             end = time.time()
-            latency = (end - start) / Config.repetition * 1000
+            latency = (end - start) / n_rep * 1000
         elif Config.mode == consts.BenchMode.KERNEL:
             do_bench = triton.testing.do_bench
             latency = do_bench(
@@ -290,14 +315,15 @@ class Benchmark:
                 grad_to_none=xs if self.is_backward else None,
             )
         elif Config.mode == consts.BenchMode.WRAPPER:
-            for i in range(Config.warm_up):
+            n_warm, n_rep = get_iter_count(fn)
+            for i in range(n_warm):
                 fn()
             torch_device_fn.synchronize()
             start = time.time()
-            for i in range(Config.repetition):
+            for i in range(n_rep):
                 fn()
             end = time.time()
-            latency = (end - start) / Config.repetition * 1000
+            latency = (end - start) / n_rep * 1000
         else:
             raise ValueError("Undefined Value of Benchmark Mode.")
         # average latency in ms

--- a/benchmark/base.py
+++ b/benchmark/base.py
@@ -324,6 +324,14 @@ class Benchmark:
                 fn()
             end = time.time()
             latency = (end - start) / n_rep * 1000
+        elif Config.mode == consts.BenchMode.CUDAGRAPH:
+            do_bench_cudagraph = triton.testing.do_bench_cudagraph
+            latency = do_bench_cudagraph(
+                fn,
+                rep=Config.repetition,
+                return_mode="median",
+                grad_to_none=xs if self.is_backward else None,
+            )
         else:
             raise ValueError("Undefined Value of Benchmark Mode.")
         # average latency in ms

--- a/benchmark/conftest.py
+++ b/benchmark/conftest.py
@@ -75,8 +75,8 @@ class BenchConfig:
     def __init__(self):
         self.mode = consts.BenchMode.KERNEL
         self.bench_level = consts.BenchLevel.COMPREHENSIVE
-        self.warm_up = consts.DEFAULT_WARMUP_COUNT
-        self.repetition = consts.DEFAULT_ITER_COUNT
+        self.warm_up = consts.DEFAULT_WARMUP_TIME
+        self.repetition = consts.DEFAULT_ITER_TIME
 
         # Speed Up Benchmark Test, Big Shape Will Cause Timeout
         if vendor_name == "kunlunxin":
@@ -118,14 +118,14 @@ def pytest_addoption(parser):
 
     parser.addoption(
         "--warmup",
-        default=consts.DEFAULT_WARMUP_COUNT,
-        help="Number of warmup runs before benchmark run.",
+        default=consts.DEFAULT_WARMUP_TIME,
+        help="Time(ms) of warmup runs before benchmark run.",
     )
 
     parser.addoption(
         "--iter",
-        default=consts.DEFAULT_ITER_COUNT,
-        help="Number of reps for each benchmark run.",
+        default=consts.DEFAULT_ITER_TIME,
+        help="Time(ms) of reps for each benchmark run.",
     )
 
     parser.addoption(

--- a/benchmark/conftest.py
+++ b/benchmark/conftest.py
@@ -100,10 +100,11 @@ def pytest_addoption(parser):
         action="store",
         default="kernel",
         required=False,
-        choices=["kernel", "operator", "wrapper"],
+        choices=[mode.value for mode in consts.BenchMode],
         help=(
             "Specify how to measure latency, 'kernel' for device kernel, "
-            "'operator' for end2end operator or 'wrapper' for runtime wrapper."
+            "'operator' for end2end operator, 'wrapper' for runtime wrapper, "
+            "or 'cudagraph' for CUDA Graph captured execution."
         ),
     )
 

--- a/benchmark/consts.py
+++ b/benchmark/consts.py
@@ -45,8 +45,8 @@ def get_fp8_dtype():
 
 FP8_DTYPES = [get_fp8_dtype()]
 
-DEFAULT_WARMUP_COUNT = 1000
-DEFAULT_ITER_COUNT = 100
+DEFAULT_WARMUP_TIME = 1000
+DEFAULT_ITER_TIME = 100
 
 # LEGACY_SHAPES are maintained for legacy benchmark SIZE settings and may be removed in the future.
 # Do not reference this elsewhere.

--- a/benchmark/consts.py
+++ b/benchmark/consts.py
@@ -177,6 +177,7 @@ class BenchMode(Enum):
     KERNEL = "kernel"
     OPERATOR = "operator"
     WRAPPER = "wrapper"
+    CUDAGRAPH = "cudagraph"
 
 
 class BenchLevel(Enum):

--- a/benchmark/test_grouped_topk.py
+++ b/benchmark/test_grouped_topk.py
@@ -17,20 +17,75 @@ import torch
 
 import flaggems_vllm
 
-from . import base, utils
+from . import base
+
+
+def torch_grouped_topk(
+    scores: torch.Tensor,
+    num_expert_group: int,
+    topk_group: int,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    bias: torch.Tensor,
+    scoring_func: int = 0,
+):
+    """
+    Adapted from vLLM: vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py.
+    Ignore the non-stablility of torch.topk in benchmark test.
+    """
+    scores = scores.float()
+    if scoring_func == 1:
+        scores = scores.sigmoid()
+
+    num_token = scores.size(0)
+    original_scores = scores
+    scores = scores + bias.unsqueeze(0)
+    group_scores = (
+        scores.view(num_token, num_expert_group, -1).topk(2, dim=-1)[0].sum(dim=-1)
+    )
+
+    use_sorted = True
+    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=use_sorted)[
+        1
+    ]  # [n, top_k_group]
+    group_mask = torch.zeros_like(group_scores)  # [n, n_group]
+    group_mask.scatter_(1, group_idx, 1)  # [n, n_group]
+    score_mask = (
+        group_mask.unsqueeze(-1)
+        .expand(num_token, num_expert_group, scores.size(-1) // num_expert_group)
+        .reshape(num_token, -1)
+    )  # [n, e]
+    tmp_scores = scores.masked_fill(~score_mask.bool(), float("-inf"))  # [n, e]
+
+    if bias is not None:
+        topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=use_sorted)[1]
+        # Use original unbiased scores for the routing weights
+        topk_weights = original_scores.gather(1, topk_ids)
+    else:
+        topk_weights, topk_ids = torch.topk(
+            tmp_scores, k=topk, dim=-1, sorted=use_sorted
+        )
+
+    if renormalize:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+
+    if routed_scaling_factor != 1.0:
+        topk_weights = topk_weights * routed_scaling_factor
+    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+
 
 vendor_name = flaggems_vllm.vendor_name
 
 try:
-    if vendor_name == "metax":
-        from vllm_metax._custom_ops import grouped_topk as vllm_grouped_topk
-    else:
-        from vllm._custom_ops import grouped_topk as vllm_grouped_topk
+    import vllm._custom_ops as ops  # noqa: F401
 
-    HAS_VLLM = True
+    if hasattr(torch.ops._moe_C, "grouped_topk"):
+        ref_grouped_topk = torch.ops._moe_C.grouped_topk
+    else:
+        ref_grouped_topk = torch_grouped_topk
 except (ImportError, AttributeError):
-    HAS_VLLM = False
-    vllm_grouped_topk = None
+    ref_grouped_topk = torch_grouped_topk
 
 
 class GroupedTopKBenchmark(base.Benchmark):
@@ -83,24 +138,13 @@ class GroupedTopKBenchmark(base.Benchmark):
 
 
 @pytest.mark.grouped_topk
-@pytest.mark.skipif(not HAS_VLLM, reason="Skipped due to missing vLLM grouped_topk")
-@pytest.mark.skipif(
-    utils.SkipVersion("vllm", "<0.9"),
-    reason="The version prior to 0.9 does not include the grouped_topk kernel.",
-)
-@pytest.mark.skipif(
-    utils.SkipVersion("torch", "<2.7"),
-    reason="The version prior to 2.7 is not compatible with VLLM.",
-)
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "iluvatar", reason="#2891: Not working")
-@pytest.mark.skipif(vendor_name == "mthreads", reason="#2891: Not working")
-@pytest.mark.skipif(vendor_name == "hygon", reason="#2891: RuntimeError")
 @pytest.mark.skipif(flaggems_vllm.vendor_name == "cambricon", reason="#2891: TypeError")
 def test_grouped_topk_no_renorm():
     bench = GroupedTopKBenchmark(
         op_name="grouped_topk",
-        torch_op=vllm_grouped_topk,
+        torch_op=ref_grouped_topk,
         dtypes=[torch.bfloat16],
         renormalize=False,
         scoring_func=0,
@@ -111,24 +155,13 @@ def test_grouped_topk_no_renorm():
 
 
 @pytest.mark.grouped_topk
-@pytest.mark.skipif(not HAS_VLLM, reason="Skipped due to missing vLLM grouped_topk")
-@pytest.mark.skipif(
-    utils.SkipVersion("vllm", "<0.9"),
-    reason="The version prior to 0.9 does not include the grouped_topk kernel.",
-)
-@pytest.mark.skipif(
-    utils.SkipVersion("torch", "<2.7"),
-    reason="The version prior to 2.7 is not compatible with VLLM.",
-)
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="#2891: Not working ")
 @pytest.mark.skipif(vendor_name == "iluvatar", reason="#2891: Not working")
-@pytest.mark.skipif(vendor_name == "mthreads", reason="#2891: Not working")
-@pytest.mark.skipif(vendor_name == "hygon", reason="#2891: RuntimeError")
 @pytest.mark.skipif(flaggems_vllm.vendor_name == "cambricon", reason="#2891: TypeError")
 def test_grouped_topk_score_0():
     bench = GroupedTopKBenchmark(
         op_name="grouped_topk",
-        torch_op=vllm_grouped_topk,
+        torch_op=ref_grouped_topk,
         dtypes=[torch.bfloat16],
         renormalize=True,
         scoring_func=0,
@@ -139,24 +172,13 @@ def test_grouped_topk_score_0():
 
 
 @pytest.mark.grouped_topk
-@pytest.mark.skipif(not HAS_VLLM, reason="Skipped due to missing vLLM grouped_topk")
-@pytest.mark.skipif(
-    utils.SkipVersion("vllm", "<0.9"),
-    reason="The version prior to 0.9 does not include the grouped_topk kernel.",
-)
-@pytest.mark.skipif(
-    utils.SkipVersion("torch", "<2.7"),
-    reason="The version prior to 2.7 is not compatible with VLLM.",
-)
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "iluvatar", reason="#2891: Not working")
-@pytest.mark.skipif(vendor_name == "mthreads", reason="#2891: Not working")
-@pytest.mark.skipif(vendor_name == "hygon", reason="#2891: RuntimeError")
 @pytest.mark.skipif(flaggems_vllm.vendor_name == "cambricon", reason="#2891: TypeError")
 def test_grouped_topk_score_1():
     bench = GroupedTopKBenchmark(
         op_name="grouped_topk",
-        torch_op=vllm_grouped_topk,
+        torch_op=ref_grouped_topk,
         dtypes=[torch.bfloat16],
         renormalize=True,
         scoring_func=1,

--- a/benchmark/test_grouped_topk.py
+++ b/benchmark/test_grouped_topk.py
@@ -19,14 +19,18 @@ import flaggems_vllm
 
 from . import base, utils
 
+vendor_name = flaggems_vllm.vendor_name
+
 try:
-    from vllm._custom_ops import grouped_topk as vllm_grouped_topk
+    if vendor_name == "metax":
+        from vllm_metax._custom_ops import grouped_topk as vllm_grouped_topk
+    else:
+        from vllm._custom_ops import grouped_topk as vllm_grouped_topk
 
     HAS_VLLM = True
 except (ImportError, AttributeError):
     HAS_VLLM = False
-
-vendor_name = flaggems_vllm.vendor_name
+    vllm_grouped_topk = None
 
 
 class GroupedTopKBenchmark(base.Benchmark):
@@ -46,20 +50,13 @@ class GroupedTopKBenchmark(base.Benchmark):
 
     def set_shapes(self, shape_file_path=None):
         grouped_topk_configs = [
-            (1, 64, 8, 2, 8),
-            (8, 64, 8, 2, 8),
-            (32, 64, 8, 2, 8),
-            (64, 64, 8, 2, 8),
-            (128, 64, 8, 2, 8),
-            (256, 64, 8, 2, 8),
-            (32, 128, 8, 2, 8),
-            (64, 128, 8, 2, 8),
-            (128, 128, 8, 2, 8),
-            (64, 64, 4, 2, 4),
-            (64, 128, 16, 2, 8),
-            (512, 64, 8, 2, 8),
-            (1024, 64, 8, 2, 8),
-            (2048, 64, 8, 2, 8),
+            # Deepseek-3.2
+            (num_tokens, num_experts, n_group, topk_group, topk)
+            for num_tokens in [1, 8, 32, 64, 128, 256, 496, 512, 16384]
+            for num_experts in [256]
+            for n_group in [8]
+            for topk_group in [4]
+            for topk in [8]
         ]
         self.shapes = grouped_topk_configs
 
@@ -71,7 +68,7 @@ class GroupedTopKBenchmark(base.Benchmark):
         num_tokens, num_experts, n_group, topk_group, topk = config
 
         scores = torch.randn(num_tokens, num_experts, device=device, dtype=dtype)
-        bias = torch.randn(num_experts, device=device, dtype=dtype)
+        bias = torch.randn(num_experts, device=device, dtype=torch.float32)
 
         yield (
             scores,
@@ -95,7 +92,6 @@ class GroupedTopKBenchmark(base.Benchmark):
     utils.SkipVersion("torch", "<2.7"),
     reason="The version prior to 2.7 is not compatible with VLLM.",
 )
-@pytest.mark.skipif(vendor_name == "metax", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "iluvatar", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "mthreads", reason="#2891: Not working")
@@ -105,7 +101,7 @@ def test_grouped_topk_no_renorm():
     bench = GroupedTopKBenchmark(
         op_name="grouped_topk",
         torch_op=vllm_grouped_topk,
-        dtypes=[torch.float32, torch.bfloat16],
+        dtypes=[torch.bfloat16],
         renormalize=False,
         scoring_func=0,
     )
@@ -124,7 +120,6 @@ def test_grouped_topk_no_renorm():
     utils.SkipVersion("torch", "<2.7"),
     reason="The version prior to 2.7 is not compatible with VLLM.",
 )
-@pytest.mark.skipif(vendor_name == "metax", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="#2891: Not working ")
 @pytest.mark.skipif(vendor_name == "iluvatar", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "mthreads", reason="#2891: Not working")
@@ -134,7 +129,7 @@ def test_grouped_topk_score_0():
     bench = GroupedTopKBenchmark(
         op_name="grouped_topk",
         torch_op=vllm_grouped_topk,
-        dtypes=[torch.float32, torch.bfloat16],
+        dtypes=[torch.bfloat16],
         renormalize=True,
         scoring_func=0,
     )
@@ -153,7 +148,6 @@ def test_grouped_topk_score_0():
     utils.SkipVersion("torch", "<2.7"),
     reason="The version prior to 2.7 is not compatible with VLLM.",
 )
-@pytest.mark.skipif(vendor_name == "metax", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "iluvatar", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "mthreads", reason="#2891: Not working")
@@ -163,7 +157,7 @@ def test_grouped_topk_score_1():
     bench = GroupedTopKBenchmark(
         op_name="grouped_topk",
         torch_op=vllm_grouped_topk,
-        dtypes=[torch.float32, torch.bfloat16],
+        dtypes=[torch.bfloat16],
         renormalize=True,
         scoring_func=1,
     )

--- a/benchmark/test_grouped_topk.py
+++ b/benchmark/test_grouped_topk.py
@@ -104,8 +104,35 @@ def aiter_biased_grouped_topk(
     return topk_weights, topk_ids
 
 
+def mthreads_grouped_topk(
+    scores: torch.Tensor,
+    num_expert_group: int,
+    topk_group: int,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    bias: torch.Tensor,
+    scoring_func: int = 0,
+):
+    num_fused_shared_experts = 0
+    apply_routed_scaling_factor_on_output = routed_scaling_factor != 1.0
+    topk_weights, topk_ids = moe_fused_gate(
+        scores.float(),
+        bias.float(),
+        num_expert_group,
+        topk_group,
+        topk,
+        num_fused_shared_experts,
+        routed_scaling_factor if routed_scaling_factor is not None else 1.0,
+        renormalize,
+        apply_routed_scaling_factor_on_output,
+    )
+    return topk_weights, topk_ids
+
+
 vendor_name = flaggems_vllm.vendor_name
 USE_AITER = False
+USE_MATE = False
 
 try:
     if vendor_name == "hygon":
@@ -113,6 +140,11 @@ try:
 
         ref_grouped_topk = aiter_biased_grouped_topk
         USE_AITER = True
+    elif vendor_name == "mthreads":
+        from mate import moe_fused_gate  # noqa: F401
+
+        ref_grouped_topk = mthreads_grouped_topk
+        USE_MATE = True
     else:
         import vllm._custom_ops  # noqa: F401
 
@@ -177,6 +209,9 @@ class GroupedTopKBenchmark(base.Benchmark):
 @pytest.mark.skipif(
     USE_AITER, reason="scoring_func == 0 is not supported by moe_fused_gate in aiter"
 )
+@pytest.mark.skipif(
+    USE_MATE, reason="scoring_func == 0 is not supported by moe_fused_gate in mate"
+)
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "iluvatar", reason="#2891: Not working")
 @pytest.mark.skipif(flaggems_vllm.vendor_name == "cambricon", reason="#2891: TypeError")
@@ -196,6 +231,9 @@ def test_grouped_topk_no_renorm():
 @pytest.mark.grouped_topk
 @pytest.mark.skipif(
     USE_AITER, reason="scoring_func == 0 is not supported by moe_fused_gate in aiter"
+)
+@pytest.mark.skipif(
+    USE_MATE, reason="scoring_func == 0 is not supported by moe_fused_gate in mate"
 )
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="#2891: Not working ")
 @pytest.mark.skipif(vendor_name == "iluvatar", reason="#2891: Not working")

--- a/benchmark/test_grouped_topk.py
+++ b/benchmark/test_grouped_topk.py
@@ -75,15 +75,51 @@ def torch_grouped_topk(
     return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
 
 
+def aiter_biased_grouped_topk(
+    scores: torch.Tensor,
+    num_expert_group: int,
+    topk_group: int,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    bias: torch.Tensor,
+    scoring_func: int = 0,
+):
+    num_tokens = scores.size(0)
+    topk_weights = torch.empty(
+        (num_tokens, topk), dtype=torch.float32, device=scores.device
+    )
+    topk_ids = torch.empty((num_tokens, topk), dtype=torch.int32, device=scores.device)
+    moe_fused_gate(
+        scores.float(),
+        bias.float(),
+        topk_weights,
+        topk_ids,
+        num_expert_group,
+        topk_group,
+        topk=topk,
+        num_fused_shared_experts=0,
+        routed_scaling_factor=routed_scaling_factor,
+    )
+    return topk_weights, topk_ids
+
+
 vendor_name = flaggems_vllm.vendor_name
+USE_AITER = False
 
 try:
-    import vllm._custom_ops as ops  # noqa: F401
+    if vendor_name == "hygon":
+        from aiter import moe_fused_gate  # noqa: F401
 
-    if hasattr(torch.ops._moe_C, "grouped_topk"):
-        ref_grouped_topk = torch.ops._moe_C.grouped_topk
+        ref_grouped_topk = aiter_biased_grouped_topk
+        USE_AITER = True
     else:
-        ref_grouped_topk = torch_grouped_topk
+        import vllm._custom_ops  # noqa: F401
+
+        if hasattr(torch.ops._moe_C, "grouped_topk"):
+            ref_grouped_topk = torch.ops._moe_C.grouped_topk
+        else:
+            ref_grouped_topk = torch_grouped_topk
 except (ImportError, AttributeError):
     ref_grouped_topk = torch_grouped_topk
 
@@ -138,6 +174,9 @@ class GroupedTopKBenchmark(base.Benchmark):
 
 
 @pytest.mark.grouped_topk
+@pytest.mark.skipif(
+    USE_AITER, reason="scoring_func == 0 is not supported by moe_fused_gate in aiter"
+)
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "iluvatar", reason="#2891: Not working")
 @pytest.mark.skipif(flaggems_vllm.vendor_name == "cambricon", reason="#2891: TypeError")
@@ -155,6 +194,9 @@ def test_grouped_topk_no_renorm():
 
 
 @pytest.mark.grouped_topk
+@pytest.mark.skipif(
+    USE_AITER, reason="scoring_func == 0 is not supported by moe_fused_gate in aiter"
+)
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="#2891: Not working ")
 @pytest.mark.skipif(vendor_name == "iluvatar", reason="#2891: Not working")
 @pytest.mark.skipif(flaggems_vllm.vendor_name == "cambricon", reason="#2891: TypeError")

--- a/src/flaggems_vllm/ops/grouped_topk.py
+++ b/src/flaggems_vllm/ops/grouped_topk.py
@@ -18,6 +18,30 @@ import torch
 import triton
 import triton.language as tl
 
+from flaggems_vllm.utils import tl_extra_shim
+from flaggems_vllm.utils.triton_version_utils import has_triton_tle
+
+
+def backend_tle_enabled():
+    from flaggems_vllm.runtime import backend, device
+
+    vendor_info = backend.get_vendor_info(device.vendor_name)
+    return vendor_info.tle_enabled
+
+
+if backend_tle_enabled() & has_triton_tle(3, 6, 0):
+    try:
+        import triton.experimental.tle.language as tle
+
+        HAS_TLE = True
+    except ImportError:
+        tle = None
+        HAS_TLE = False
+else:
+    tle = None
+    HAS_TLE = False
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -54,7 +78,7 @@ def topk_with_k2_triton(
         bias_ptr + bias_offset + lane,
         mask=mask,
         other=0.0,
-    )
+    ).to(INPUT_DTYPE)
 
     x = x + b
 
@@ -181,7 +205,7 @@ def group_idx_and_topk_triton(
         bias_ptr + expert_offsets,
         mask=valid_expert,
         other=0.0,
-    )
+    ).to(INPUT_DTYPE)
 
     selection_scores_native = scored + expert_bias
 
@@ -242,6 +266,246 @@ def group_idx_and_topk_triton(
     )
 
 
+@triton.jit
+def _sigmoid(x):
+    log2e: tl.constexpr = 1.4426950408889634
+    return 1 / (1 + tl_extra_shim.exp2(-x * log2e))
+
+
+@triton.jit
+def _pack_val_idx_fp32(val, idx):
+    MAX_IDX: tl.constexpr = 0xFFFF
+    bits = val.to(tl.uint32, bitcast=True)
+    key = tl.where((bits & 0x80000000) != 0, ~bits, bits | 0x80000000)
+    high = key.to(tl.uint64) << 32
+    low = (0xFFFF & (MAX_IDX - idx)).to(tl.uint64)
+    return high | low
+
+
+@triton.jit
+def _unpack_val_idx_fp32(pair):
+    MAX_IDX: tl.constexpr = 0xFFFF
+    key = (pair >> 32).to(tl.uint32)
+    idx = (MAX_IDX - (pair & 0xFFFF)).to(tl.uint32)
+    bits = tl.where((key & 0x80000000) != 0, key ^ 0x80000000, ~key)
+    val = bits.to(tl.float32, bitcast=True)
+    return val, idx
+
+
+# Adapted from vLLM:
+#   ./vllm/csrc/moe/grouped_topk_kernels.cu
+#   ./vllm/csrc/moe/moeTopKFuncs.cuh
+@triton.jit
+def triton_grouped_topk_fused_small_expert_count_kernel(
+    scores_ptr,
+    topk_values_ptr,
+    topk_indices_ptr,
+    routing_bias_ptr,
+    num_tokens,
+    num_groups,
+    topk_group,
+    topk: tl.constexpr,
+    num_experts,
+    num_experts_per_group,
+    renormalize,
+    routed_scaling_factor,
+    scores_stride0,
+    g_score_sigmoid_ptr,
+    g_score_bias_ptr,
+    SCORING_FUNC: tl.constexpr,
+    HAS_TLE: tl.constexpr,
+):
+    WARP_SIZE: tl.constexpr = 32
+    NUM_WARPS: tl.constexpr = 8
+    neg_inf: tl.constexpr = float("-inf")
+    MAX_IDX: tl.constexpr = 65535
+
+    token_id = tl.program_id(0)
+    scores_ptr += token_id * scores_stride0
+    topk_values_ptr += token_id * topk
+    topk_indices_ptr += token_id * topk
+    warps = tl.arange(0, NUM_WARPS)
+    lane = tl.arange(0, WARP_SIZE)
+
+    if HAS_TLE:
+        s_score_sigmoid = tle.gpu.alloc(
+            [NUM_WARPS, WARP_SIZE],
+            dtype=tl.float32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        s_score_bias = tle.gpu.alloc(
+            [NUM_WARPS, WARP_SIZE],
+            dtype=tl.float32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        s_score_sigmoid_ptr = tle.gpu.local_ptr(s_score_sigmoid, (0, 0))
+        s_score_bias_ptr = tle.gpu.local_ptr(s_score_bias, (0, 0))
+    else:
+        s_score_sigmoid_ptr = g_score_sigmoid_ptr + token_id * scores_stride0
+        s_score_bias_ptr = g_score_bias_ptr + token_id * scores_stride0
+
+    # step1: load score/bias, get score_sigmoid/score_bias
+    offs = warps[:, None] * num_experts_per_group + lane[None, :]
+    score = tl.load(
+        scores_ptr + offs,
+        mask=(warps[:, None] < num_groups) & (lane[None, :] < num_experts_per_group),
+        other=neg_inf,
+    ).to(tl.float32)
+    if SCORING_FUNC == 1:
+        score_sigmoid = _sigmoid(score)
+    else:
+        score_sigmoid = score
+    tl.store(
+        s_score_sigmoid_ptr + offs,
+        score_sigmoid,
+        mask=(warps[:, None] < num_groups) & (lane[None, :] < num_experts_per_group),
+    )
+    bias_val = tl.load(
+        routing_bias_ptr + offs,
+        mask=(warps[:, None] < num_groups) & (lane[None, :] < num_experts_per_group),
+        other=neg_inf,
+    ).to(tl.float32)
+    score_bias = score_sigmoid + bias_val
+    tl.store(
+        s_score_bias_ptr + offs,
+        score_bias,
+        mask=(warps[:, None] < num_groups) & (lane[None, :] < num_experts_per_group),
+    )
+
+    # step2: get top2 as group_score
+    min_val0 = tl.full((NUM_WARPS, WARP_SIZE), neg_inf, dtype=tl.float32)
+    comp_val_idx0 = _pack_val_idx_fp32(score_bias, offs)
+    packed_max00 = tl.max(comp_val_idx0, axis=-1)
+    val_max0, _0 = _unpack_val_idx_fp32(packed_max00)
+    comp_val_idx0 = tl.where(
+        comp_val_idx0 == packed_max00[:, None],
+        _pack_val_idx_fp32(min_val0, offs),
+        comp_val_idx0,
+    )
+    packed_max01 = tl.max(comp_val_idx0, axis=-1)
+    val_max1, _0 = _unpack_val_idx_fp32(packed_max01)
+    group_score = val_max0 + val_max1
+
+    # step3: get topk_group, topk_group <= MAX_NUM_TOP_GROUPS, where MAX_NUM_TOP_GROUPS = 4
+    min_val1 = tl.full((NUM_WARPS,), neg_inf, dtype=tl.float32)
+    comp_val_idx1 = _pack_val_idx_fp32(group_score, warps)
+    packed_max10 = tl.max(comp_val_idx1)
+    _2, group_idx0 = _unpack_val_idx_fp32(packed_max10)
+    comp_val_idx1 = tl.where(
+        comp_val_idx1 == packed_max10,
+        _pack_val_idx_fp32(min_val1, warps),
+        comp_val_idx1,
+    )
+    packed_max11 = tl.max(comp_val_idx1)
+    _2, group_idx1 = _unpack_val_idx_fp32(packed_max11)
+    comp_val_idx1 = tl.where(
+        comp_val_idx1 == packed_max11,
+        _pack_val_idx_fp32(min_val1, warps),
+        comp_val_idx1,
+    )
+    packed_max12 = tl.max(comp_val_idx1)
+    _2, group_idx2 = _unpack_val_idx_fp32(packed_max12)
+    comp_val_idx1 = tl.where(
+        comp_val_idx1 == packed_max12,
+        _pack_val_idx_fp32(min_val1, warps),
+        comp_val_idx1,
+    )
+    packed_max13 = tl.max(comp_val_idx1)
+    _2, group_idx3 = _unpack_val_idx_fp32(packed_max13)
+
+    # step4: get topk, topk <= MAX_NUM_TOP_EXPERTS, where MAX_NUM_TOP_EXPERTS = 8
+    expert_idx_group0 = group_idx0 * num_experts_per_group + lane
+    expert_idx_group1 = group_idx1 * num_experts_per_group + lane
+    expert_idx_group2 = group_idx2 * num_experts_per_group + lane
+    expert_idx_group3 = group_idx3 * num_experts_per_group + lane
+    expert_score_group0 = tl.load(
+        s_score_bias_ptr + expert_idx_group0,
+        mask=(0 < topk_group) & (lane < num_experts_per_group),
+        other=neg_inf,
+    )
+    expert_score_group1 = tl.load(
+        s_score_bias_ptr + expert_idx_group1,
+        mask=(1 < topk_group) & (lane < num_experts_per_group),
+        other=neg_inf,
+    )
+    expert_score_group2 = tl.load(
+        s_score_bias_ptr + expert_idx_group2,
+        mask=(2 < topk_group) & (lane < num_experts_per_group),
+        other=neg_inf,
+    )
+    expert_score_group3 = tl.load(
+        s_score_bias_ptr + expert_idx_group3,
+        mask=(3 < topk_group) & (lane < num_experts_per_group),
+        other=neg_inf,
+    )
+    comp_val_idx20 = _pack_val_idx_fp32(expert_score_group0, expert_idx_group0)
+    comp_val_idx21 = _pack_val_idx_fp32(expert_score_group1, expert_idx_group1)
+    comp_val_idx22 = _pack_val_idx_fp32(expert_score_group2, expert_idx_group2)
+    comp_val_idx23 = _pack_val_idx_fp32(expert_score_group3, expert_idx_group3)
+    # TOPK_SWAP(0, 2); TOPK_SWAP(1, 3); TOPK_SWAP(0, 1); TOPK_SWAP(2, 3); TOPK_SWAP(1, 2);
+    comp_val_idx20, comp_val_idx22 = max(comp_val_idx20, comp_val_idx22), min(
+        comp_val_idx20, comp_val_idx22
+    )
+    comp_val_idx21, comp_val_idx23 = max(comp_val_idx21, comp_val_idx23), min(
+        comp_val_idx21, comp_val_idx23
+    )
+    comp_val_idx20, comp_val_idx21 = max(comp_val_idx20, comp_val_idx21), min(
+        comp_val_idx20, comp_val_idx21
+    )
+    comp_val_idx22, comp_val_idx23 = max(comp_val_idx22, comp_val_idx23), min(
+        comp_val_idx22, comp_val_idx23
+    )
+    comp_val_idx21, comp_val_idx22 = max(comp_val_idx21, comp_val_idx22), min(
+        comp_val_idx21, comp_val_idx22
+    )
+
+    min_val2 = tl.full((WARP_SIZE,), neg_inf, dtype=tl.float32)
+    top_experts = tl.full((WARP_SIZE,), MAX_IDX, dtype=tl.uint32)
+    packed_max20 = tl.full((), 0, dtype=tl.uint64)
+    for kk in tl.static_range(0, topk):
+        update = (kk > 0) & (comp_val_idx20 == packed_max20)
+        comp_val_idx20 = tl.where(
+            update,
+            comp_val_idx21,
+            comp_val_idx20,
+        )
+        comp_val_idx21 = tl.where(
+            update,
+            comp_val_idx22,
+            comp_val_idx21,
+        )
+        comp_val_idx22 = tl.where(
+            update,
+            comp_val_idx23,
+            comp_val_idx22,
+        )
+        comp_val_idx23 = tl.where(
+            update,
+            _pack_val_idx_fp32(min_val2, expert_idx_group3),
+            comp_val_idx23,
+        )
+        packed_max20 = tl.max(comp_val_idx20)
+        _3, out_idx = _unpack_val_idx_fp32(packed_max20)
+        top_experts = tl.where(lane == kk, out_idx, top_experts)
+
+    # step5: renormalize and output
+    lane_unbiased = tl.load(
+        s_score_sigmoid_ptr + top_experts, mask=lane < topk, other=0.0
+    )
+    topk_sum = 1e-20
+    if renormalize:
+        topk_sum += tl.sum(lane_unbiased)
+    scale = routed_scaling_factor.to(tl.float32)
+    if renormalize:
+        scale /= topk_sum
+    tl.store(topk_values_ptr + lane, lane_unbiased * scale, mask=lane < topk)
+    tl.store(topk_indices_ptr + lane, top_experts, mask=lane < topk)
+
+
 def grouped_topk(
     scores: torch.Tensor,
     n_group: int,
@@ -265,8 +529,6 @@ def grouped_topk(
     if scoring_func not in (0, 1):
         raise ValueError("scoring_func must be 0 (none) or 1 (sigmoid)")
 
-    if bias.dtype != scores.dtype:
-        bias = bias.to(scores.dtype)
     if bias.ndim != 1:
         bias = bias.flatten()
     if len(bias) != num_experts:
@@ -284,6 +546,64 @@ def grouped_topk(
         INPUT_DTYPE = tl.bfloat16
     else:
         raise ValueError(f"Unsupported dtype: {scores.dtype}")
+
+    if (
+        (n_group > 1)
+        & (n_group <= 32)
+        & (num_experts <= 256)
+        & (num_experts_per_group <= 32)
+        & (num_experts_per_group * topk_group <= 128)
+        & (topk <= 8)
+        & (topk_group <= 4)
+    ):
+        # DeepSeek-v3.2
+        topk_values = torch.empty(
+            (num_tokens, topk),
+            device=scores.device,
+            dtype=torch.float32,
+        )
+        topk_indices = torch.empty(
+            (num_tokens, topk),
+            device=scores.device,
+            dtype=torch.int32,
+        )
+        if not HAS_TLE:
+            g_scores_sigmoid = torch.empty(
+                (num_tokens, num_experts),
+                device=scores.device,
+                dtype=torch.float32,
+            )
+            g_scores_bias = torch.empty(
+                (num_tokens, num_experts),
+                device=scores.device,
+                dtype=torch.float32,
+            )
+        else:
+            g_scores_sigmoid = None
+            g_scores_bias = None
+
+        triton_grouped_topk_fused_small_expert_count_kernel[(num_tokens,)](
+            scores,
+            topk_values,
+            topk_indices,
+            bias,
+            num_tokens,
+            n_group,
+            topk_group,
+            topk,
+            num_experts,
+            num_experts_per_group,
+            renormalize,
+            routed_scaling_factor,
+            scores.stride(0),
+            g_scores_sigmoid,
+            g_scores_bias,
+            SCORING_FUNC=scoring_func,
+            HAS_TLE=HAS_TLE,
+            num_warps=1,
+        )
+
+        return topk_values, topk_indices
 
     if scoring_func == 1:
         from flaggems_vllm.ops.tanh import tanh as gems_tanh

--- a/src/flaggems_vllm/ops/grouped_topk.py
+++ b/src/flaggems_vllm/ops/grouped_topk.py
@@ -315,6 +315,7 @@ def triton_grouped_topk_fused_small_expert_count_kernel(
     SCORING_FUNC: tl.constexpr,
     HAS_TLE: tl.constexpr,
     NUM_GROUPS_PAD: tl.constexpr,
+    FULL_SHAPE: tl.constexpr,
 ):
     WARP_SIZE: tl.constexpr = 32
     NUM_WARPS: tl.constexpr = NUM_GROUPS_PAD
@@ -351,31 +352,45 @@ def triton_grouped_topk_fused_small_expert_count_kernel(
 
     # step1: load score/bias, get score_sigmoid/score_bias
     offs = warps[:, None] * num_experts_per_group + lane[None, :]
-    score = tl.load(
-        scores_ptr + offs,
-        mask=(warps[:, None] < num_groups) & (lane[None, :] < num_experts_per_group),
-        other=neg_inf,
-    ).to(tl.float32)
+    if FULL_SHAPE:
+        score = tl.load(scores_ptr + offs).to(tl.float32)
+    else:
+        score = tl.load(
+            scores_ptr + offs,
+            mask=(warps[:, None] < num_groups)
+            & (lane[None, :] < num_experts_per_group),
+            other=neg_inf,
+        ).to(tl.float32)
     if SCORING_FUNC == 1:
         score_sigmoid = _sigmoid(score)
     else:
         score_sigmoid = score
-    tl.store(
-        s_score_sigmoid_ptr + offs,
-        score_sigmoid,
-        mask=(warps[:, None] < num_groups) & (lane[None, :] < num_experts_per_group),
-    )
-    bias_val = tl.load(
-        routing_bias_ptr + offs,
-        mask=(warps[:, None] < num_groups) & (lane[None, :] < num_experts_per_group),
-        other=neg_inf,
-    ).to(tl.float32)
+    if FULL_SHAPE:
+        tl.store(s_score_sigmoid_ptr + offs, score_sigmoid)
+        bias_val = tl.load(routing_bias_ptr + offs).to(tl.float32)
+    else:
+        tl.store(
+            s_score_sigmoid_ptr + offs,
+            score_sigmoid,
+            mask=(warps[:, None] < num_groups)
+            & (lane[None, :] < num_experts_per_group),
+        )
+        bias_val = tl.load(
+            routing_bias_ptr + offs,
+            mask=(warps[:, None] < num_groups)
+            & (lane[None, :] < num_experts_per_group),
+            other=neg_inf,
+        ).to(tl.float32)
     score_bias = score_sigmoid + bias_val
-    tl.store(
-        s_score_bias_ptr + offs,
-        score_bias,
-        mask=(warps[:, None] < num_groups) & (lane[None, :] < num_experts_per_group),
-    )
+    if FULL_SHAPE:
+        tl.store(s_score_bias_ptr + offs, score_bias)
+    else:
+        tl.store(
+            s_score_bias_ptr + offs,
+            score_bias,
+            mask=(warps[:, None] < num_groups)
+            & (lane[None, :] < num_experts_per_group),
+        )
 
     # step2: get top2 as group_score
     min_val0 = tl.full((NUM_WARPS, WARP_SIZE), neg_inf, dtype=tl.float32)
@@ -419,30 +434,56 @@ def triton_grouped_topk_fused_small_expert_count_kernel(
     _2, group_idx3 = _unpack_val_idx_fp32(packed_max13)
 
     # step4: get topk, topk <= MAX_NUM_TOP_EXPERTS, where MAX_NUM_TOP_EXPERTS = 8
-    expert_idx_group0 = group_idx0 * num_experts_per_group + lane
-    expert_idx_group1 = group_idx1 * num_experts_per_group + lane
-    expert_idx_group2 = group_idx2 * num_experts_per_group + lane
-    expert_idx_group3 = group_idx3 * num_experts_per_group + lane
-    expert_score_group0 = tl.load(
-        s_score_bias_ptr + expert_idx_group0,
-        mask=(0 < topk_group) & (lane < num_experts_per_group),
-        other=neg_inf,
-    )
-    expert_score_group1 = tl.load(
-        s_score_bias_ptr + expert_idx_group1,
-        mask=(1 < topk_group) & (lane < num_experts_per_group),
-        other=neg_inf,
-    )
-    expert_score_group2 = tl.load(
-        s_score_bias_ptr + expert_idx_group2,
-        mask=(2 < topk_group) & (lane < num_experts_per_group),
-        other=neg_inf,
-    )
-    expert_score_group3 = tl.load(
-        s_score_bias_ptr + expert_idx_group3,
-        mask=(3 < topk_group) & (lane < num_experts_per_group),
-        other=neg_inf,
-    )
+    if FULL_SHAPE:
+        expert_idx_group0 = group_idx0 * WARP_SIZE + lane
+        expert_idx_group1 = group_idx1 * WARP_SIZE + lane
+        expert_idx_group2 = group_idx2 * WARP_SIZE + lane
+        expert_idx_group3 = group_idx3 * WARP_SIZE + lane
+        expert_score_group0 = tl.load(
+            s_score_bias_ptr + expert_idx_group0,
+            mask=0 < topk_group,
+            other=neg_inf,
+        )
+        expert_score_group1 = tl.load(
+            s_score_bias_ptr + expert_idx_group1,
+            mask=1 < topk_group,
+            other=neg_inf,
+        )
+        expert_score_group2 = tl.load(
+            s_score_bias_ptr + expert_idx_group2,
+            mask=2 < topk_group,
+            other=neg_inf,
+        )
+        expert_score_group3 = tl.load(
+            s_score_bias_ptr + expert_idx_group3,
+            mask=3 < topk_group,
+            other=neg_inf,
+        )
+    else:
+        expert_idx_group0 = group_idx0 * num_experts_per_group + lane
+        expert_idx_group1 = group_idx1 * num_experts_per_group + lane
+        expert_idx_group2 = group_idx2 * num_experts_per_group + lane
+        expert_idx_group3 = group_idx3 * num_experts_per_group + lane
+        expert_score_group0 = tl.load(
+            s_score_bias_ptr + expert_idx_group0,
+            mask=(0 < topk_group) & (lane < num_experts_per_group),
+            other=neg_inf,
+        )
+        expert_score_group1 = tl.load(
+            s_score_bias_ptr + expert_idx_group1,
+            mask=(1 < topk_group) & (lane < num_experts_per_group),
+            other=neg_inf,
+        )
+        expert_score_group2 = tl.load(
+            s_score_bias_ptr + expert_idx_group2,
+            mask=(2 < topk_group) & (lane < num_experts_per_group),
+            other=neg_inf,
+        )
+        expert_score_group3 = tl.load(
+            s_score_bias_ptr + expert_idx_group3,
+            mask=(3 < topk_group) & (lane < num_experts_per_group),
+            other=neg_inf,
+        )
     comp_val_idx20 = _pack_val_idx_fp32(expert_score_group0, expert_idx_group0)
     comp_val_idx21 = _pack_val_idx_fp32(expert_score_group1, expert_idx_group1)
     comp_val_idx22 = _pack_val_idx_fp32(expert_score_group2, expert_idx_group2)
@@ -603,6 +644,7 @@ def grouped_topk(
             SCORING_FUNC=scoring_func,
             HAS_TLE=HAS_TLE,
             NUM_GROUPS_PAD=n_group_pad,
+            FULL_SHAPE=num_experts_per_group == 32 and n_group == n_group_pad,
             num_warps=1,
         )
 

--- a/src/flaggems_vllm/runtime/backend/_ascend/ops/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_ascend/ops/__init__.py
@@ -21,6 +21,7 @@ from flaggems_vllm.runtime.backend._ascend.ops.fused_moe import (
     inplace_fused_experts,
     outplace_fused_experts,
 )
+from flaggems_vllm.runtime.backend._ascend.ops.grouped_topk import grouped_topk
 from flaggems_vllm.runtime.backend._ascend.ops.hyperconnection import (
     qwen4_hc_inject_combine,
 )
@@ -33,6 +34,7 @@ from flaggems_vllm.runtime.backend._ascend.ops.scaled_int8_quant import (
 
 __all__ = [
     "fused_experts_impl",
+    "grouped_topk",
     "inplace_fused_experts",
     "outplace_fused_experts",
     "qwen4_store_qsa_kv_rows",

--- a/src/flaggems_vllm/runtime/backend/_ascend/ops/grouped_topk.py
+++ b/src/flaggems_vllm/runtime/backend/_ascend/ops/grouped_topk.py
@@ -16,31 +16,10 @@ import logging
 
 import torch
 import triton
+import triton.experimental.tle.language as tle
 import triton.language as tl
 
 from flaggems_vllm.utils import tl_extra_shim
-from flaggems_vllm.utils.triton_version_utils import has_triton_tle
-
-
-def backend_tle_enabled():
-    from flaggems_vllm.runtime import backend, device
-
-    vendor_info = backend.get_vendor_info(device.vendor_name)
-    return vendor_info.tle_enabled
-
-
-if backend_tle_enabled() & has_triton_tle(3, 6, 0):
-    try:
-        import triton.experimental.tle.language as tle
-
-        HAS_TLE = True
-    except ImportError:
-        tle = None
-        HAS_TLE = False
-else:
-    tle = None
-    HAS_TLE = False
-
 
 logger = logging.getLogger(__name__)
 
@@ -272,26 +251,6 @@ def _sigmoid(x):
     return 1 / (1 + tl_extra_shim.exp2(-x * log2e))
 
 
-@triton.jit
-def _pack_val_idx_fp32(val, idx):
-    MAX_IDX: tl.constexpr = 0xFFFF
-    bits = val.to(tl.uint32, bitcast=True)
-    key = tl.where((bits & 0x80000000) != 0, ~bits, bits | 0x80000000)
-    high = key.to(tl.uint64) << 32
-    low = (0xFFFF & (MAX_IDX - idx)).to(tl.uint64)
-    return high | low
-
-
-@triton.jit
-def _unpack_val_idx_fp32(pair):
-    MAX_IDX: tl.constexpr = 0xFFFF
-    key = (pair >> 32).to(tl.uint32)
-    idx = (MAX_IDX - (pair & 0xFFFF)).to(tl.uint32)
-    bits = tl.where((key & 0x80000000) != 0, key ^ 0x80000000, ~key)
-    val = bits.to(tl.float32, bitcast=True)
-    return val, idx
-
-
 # Adapted from vLLM:
 #   ./vllm/csrc/moe/grouped_topk_kernels.cu
 #   ./vllm/csrc/moe/moeTopKFuncs.cuh
@@ -310,16 +269,17 @@ def triton_grouped_topk_fused_small_expert_count_kernel(
     renormalize,
     routed_scaling_factor,
     scores_stride0,
-    g_score_sigmoid_ptr,
-    g_score_bias_ptr,
+    SCORE_DTYPE: tl.constexpr,
+    BIAS_DTYPE: tl.constexpr,
     SCORING_FUNC: tl.constexpr,
-    HAS_TLE: tl.constexpr,
+    FULL_SHAPE: tl.constexpr,
     NUM_GROUPS_PAD: tl.constexpr,
 ):
+    MAX_TOPK_GROUP: tl.constexpr = 4
+    MAX_TOPK: tl.constexpr = 8
     WARP_SIZE: tl.constexpr = 32
     NUM_WARPS: tl.constexpr = NUM_GROUPS_PAD
     neg_inf: tl.constexpr = float("-inf")
-    MAX_IDX: tl.constexpr = 65535
 
     token_id = tl.program_id(0)
     scores_ptr += token_id * scores_stride0
@@ -328,183 +288,143 @@ def triton_grouped_topk_fused_small_expert_count_kernel(
     warps = tl.arange(0, NUM_WARPS)
     lane = tl.arange(0, WARP_SIZE)
 
-    if HAS_TLE:
-        s_score_sigmoid = tle.gpu.alloc(
-            [NUM_WARPS, WARP_SIZE],
-            dtype=tl.float32,
-            layout=None,
-            scope=tle.gpu.smem,
-            nv_mma_shared_layout=False,
+    # step1: load score and bias, get score_sigmoid and score_bias
+    if FULL_SHAPE:
+        # num_groups = NUM_GROUPS_PAD, num_experts_per_group = WARP_SIZE
+        offs = warps[:, None] * WARP_SIZE + lane[None, :]
+        score_ub = tle.dsa.alloc(
+            [NUM_WARPS, WARP_SIZE], dtype=SCORE_DTYPE, mem_addr_space=tle.dsa.ascend.UB
         )
-        s_score_bias = tle.gpu.alloc(
-            [NUM_WARPS, WARP_SIZE],
-            dtype=tl.float32,
-            layout=None,
-            scope=tle.gpu.smem,
-            nv_mma_shared_layout=False,
+        bias_ub = tle.dsa.alloc(
+            [NUM_WARPS, WARP_SIZE], dtype=BIAS_DTYPE, mem_addr_space=tle.dsa.ascend.UB
         )
-        s_score_sigmoid_ptr = tle.gpu.local_ptr(s_score_sigmoid, (0, 0))
-        s_score_bias_ptr = tle.gpu.local_ptr(s_score_bias, (0, 0))
+        tle.dsa.copy(scores_ptr + offs, score_ub, [NUM_WARPS, WARP_SIZE])
+        tle.dsa.copy(routing_bias_ptr + offs, bias_ub, [NUM_WARPS, WARP_SIZE])
+        score = tle.dsa.to_tensor(score_ub).to(tl.float32)
+        if SCORING_FUNC == 1:
+            score_sigmoid = _sigmoid(score)
+        else:
+            score_sigmoid = score
+        bias_val = tle.dsa.to_tensor(bias_ub)
+        score_bias = score_sigmoid + bias_val
     else:
-        s_score_sigmoid_ptr = g_score_sigmoid_ptr + token_id * scores_stride0
-        s_score_bias_ptr = g_score_bias_ptr + token_id * scores_stride0
+        offs = warps[:, None] * num_experts_per_group + lane[None, :]
+        score = tl.load(
+            scores_ptr + offs,
+            mask=(warps[:, None] < num_groups)
+            & (lane[None, :] < num_experts_per_group),
+            other=neg_inf,
+        ).to(tl.float32)
+        if SCORING_FUNC == 1:
+            score_sigmoid = _sigmoid(score)
+        else:
+            score_sigmoid = score
+        bias_val = tl.load(
+            routing_bias_ptr + offs,
+            mask=(warps[:, None] < num_groups)
+            & (lane[None, :] < num_experts_per_group),
+            other=neg_inf,
+        ).to(tl.float32)
+        score_bias = score_sigmoid + bias_val
 
-    # step1: load score/bias, get score_sigmoid/score_bias
-    offs = warps[:, None] * num_experts_per_group + lane[None, :]
-    score = tl.load(
-        scores_ptr + offs,
-        mask=(warps[:, None] < num_groups) & (lane[None, :] < num_experts_per_group),
-        other=neg_inf,
-    ).to(tl.float32)
-    if SCORING_FUNC == 1:
-        score_sigmoid = _sigmoid(score)
-    else:
-        score_sigmoid = score
-    tl.store(
-        s_score_sigmoid_ptr + offs,
-        score_sigmoid,
-        mask=(warps[:, None] < num_groups) & (lane[None, :] < num_experts_per_group),
+    # step2: get sum(top2) as group_score
+    group_max_val0, group_max_index0 = tl.max(
+        score_bias, axis=-1, return_indices=True, return_indices_tie_break_left=True
     )
-    bias_val = tl.load(
-        routing_bias_ptr + offs,
-        mask=(warps[:, None] < num_groups) & (lane[None, :] < num_experts_per_group),
-        other=neg_inf,
-    ).to(tl.float32)
-    score_bias = score_sigmoid + bias_val
-    tl.store(
-        s_score_bias_ptr + offs,
-        score_bias,
-        mask=(warps[:, None] < num_groups) & (lane[None, :] < num_experts_per_group),
+    tmp_score_bias = tl.where(
+        group_max_index0[:, None] == lane[None, :], neg_inf, score_bias
     )
+    group_max_val1 = tl.max(tmp_score_bias, axis=-1, return_indices_tie_break_left=True)
+    group_score = group_max_val0 + group_max_val1  # [NUM_WARPS]
 
-    # step2: get top2 as group_score
-    min_val0 = tl.full((NUM_WARPS, WARP_SIZE), neg_inf, dtype=tl.float32)
-    comp_val_idx0 = _pack_val_idx_fp32(score_bias, offs)
-    packed_max00 = tl.max(comp_val_idx0, axis=-1)
-    val_max0, _0 = _unpack_val_idx_fp32(packed_max00)
-    comp_val_idx0 = tl.where(
-        comp_val_idx0 == packed_max00[:, None],
-        _pack_val_idx_fp32(min_val0, offs),
-        comp_val_idx0,
-    )
-    packed_max01 = tl.max(comp_val_idx0, axis=-1)
-    val_max1, _0 = _unpack_val_idx_fp32(packed_max01)
-    group_score = val_max0 + val_max1
-
-    # step3: get topk_group, topk_group <= MAX_NUM_TOP_GROUPS, where MAX_NUM_TOP_GROUPS = 4
-    min_val1 = tl.full((NUM_WARPS,), neg_inf, dtype=tl.float32)
-    comp_val_idx1 = _pack_val_idx_fp32(group_score, warps)
-    packed_max10 = tl.max(comp_val_idx1)
-    _2, group_idx0 = _unpack_val_idx_fp32(packed_max10)
-    comp_val_idx1 = tl.where(
-        comp_val_idx1 == packed_max10,
-        _pack_val_idx_fp32(min_val1, warps),
-        comp_val_idx1,
-    )
-    packed_max11 = tl.max(comp_val_idx1)
-    _2, group_idx1 = _unpack_val_idx_fp32(packed_max11)
-    comp_val_idx1 = tl.where(
-        comp_val_idx1 == packed_max11,
-        _pack_val_idx_fp32(min_val1, warps),
-        comp_val_idx1,
-    )
-    packed_max12 = tl.max(comp_val_idx1)
-    _2, group_idx2 = _unpack_val_idx_fp32(packed_max12)
-    comp_val_idx1 = tl.where(
-        comp_val_idx1 == packed_max12,
-        _pack_val_idx_fp32(min_val1, warps),
-        comp_val_idx1,
-    )
-    packed_max13 = tl.max(comp_val_idx1)
-    _2, group_idx3 = _unpack_val_idx_fp32(packed_max13)
-
-    # step4: get topk, topk <= MAX_NUM_TOP_EXPERTS, where MAX_NUM_TOP_EXPERTS = 8
-    expert_idx_group0 = group_idx0 * num_experts_per_group + lane
-    expert_idx_group1 = group_idx1 * num_experts_per_group + lane
-    expert_idx_group2 = group_idx2 * num_experts_per_group + lane
-    expert_idx_group3 = group_idx3 * num_experts_per_group + lane
-    expert_score_group0 = tl.load(
-        s_score_bias_ptr + expert_idx_group0,
-        mask=(0 < topk_group) & (lane < num_experts_per_group),
-        other=neg_inf,
-    )
-    expert_score_group1 = tl.load(
-        s_score_bias_ptr + expert_idx_group1,
-        mask=(1 < topk_group) & (lane < num_experts_per_group),
-        other=neg_inf,
-    )
-    expert_score_group2 = tl.load(
-        s_score_bias_ptr + expert_idx_group2,
-        mask=(2 < topk_group) & (lane < num_experts_per_group),
-        other=neg_inf,
-    )
-    expert_score_group3 = tl.load(
-        s_score_bias_ptr + expert_idx_group3,
-        mask=(3 < topk_group) & (lane < num_experts_per_group),
-        other=neg_inf,
-    )
-    comp_val_idx20 = _pack_val_idx_fp32(expert_score_group0, expert_idx_group0)
-    comp_val_idx21 = _pack_val_idx_fp32(expert_score_group1, expert_idx_group1)
-    comp_val_idx22 = _pack_val_idx_fp32(expert_score_group2, expert_idx_group2)
-    comp_val_idx23 = _pack_val_idx_fp32(expert_score_group3, expert_idx_group3)
-    # TOPK_SWAP(0, 2); TOPK_SWAP(1, 3); TOPK_SWAP(0, 1); TOPK_SWAP(2, 3); TOPK_SWAP(1, 2);
-    comp_val_idx20, comp_val_idx22 = max(comp_val_idx20, comp_val_idx22), min(
-        comp_val_idx20, comp_val_idx22
-    )
-    comp_val_idx21, comp_val_idx23 = max(comp_val_idx21, comp_val_idx23), min(
-        comp_val_idx21, comp_val_idx23
-    )
-    comp_val_idx20, comp_val_idx21 = max(comp_val_idx20, comp_val_idx21), min(
-        comp_val_idx20, comp_val_idx21
-    )
-    comp_val_idx22, comp_val_idx23 = max(comp_val_idx22, comp_val_idx23), min(
-        comp_val_idx22, comp_val_idx23
-    )
-    comp_val_idx21, comp_val_idx22 = max(comp_val_idx21, comp_val_idx22), min(
-        comp_val_idx21, comp_val_idx22
-    )
-
-    min_val2 = tl.full((WARP_SIZE,), neg_inf, dtype=tl.float32)
-    top_experts = tl.full((WARP_SIZE,), MAX_IDX, dtype=tl.uint32)
-    packed_max20 = tl.full((), 0, dtype=tl.uint64)
-    for kk in tl.static_range(0, topk):
-        update = (kk > 0) & (comp_val_idx20 == packed_max20)
-        comp_val_idx20 = tl.where(
-            update,
-            comp_val_idx21,
-            comp_val_idx20,
+    # step3: get topk_group
+    invalid_score = tl.full([1], neg_inf, dtype=tl.float32)
+    group_idx = tl.zeros([MAX_TOPK_GROUP], dtype=tl.int32)
+    group_score_bias = tl.full([MAX_TOPK_GROUP, WARP_SIZE], neg_inf, dtype=tl.float32)
+    for i in tl.static_range(topk_group):
+        _1, idx = tl.max(
+            group_score,
+            axis=-1,
+            return_indices=True,
+            return_indices_tie_break_left=True,
         )
-        comp_val_idx21 = tl.where(
-            update,
-            comp_val_idx22,
-            comp_val_idx21,
+        group_score = tle.dsa.insert_slice(
+            group_score, invalid_score, offsets=(idx,), sizes=(1,), strides=(1,)
         )
-        comp_val_idx22 = tl.where(
-            update,
-            comp_val_idx23,
-            comp_val_idx22,
+        group_idx = tle.dsa.insert_slice(
+            group_idx,
+            tl.full([1], idx, dtype=tl.int32),
+            offsets=(i,),
+            sizes=(1,),
+            strides=(1,),
         )
-        comp_val_idx23 = tl.where(
-            update,
-            _pack_val_idx_fp32(min_val2, expert_idx_group3),
-            comp_val_idx23,
+        group_slice = tle.dsa.extract_slice(
+            score_bias, offsets=(idx, 0), sizes=(1, WARP_SIZE), strides=(1, 1)
         )
-        packed_max20 = tl.max(comp_val_idx20)
-        _3, out_idx = _unpack_val_idx_fp32(packed_max20)
-        top_experts = tl.where(lane == kk, out_idx, top_experts)
+        group_score_bias = tle.dsa.insert_slice(
+            group_score_bias,
+            group_slice,
+            offsets=(i, 0),
+            sizes=(1, WARP_SIZE),
+            strides=(1, 1),
+        )
+    group_score_bias = group_score_bias.reshape(MAX_TOPK_GROUP * WARP_SIZE)
 
-    # step5: renormalize and output
-    lane_unbiased = tl.load(
-        s_score_sigmoid_ptr + top_experts, mask=lane < topk, other=0.0
+    # step4: get topk
+    top_experts_idx = tl.zeros([MAX_TOPK], dtype=tl.int32)
+    top_experts_pos = tl.zeros([MAX_TOPK], dtype=tl.int32)
+    topk_offs = tl.arange(0, MAX_TOPK)
+    topk_group_offs = tl.arange(0, MAX_TOPK_GROUP)
+    for j in tl.static_range(topk):
+        _2, off = tl.max(
+            group_score_bias,
+            axis=-1,
+            return_indices=True,
+            return_indices_tie_break_left=True,
+        )
+        group_score_bias = tle.dsa.insert_slice(
+            group_score_bias,
+            tl.full([1], neg_inf, dtype=tl.float32),
+            offsets=(off,),
+            sizes=(1,),
+            strides=(1,),
+        )
+        local_group_off = off // WARP_SIZE
+        inner_off = off % WARP_SIZE
+        # TODO: User tle.dsa.extract_element instead of tl.min(tl.where(...)) after the related issue is resolved
+        actual_group_off = tl.min(
+            tl.where(topk_group_offs == local_group_off, group_idx, NUM_WARPS)
+        )
+        expert_id = actual_group_off * num_experts_per_group + inner_off
+        pos = actual_group_off * WARP_SIZE + inner_off
+        top_experts_idx = tle.dsa.insert_slice(
+            top_experts_idx,
+            tl.full([1], expert_id, dtype=tl.int32),
+            offsets=(j,),
+            sizes=(1,),
+            strides=(1,),
+        )
+        top_experts_pos = tle.dsa.insert_slice(
+            top_experts_pos,
+            tl.full([1], pos, dtype=tl.int32),
+            offsets=(j,),
+            sizes=(1,),
+            strides=(1,),
+        )
+
+    # step5: output
+    topk_unbiased = tl.gather(
+        tl.reshape(score_sigmoid, (NUM_WARPS * WARP_SIZE)), top_experts_pos, 0
     )
+    topk_unbiased = tl.where(topk_offs < topk, topk_unbiased, 0.0)
     topk_sum = 1e-20
     if renormalize:
-        topk_sum += tl.sum(lane_unbiased)
+        topk_sum += tl.sum(topk_unbiased)
     scale = routed_scaling_factor.to(tl.float32)
     if renormalize:
         scale /= topk_sum
-    tl.store(topk_values_ptr + lane, lane_unbiased * scale, mask=lane < topk)
-    tl.store(topk_indices_ptr + lane, top_experts, mask=lane < topk)
+    tl.store(topk_values_ptr + topk_offs, topk_unbiased * scale, mask=topk_offs < topk)
+    tl.store(topk_indices_ptr + topk_offs, top_experts_idx, mask=topk_offs < topk)
 
 
 def grouped_topk(
@@ -517,7 +437,7 @@ def grouped_topk(
     bias: torch.Tensor,
     scoring_func: int = 0,
 ):
-    logger.debug("GEMS GROUPED TOPK")
+    logger.debug("GEMS_ASCEND GROUPED TOPK")
     if scores.ndim != 2:
         raise ValueError("scores must be a 2D Tensor")
     num_tokens, num_experts = scores.shape
@@ -568,22 +488,16 @@ def grouped_topk(
             device=scores.device,
             dtype=torch.int32,
         )
-        if not HAS_TLE:
-            g_scores_sigmoid = torch.empty(
-                (num_tokens, num_experts),
-                device=scores.device,
-                dtype=torch.float32,
-            )
-            g_scores_bias = torch.empty(
-                (num_tokens, num_experts),
-                device=scores.device,
-                dtype=torch.float32,
-            )
+        if bias.dtype == torch.float32:
+            BIAS_DTYPE = tl.float32
+        elif bias.dtype == torch.float16:
+            BIAS_DTYPE = tl.float16
+        elif bias.dtype == torch.bfloat16:
+            BIAS_DTYPE = tl.bfloat16
         else:
-            g_scores_sigmoid = None
-            g_scores_bias = None
-
+            raise ValueError(f"Unsupported dtype: {bias.dtype}")
         n_group_pad = triton.next_power_of_2(n_group)
+
         triton_grouped_topk_fused_small_expert_count_kernel[(num_tokens,)](
             scores,
             topk_values,
@@ -598,20 +512,17 @@ def grouped_topk(
             renormalize,
             routed_scaling_factor,
             scores.stride(0),
-            g_scores_sigmoid,
-            g_scores_bias,
+            SCORE_DTYPE=INPUT_DTYPE,
+            BIAS_DTYPE=BIAS_DTYPE,
             SCORING_FUNC=scoring_func,
-            HAS_TLE=HAS_TLE,
+            FULL_SHAPE=(num_experts_per_group == 32) & (n_group_pad == n_group),
             NUM_GROUPS_PAD=n_group_pad,
             num_warps=1,
         )
-
         return topk_values, topk_indices
 
     if scoring_func == 1:
-        from flaggems_vllm.ops.tanh import tanh as gems_tanh
-
-        scores_processed = 0.5 * gems_tanh(0.5 * scores) + 0.5
+        scores_processed = torch.sigmoid(scores.float()).to(scores.dtype)
     else:
         scores_processed = scores
 

--- a/src/flaggems_vllm/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_mthreads/ops/__init__.py
@@ -15,6 +15,7 @@
 from flaggems_vllm.runtime.backend._mthreads.ops.compress_norm_mrope import (
     qwen4_compress_norm_mrope_store_groups,
 )
+from flaggems_vllm.runtime.backend._mthreads.ops.grouped_topk import grouped_topk
 from flaggems_vllm.runtime.backend._mthreads.ops.hyperconnection import (
     qwen4_hc_inject_combine,
 )
@@ -31,6 +32,7 @@ from flaggems_vllm.runtime.backend._mthreads.ops.scaled_int8_quant import (
 
 __all__ = [
     "SUPPORTED_FP8_DTYPE",
+    "grouped_topk",
     "per_token_group_quant_fp8",
     "qwen4_store_qsa_kv_rows",
     "qwen4_hc_inject_combine",

--- a/src/flaggems_vllm/runtime/backend/_mthreads/ops/grouped_topk.py
+++ b/src/flaggems_vllm/runtime/backend/_mthreads/ops/grouped_topk.py
@@ -1,0 +1,1037 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flaggems_vllm.utils import tl_extra_shim
+from flaggems_vllm.utils.triton_version_utils import has_triton_tle
+
+
+def backend_tle_enabled():
+    from flaggems_vllm.runtime import backend, device
+
+    vendor_info = backend.get_vendor_info(device.vendor_name)
+    return vendor_info.tle_enabled
+
+
+if backend_tle_enabled() & has_triton_tle(3, 6, 0):
+    try:
+        import triton.experimental.tle.language as tle
+
+        HAS_TLE = True
+    except ImportError:
+        tle = None
+        HAS_TLE = False
+else:
+    tle = None
+    HAS_TLE = False
+
+
+logger = logging.getLogger(__name__)
+MULTI_ROW_THRESHOLD = 2048
+
+
+@triton.jit
+def topk_with_k2_triton(
+    scores_ptr,
+    bias_ptr,
+    group_scores_ptr,
+    num_experts_per_group,
+    n_group,
+    stride_scores_token,
+    stride_group_scores_token,
+    BLOCK_SIZE: tl.constexpr,
+    INPUT_DTYPE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    token_id = pid // n_group
+    group_id = pid % n_group
+
+    lane = tl.arange(0, BLOCK_SIZE)
+    mask = lane < num_experts_per_group
+
+    scores_offset = token_id * stride_scores_token + group_id * num_experts_per_group
+    bias_offset = group_id * num_experts_per_group
+
+    x = tl.load(
+        scores_ptr + scores_offset + lane,
+        mask=mask,
+        other=-float("inf"),
+    )
+
+    b = tl.load(
+        bias_ptr + bias_offset + lane,
+        mask=mask,
+        other=0.0,
+    ).to(INPUT_DTYPE)
+
+    x = x + b
+
+    x_f32 = x.to(tl.float32)
+
+    max1 = tl.max(x_f32, axis=0)
+    is_max1 = (x_f32 == max1) & mask
+    count_max1 = tl.sum(is_max1.to(tl.int32), axis=0)
+
+    x2 = tl.where(
+        is_max1 & (count_max1 == 1),
+        -float("inf"),
+        x_f32,
+    )
+    max2 = tl.max(x2, axis=0)
+
+    group_scores_offset = token_id * stride_group_scores_token + group_id
+    tl.store(
+        group_scores_ptr + group_scores_offset,
+        (max1 + max2).to(INPUT_DTYPE),
+    )
+
+
+@triton.jit
+def group_idx_and_topk_triton(
+    scores_ptr,
+    group_scores_ptr,
+    topk_values_ptr,
+    topk_indices_ptr,
+    bias_ptr,
+    num_tokens,
+    n_group,
+    topk_group,
+    topk,
+    num_experts,
+    num_experts_per_group,
+    routed_scaling_factor,
+    stride_scores_token,
+    stride_group_scores_token,
+    stride_out_token,
+    N_GROUP: tl.constexpr,
+    TOPK_GROUP: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK_GROUP: tl.constexpr,
+    BLOCK_EXPERT: tl.constexpr,
+    INPUT_DTYPE: tl.constexpr,
+    renormalize: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    if pid >= num_tokens:
+        return
+
+    neg_inf = -float("inf")
+
+    group_offsets = tl.arange(0, BLOCK_GROUP)
+    valid_group = group_offsets < n_group
+
+    group_scores = tl.load(
+        group_scores_ptr + pid * stride_group_scores_token + group_offsets,
+        mask=valid_group,
+        other=neg_inf,
+    )
+
+    group_scores_f32 = group_scores.to(tl.float32)
+    is_finite = (group_scores_f32 == group_scores_f32) & (
+        group_scores_f32 != float("inf")
+    )
+    group_scores_f32 = tl.where(is_finite & valid_group, group_scores_f32, neg_inf)
+
+    max_group_score = tl.max(group_scores_f32, axis=0)
+    if_proceed = max_group_score != neg_inf
+
+    value = group_scores_f32
+    target_num_min = BLOCK_GROUP - n_group + topk_group
+    count_equal_to_top_value = BLOCK_GROUP - n_group
+    pre_count_equal_to_top_value = 0
+    topk_group_value = neg_inf
+
+    for _ in range(TOPK_GROUP):
+        need = count_equal_to_top_value < target_num_min
+        max_val = tl.max(value, axis=0)
+
+        is_max = need & (value == max_val)
+        value = tl.where(is_max, neg_inf, value)
+
+        newly = tl.sum(is_max.to(tl.int32), axis=0)
+
+        pre_count_equal_to_top_value = tl.where(
+            need, count_equal_to_top_value, pre_count_equal_to_top_value
+        )
+        count_equal_to_top_value = tl.where(
+            need, count_equal_to_top_value + newly, count_equal_to_top_value
+        )
+        topk_group_value = tl.where(need, max_val, topk_group_value)
+
+    num_equalto_topkth_group = target_num_min - pre_count_equal_to_top_value
+
+    group_gt = group_scores_f32 > topk_group_value
+    group_eq = group_scores_f32 == topk_group_value
+
+    eq_i = group_eq.to(tl.int32)
+    prefix_eq = tl.cumsum(eq_i, axis=0) - eq_i
+
+    group_selected = (
+        group_gt | (group_eq & (prefix_eq < num_equalto_topkth_group))
+    ) & valid_group
+
+    expert_offsets = tl.arange(0, BLOCK_EXPERT)
+    valid_expert = expert_offsets < num_experts
+    expert_group = expert_offsets // num_experts_per_group
+
+    expert_in_group = expert_group[:, None] == group_offsets[None, :]
+    expert_selected = (
+        tl.sum((expert_in_group & group_selected[None, :]).to(tl.int32), axis=1) > 0
+    ) & valid_expert
+
+    scored = tl.load(
+        scores_ptr + pid * stride_scores_token + expert_offsets,
+        mask=expert_selected,
+        other=neg_inf,
+    )
+
+    expert_bias = tl.load(
+        bias_ptr + expert_offsets,
+        mask=valid_expert,
+        other=0.0,
+    ).to(INPUT_DTYPE)
+
+    selection_scores_native = scored + expert_bias
+
+    selection_scores = tl.where(
+        expert_selected,
+        selection_scores_native.to(tl.float32),
+        neg_inf,
+    )
+
+    topk_vals = tl.full([TOPK], 0.0, tl.float32)
+    topk_idx = tl.full([TOPK], 0, tl.int32)
+    pos_range = tl.arange(0, TOPK)
+
+    for i in range(TOPK):
+        max_val = tl.max(selection_scores, axis=0)
+        is_max = selection_scores == max_val
+
+        candidate_idx = tl.where(is_max, expert_offsets, num_experts + 1)
+        selected_idx = tl.min(candidate_idx, axis=0)
+
+        selected_score = tl.load(
+            scores_ptr + pid * stride_scores_token + selected_idx,
+            mask=selected_idx < num_experts,
+            other=neg_inf,
+        ).to(tl.float32)
+
+        topk_vals = tl.where(pos_range == i, selected_score, topk_vals)
+        topk_idx = tl.where(pos_range == i, selected_idx.to(tl.int32), topk_idx)
+
+        selection_scores = tl.where(
+            expert_offsets == selected_idx, neg_inf, selection_scores
+        )
+
+    if renormalize == 1:
+        topk_sum = tl.sum(topk_vals, axis=0) + 1e-20
+        scale = routed_scaling_factor / topk_sum
+    else:
+        scale = routed_scaling_factor
+
+    topk_vals = topk_vals * scale
+
+    default_idx = pos_range.to(tl.int32)
+    default_vals = tl.full([TOPK], 1.0 / topk, tl.float32)
+
+    final_vals = tl.where(if_proceed, topk_vals, default_vals)
+    final_idx = tl.where(if_proceed, topk_idx, default_idx)
+
+    tl.store(
+        topk_values_ptr + pid * stride_out_token + pos_range,
+        final_vals,
+        mask=pos_range < topk,
+    )
+
+    tl.store(
+        topk_indices_ptr + pid * stride_out_token + pos_range,
+        final_idx,
+        mask=pos_range < topk,
+    )
+
+
+@triton.jit
+def _sigmoid(x):
+    log2e: tl.constexpr = 1.4426950408889634
+    return 1 / (1 + tl_extra_shim.exp2(-x * log2e))
+
+
+@triton.jit
+def _pack_val_idx_fp32(val, idx):
+    MAX_IDX: tl.constexpr = 0xFFFF
+    bits = val.to(tl.uint32, bitcast=True)
+    key = tl.where((bits & 0x80000000) != 0, ~bits, bits | 0x80000000)
+    high = key.to(tl.uint64) << 32
+    low = (0xFFFF & (MAX_IDX - idx)).to(tl.uint64)
+    return high | low
+
+
+@triton.jit
+def _unpack_val_idx_fp32(pair):
+    MAX_IDX: tl.constexpr = 0xFFFF
+    key = (pair >> 32).to(tl.uint32)
+    idx = (MAX_IDX - (pair & 0xFFFF)).to(tl.uint32)
+    bits = tl.where((key & 0x80000000) != 0, key ^ 0x80000000, ~key)
+    val = bits.to(tl.float32, bitcast=True)
+    return val, idx
+
+
+# Common implementation from ../../../../ops/grouped_topk.py
+@triton.jit
+def triton_grouped_topk_fused_kernel(
+    scores_ptr,
+    topk_values_ptr,
+    topk_indices_ptr,
+    routing_bias_ptr,
+    num_tokens,
+    num_groups,
+    topk_group: tl.constexpr,
+    topk: tl.constexpr,
+    num_experts,
+    num_experts_per_group,
+    renormalize,
+    routed_scaling_factor,
+    scores_stride0,
+    g_score_sigmoid_ptr,
+    g_score_bias_ptr,
+    SCORING_FUNC: tl.constexpr,
+    HAS_TLE: tl.constexpr,
+    NUM_GROUPS_PAD: tl.constexpr,
+    FULL_SHAPE: tl.constexpr,
+):
+    WARP_SIZE: tl.constexpr = 32
+    NUM_WARPS: tl.constexpr = NUM_GROUPS_PAD
+    neg_inf: tl.constexpr = float("-inf")
+    MAX_IDX: tl.constexpr = 65535
+
+    token_id = tl.program_id(0)
+    scores_ptr += token_id * scores_stride0
+    topk_values_ptr += token_id * topk
+    topk_indices_ptr += token_id * topk
+    warps = tl.arange(0, NUM_WARPS)
+    lane = tl.arange(0, WARP_SIZE)
+
+    if HAS_TLE:
+        s_score_sigmoid = tle.gpu.alloc(
+            [NUM_WARPS, WARP_SIZE],
+            dtype=tl.float32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        s_score_bias = tle.gpu.alloc(
+            [NUM_WARPS, WARP_SIZE],
+            dtype=tl.float32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        s_score_sigmoid_ptr = tle.gpu.local_ptr(s_score_sigmoid, (0, 0))
+        s_score_bias_ptr = tle.gpu.local_ptr(s_score_bias, (0, 0))
+    else:
+        s_score_sigmoid_ptr = g_score_sigmoid_ptr + token_id * scores_stride0
+        s_score_bias_ptr = g_score_bias_ptr + token_id * scores_stride0
+
+    # step1: load score/bias, get score_sigmoid/score_bias
+    offs = warps[:, None] * num_experts_per_group + lane[None, :]
+    if FULL_SHAPE:
+        score = tl.load(scores_ptr + offs).to(tl.float32)
+    else:
+        score = tl.load(
+            scores_ptr + offs,
+            mask=(warps[:, None] < num_groups)
+            & (lane[None, :] < num_experts_per_group),
+            other=neg_inf,
+        ).to(tl.float32)
+    if SCORING_FUNC == 1:
+        score_sigmoid = _sigmoid(score)
+    else:
+        score_sigmoid = score
+    if FULL_SHAPE:
+        tl.store(s_score_sigmoid_ptr + offs, score_sigmoid)
+        bias_val = tl.load(routing_bias_ptr + offs).to(tl.float32)
+    else:
+        tl.store(
+            s_score_sigmoid_ptr + offs,
+            score_sigmoid,
+            mask=(warps[:, None] < num_groups)
+            & (lane[None, :] < num_experts_per_group),
+        )
+        bias_val = tl.load(
+            routing_bias_ptr + offs,
+            mask=(warps[:, None] < num_groups)
+            & (lane[None, :] < num_experts_per_group),
+            other=neg_inf,
+        ).to(tl.float32)
+    score_bias = score_sigmoid + bias_val
+    if FULL_SHAPE:
+        tl.store(s_score_bias_ptr + offs, score_bias)
+    else:
+        tl.store(
+            s_score_bias_ptr + offs,
+            score_bias,
+            mask=(warps[:, None] < num_groups)
+            & (lane[None, :] < num_experts_per_group),
+        )
+
+    # step2: get top2 as group_score
+    min_val0 = tl.full((NUM_WARPS, WARP_SIZE), neg_inf, dtype=tl.float32)
+    comp_val_idx0 = _pack_val_idx_fp32(score_bias, offs)
+    packed_max00 = tl.max(comp_val_idx0, axis=-1)
+    val_max0, _0 = _unpack_val_idx_fp32(packed_max00)
+    comp_val_idx0 = tl.where(
+        comp_val_idx0 == packed_max00[:, None],
+        _pack_val_idx_fp32(min_val0, offs),
+        comp_val_idx0,
+    )
+    packed_max01 = tl.max(comp_val_idx0, axis=-1)
+    val_max1, _0 = _unpack_val_idx_fp32(packed_max01)
+    group_score = val_max0 + val_max1
+
+    # step3: get topk_group, topk_group <= MAX_NUM_TOP_GROUPS, where MAX_NUM_TOP_GROUPS = 4
+    min_val1 = tl.full((NUM_WARPS,), neg_inf, dtype=tl.float32)
+    comp_val_idx1 = _pack_val_idx_fp32(group_score, warps)
+    packed_max10 = tl.max(comp_val_idx1)
+    _2, group_idx0 = _unpack_val_idx_fp32(packed_max10)
+    comp_val_idx1 = tl.where(
+        comp_val_idx1 == packed_max10,
+        _pack_val_idx_fp32(min_val1, warps),
+        comp_val_idx1,
+    )
+    packed_max11 = tl.max(comp_val_idx1)
+    _2, group_idx1 = _unpack_val_idx_fp32(packed_max11)
+    comp_val_idx1 = tl.where(
+        comp_val_idx1 == packed_max11,
+        _pack_val_idx_fp32(min_val1, warps),
+        comp_val_idx1,
+    )
+    packed_max12 = tl.max(comp_val_idx1)
+    _2, group_idx2 = _unpack_val_idx_fp32(packed_max12)
+    comp_val_idx1 = tl.where(
+        comp_val_idx1 == packed_max12,
+        _pack_val_idx_fp32(min_val1, warps),
+        comp_val_idx1,
+    )
+    packed_max13 = tl.max(comp_val_idx1)
+    _2, group_idx3 = _unpack_val_idx_fp32(packed_max13)
+
+    # step4: get topk, topk <= MAX_NUM_TOP_EXPERTS, where MAX_NUM_TOP_EXPERTS = 8
+    if FULL_SHAPE:
+        expert_idx_group0 = group_idx0 * WARP_SIZE + lane
+        expert_idx_group1 = group_idx1 * WARP_SIZE + lane
+        expert_idx_group2 = group_idx2 * WARP_SIZE + lane
+        expert_idx_group3 = group_idx3 * WARP_SIZE + lane
+        expert_score_group0 = tl.load(
+            s_score_bias_ptr + expert_idx_group0,
+            mask=0 < topk_group,
+            other=neg_inf,
+        )
+        expert_score_group1 = tl.load(
+            s_score_bias_ptr + expert_idx_group1,
+            mask=1 < topk_group,
+            other=neg_inf,
+        )
+        expert_score_group2 = tl.load(
+            s_score_bias_ptr + expert_idx_group2,
+            mask=2 < topk_group,
+            other=neg_inf,
+        )
+        expert_score_group3 = tl.load(
+            s_score_bias_ptr + expert_idx_group3,
+            mask=3 < topk_group,
+            other=neg_inf,
+        )
+    else:
+        expert_idx_group0 = group_idx0 * num_experts_per_group + lane
+        expert_idx_group1 = group_idx1 * num_experts_per_group + lane
+        expert_idx_group2 = group_idx2 * num_experts_per_group + lane
+        expert_idx_group3 = group_idx3 * num_experts_per_group + lane
+        expert_score_group0 = tl.load(
+            s_score_bias_ptr + expert_idx_group0,
+            mask=(0 < topk_group) & (lane < num_experts_per_group),
+            other=neg_inf,
+        )
+        expert_score_group1 = tl.load(
+            s_score_bias_ptr + expert_idx_group1,
+            mask=(1 < topk_group) & (lane < num_experts_per_group),
+            other=neg_inf,
+        )
+        expert_score_group2 = tl.load(
+            s_score_bias_ptr + expert_idx_group2,
+            mask=(2 < topk_group) & (lane < num_experts_per_group),
+            other=neg_inf,
+        )
+        expert_score_group3 = tl.load(
+            s_score_bias_ptr + expert_idx_group3,
+            mask=(3 < topk_group) & (lane < num_experts_per_group),
+            other=neg_inf,
+        )
+    comp_val_idx20 = _pack_val_idx_fp32(expert_score_group0, expert_idx_group0)
+    comp_val_idx21 = _pack_val_idx_fp32(expert_score_group1, expert_idx_group1)
+    comp_val_idx22 = _pack_val_idx_fp32(expert_score_group2, expert_idx_group2)
+    comp_val_idx23 = _pack_val_idx_fp32(expert_score_group3, expert_idx_group3)
+    # TOPK_SWAP(0, 2); TOPK_SWAP(1, 3); TOPK_SWAP(0, 1); TOPK_SWAP(2, 3); TOPK_SWAP(1, 2);
+    comp_val_idx20, comp_val_idx22 = max(comp_val_idx20, comp_val_idx22), min(
+        comp_val_idx20, comp_val_idx22
+    )
+    comp_val_idx21, comp_val_idx23 = max(comp_val_idx21, comp_val_idx23), min(
+        comp_val_idx21, comp_val_idx23
+    )
+    comp_val_idx20, comp_val_idx21 = max(comp_val_idx20, comp_val_idx21), min(
+        comp_val_idx20, comp_val_idx21
+    )
+    comp_val_idx22, comp_val_idx23 = max(comp_val_idx22, comp_val_idx23), min(
+        comp_val_idx22, comp_val_idx23
+    )
+    comp_val_idx21, comp_val_idx22 = max(comp_val_idx21, comp_val_idx22), min(
+        comp_val_idx21, comp_val_idx22
+    )
+
+    min_val2 = tl.full((WARP_SIZE,), neg_inf, dtype=tl.float32)
+    top_experts = tl.full((WARP_SIZE,), MAX_IDX, dtype=tl.uint32)
+    packed_max20 = tl.full((), 0, dtype=tl.uint64)
+    for kk in tl.static_range(0, topk):
+        update = (kk > 0) & (comp_val_idx20 == packed_max20)
+        comp_val_idx20 = tl.where(
+            update,
+            comp_val_idx21,
+            comp_val_idx20,
+        )
+        comp_val_idx21 = tl.where(
+            update,
+            comp_val_idx22,
+            comp_val_idx21,
+        )
+        comp_val_idx22 = tl.where(
+            update,
+            comp_val_idx23,
+            comp_val_idx22,
+        )
+        comp_val_idx23 = tl.where(
+            update,
+            _pack_val_idx_fp32(min_val2, expert_idx_group3),
+            comp_val_idx23,
+        )
+        packed_max20 = tl.max(comp_val_idx20)
+        _3, out_idx = _unpack_val_idx_fp32(packed_max20)
+        top_experts = tl.where(lane == kk, out_idx, top_experts)
+
+    # step5: renormalize and output
+    lane_unbiased = tl.load(
+        s_score_sigmoid_ptr + top_experts, mask=lane < topk, other=0.0
+    )
+    topk_sum = 1e-20
+    if renormalize:
+        topk_sum += tl.sum(lane_unbiased)
+    scale = routed_scaling_factor.to(tl.float32)
+    if renormalize:
+        scale /= topk_sum
+    tl.store(topk_values_ptr + lane, lane_unbiased * scale, mask=lane < topk)
+    tl.store(topk_indices_ptr + lane, top_experts, mask=lane < topk)
+
+
+# Multi-row version
+@triton.jit
+def triton_grouped_topk_fused_kernel_multi_row(
+    scores_ptr,
+    topk_values_ptr,
+    topk_indices_ptr,
+    routing_bias_ptr,
+    num_tokens,
+    num_groups,
+    topk_group: tl.constexpr,
+    topk: tl.constexpr,
+    num_experts,
+    num_experts_per_group,
+    renormalize,
+    routed_scaling_factor,
+    scores_stride0,
+    g_score_sigmoid_ptr,
+    g_score_bias_ptr,
+    SCORING_FUNC: tl.constexpr,
+    HAS_TLE: tl.constexpr,
+    NUM_GROUPS_PAD: tl.constexpr,
+    TOPK_PAD: tl.constexpr,
+    FULL_SHAPE: tl.constexpr,
+    ROW_PER_CTA: tl.constexpr,
+):
+    WARP_SIZE: tl.constexpr = 32
+    NUM_WARPS: tl.constexpr = NUM_GROUPS_PAD
+    neg_inf: tl.constexpr = float("-inf")
+    MAX_IDX: tl.constexpr = 65535
+
+    token_id = tl.program_id(0) * ROW_PER_CTA
+    row_len = min(ROW_PER_CTA, num_tokens - token_id)
+    scores_ptr += token_id * scores_stride0
+    topk_values_ptr += token_id * topk
+    topk_indices_ptr += token_id * topk
+    rows = tl.arange(0, ROW_PER_CTA)
+    warps = tl.arange(0, NUM_WARPS)
+    lane = tl.arange(0, WARP_SIZE)
+    topk_offs = tl.arange(0, TOPK_PAD)
+
+    if HAS_TLE:
+        s_score_sigmoid = tle.gpu.alloc(
+            [ROW_PER_CTA, NUM_WARPS, WARP_SIZE],
+            dtype=tl.float32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        s_score_bias = tle.gpu.alloc(
+            [ROW_PER_CTA, NUM_WARPS, WARP_SIZE],
+            dtype=tl.float32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        s_score_sigmoid_ptr = tle.gpu.local_ptr(s_score_sigmoid, (0, 0, 0))
+        s_score_bias_ptr = tle.gpu.local_ptr(s_score_bias, (0, 0, 0))
+    else:
+        s_score_sigmoid_ptr = g_score_sigmoid_ptr + token_id * scores_stride0
+        s_score_bias_ptr = g_score_bias_ptr + token_id * scores_stride0
+
+    # step1: load score/bias, get score_sigmoid/score_bias
+    offs = (
+        rows[:, None, None] * scores_stride0
+        + warps[None, :, None] * num_experts_per_group
+        + lane[None, None, :]
+    )
+    bias_offs = warps[:, None] * num_experts_per_group + lane[None, :]
+    if FULL_SHAPE:
+        score = tl.load(
+            scores_ptr + offs, mask=rows[:, None, None] < row_len, other=neg_inf
+        ).to(tl.float32)
+    else:
+        score = tl.load(
+            scores_ptr + offs,
+            mask=(rows[:, None, None] < row_len)
+            & (warps[None, :, None] < num_groups)
+            & (lane[None, None, :] < num_experts_per_group),
+            other=neg_inf,
+        ).to(tl.float32)
+    if SCORING_FUNC == 1:
+        score_sigmoid = _sigmoid(score)
+    else:
+        score_sigmoid = score
+    if FULL_SHAPE:
+        tl.store(
+            s_score_sigmoid_ptr + offs,
+            score_sigmoid,
+            mask=rows[:, None, None] < row_len,
+        )
+        bias_val = tl.load(routing_bias_ptr + bias_offs).to(tl.float32)
+    else:
+        tl.store(
+            s_score_sigmoid_ptr + offs,
+            score_sigmoid,
+            mask=(rows[:, None, None] < row_len)
+            & (warps[None, :, None] < num_groups)
+            & (lane[None, None, :] < num_experts_per_group),
+        )
+        bias_val = tl.load(
+            routing_bias_ptr + bias_offs,
+            mask=(warps[:, None] < num_groups)
+            & (lane[None, :] < num_experts_per_group),
+            other=neg_inf,
+        ).to(tl.float32)
+    score_bias = score_sigmoid + bias_val[None, :, :]
+    if FULL_SHAPE:
+        tl.store(
+            s_score_bias_ptr + offs, score_bias, mask=rows[:, None, None] < row_len
+        )
+    else:
+        tl.store(
+            s_score_bias_ptr + offs,
+            score_bias,
+            mask=(rows[:, None, None] < row_len)
+            & (warps[None, :, None] < num_groups)
+            & (lane[None, None, :] < num_experts_per_group),
+        )
+
+    # step2: get top2 as group_score
+    min_val0 = tl.full((ROW_PER_CTA, NUM_WARPS, WARP_SIZE), neg_inf, dtype=tl.float32)
+    comp_val_idx0 = _pack_val_idx_fp32(score_bias, offs)
+    packed_max00 = tl.max(comp_val_idx0, axis=-1)
+    val_max0, _0 = _unpack_val_idx_fp32(packed_max00)
+    comp_val_idx0 = tl.where(
+        comp_val_idx0 == packed_max00[:, :, None],
+        _pack_val_idx_fp32(min_val0, offs),
+        comp_val_idx0,
+    )
+    packed_max01 = tl.max(comp_val_idx0, axis=-1)
+    val_max1, _0 = _unpack_val_idx_fp32(packed_max01)
+    group_score = val_max0 + val_max1  # [ROW_PER_CTA, NUM_WARPS]
+
+    # step3: get topk_group, topk_group <= MAX_NUM_TOP_GROUPS, where MAX_NUM_TOP_GROUPS = 4
+    min_val1 = tl.full((ROW_PER_CTA, NUM_WARPS), neg_inf, dtype=tl.float32)
+    comp_val_idx1 = _pack_val_idx_fp32(group_score, warps)
+    packed_max10 = tl.max(comp_val_idx1, axis=-1)  # [ROW_PER_CTA]
+    _2, group_idx0 = _unpack_val_idx_fp32(packed_max10)
+    comp_val_idx1 = tl.where(
+        comp_val_idx1 == packed_max10[:, None],
+        _pack_val_idx_fp32(min_val1, warps),
+        comp_val_idx1,
+    )
+    packed_max11 = tl.max(comp_val_idx1, axis=-1)
+    _2, group_idx1 = _unpack_val_idx_fp32(packed_max11)
+    comp_val_idx1 = tl.where(
+        comp_val_idx1 == packed_max11[:, None],
+        _pack_val_idx_fp32(min_val1, warps),
+        comp_val_idx1,
+    )
+    packed_max12 = tl.max(comp_val_idx1, axis=-1)
+    _2, group_idx2 = _unpack_val_idx_fp32(packed_max12)
+    comp_val_idx1 = tl.where(
+        comp_val_idx1 == packed_max12[:, None],
+        _pack_val_idx_fp32(min_val1, warps),
+        comp_val_idx1,
+    )
+    packed_max13 = tl.max(comp_val_idx1, axis=-1)
+    _2, group_idx3 = _unpack_val_idx_fp32(packed_max13)
+
+    # step4: get topk, topk <= MAX_NUM_TOP_EXPERTS, where MAX_NUM_TOP_EXPERTS = 8
+    if FULL_SHAPE:
+        expert_idx_group0 = group_idx0[:, None] * WARP_SIZE + lane[None, :]
+        expert_idx_group1 = group_idx1[:, None] * WARP_SIZE + lane[None, :]
+        expert_idx_group2 = group_idx2[:, None] * WARP_SIZE + lane[None, :]
+        expert_idx_group3 = group_idx3[:, None] * WARP_SIZE + lane[None, :]
+        expert_score_group0 = tl.load(
+            s_score_bias_ptr + expert_idx_group0 + rows[:, None] * scores_stride0,
+            mask=(0 < topk_group) & (rows[:, None] < row_len),
+            other=neg_inf,
+        )
+        expert_score_group1 = tl.load(
+            s_score_bias_ptr + expert_idx_group1 + rows[:, None] * scores_stride0,
+            mask=(1 < topk_group) & (rows[:, None] < row_len),
+            other=neg_inf,
+        )
+        expert_score_group2 = tl.load(
+            s_score_bias_ptr + expert_idx_group2 + rows[:, None] * scores_stride0,
+            mask=(2 < topk_group) & (rows[:, None] < row_len),
+            other=neg_inf,
+        )
+        expert_score_group3 = tl.load(
+            s_score_bias_ptr + expert_idx_group3 + rows[:, None] * scores_stride0,
+            mask=(3 < topk_group) & (rows[:, None] < row_len),
+            other=neg_inf,
+        )
+    else:
+        expert_idx_group0 = group_idx0[:, None] * num_experts_per_group + lane[None, :]
+        expert_idx_group1 = group_idx1[:, None] * num_experts_per_group + lane[None, :]
+        expert_idx_group2 = group_idx2[:, None] * num_experts_per_group + lane[None, :]
+        expert_idx_group3 = group_idx3[:, None] * num_experts_per_group + lane[None, :]
+        group_mask = (rows[:, None] < row_len) & (lane[None, :] < num_experts_per_group)
+        expert_score_group0 = tl.load(
+            s_score_bias_ptr + expert_idx_group0 + rows[:, None] * scores_stride0,
+            mask=(0 < topk_group) & group_mask,
+            other=neg_inf,
+        )
+        expert_score_group1 = tl.load(
+            s_score_bias_ptr + expert_idx_group1 + rows[:, None] * scores_stride0,
+            mask=(1 < topk_group) & group_mask,
+            other=neg_inf,
+        )
+        expert_score_group2 = tl.load(
+            s_score_bias_ptr + expert_idx_group2 + rows[:, None] * scores_stride0,
+            mask=(2 < topk_group) & group_mask,
+            other=neg_inf,
+        )
+        expert_score_group3 = tl.load(
+            s_score_bias_ptr + expert_idx_group3 + rows[:, None] * scores_stride0,
+            mask=(3 < topk_group) & group_mask,
+            other=neg_inf,
+        )
+    comp_val_idx20 = _pack_val_idx_fp32(expert_score_group0, expert_idx_group0)
+    comp_val_idx21 = _pack_val_idx_fp32(expert_score_group1, expert_idx_group1)
+    comp_val_idx22 = _pack_val_idx_fp32(expert_score_group2, expert_idx_group2)
+    comp_val_idx23 = _pack_val_idx_fp32(expert_score_group3, expert_idx_group3)
+
+    # TOPK_SWAP(0, 2); TOPK_SWAP(1, 3); TOPK_SWAP(0, 1); TOPK_SWAP(2, 3); TOPK_SWAP(1, 2);
+    comp_val_idx20, comp_val_idx22 = max(comp_val_idx20, comp_val_idx22), min(
+        comp_val_idx20, comp_val_idx22
+    )
+    comp_val_idx21, comp_val_idx23 = max(comp_val_idx21, comp_val_idx23), min(
+        comp_val_idx21, comp_val_idx23
+    )
+    comp_val_idx20, comp_val_idx21 = max(comp_val_idx20, comp_val_idx21), min(
+        comp_val_idx20, comp_val_idx21
+    )
+    comp_val_idx22, comp_val_idx23 = max(comp_val_idx22, comp_val_idx23), min(
+        comp_val_idx22, comp_val_idx23
+    )
+    comp_val_idx21, comp_val_idx22 = max(comp_val_idx21, comp_val_idx22), min(
+        comp_val_idx21, comp_val_idx22
+    )
+    expert_score_group00, _ = _unpack_val_idx_fp32(comp_val_idx20)
+    expert_score_group11, _ = _unpack_val_idx_fp32(comp_val_idx21)
+    expert_score_group22, _ = _unpack_val_idx_fp32(comp_val_idx22)
+    expert_score_group33, _ = _unpack_val_idx_fp32(comp_val_idx23)
+
+    min_val2 = tl.full((ROW_PER_CTA, WARP_SIZE), neg_inf, dtype=tl.float32)
+    top_experts = tl.full((ROW_PER_CTA, TOPK_PAD), MAX_IDX, dtype=tl.uint32)
+    packed_max20 = tl.full((ROW_PER_CTA,), 0, dtype=tl.uint64)
+    for kk in tl.static_range(0, topk):
+        update = (kk > 0) & (comp_val_idx20 == packed_max20[:, None])
+        comp_val_idx20 = tl.where(
+            update,
+            comp_val_idx21,
+            comp_val_idx20,
+        )
+        comp_val_idx21 = tl.where(
+            update,
+            comp_val_idx22,
+            comp_val_idx21,
+        )
+        comp_val_idx22 = tl.where(
+            update,
+            comp_val_idx23,
+            comp_val_idx22,
+        )
+        comp_val_idx23 = tl.where(
+            update,
+            _pack_val_idx_fp32(min_val2, expert_idx_group3),
+            comp_val_idx23,
+        )
+        packed_max20 = tl.max(comp_val_idx20, axis=-1)
+        _3, out_idx = _unpack_val_idx_fp32(packed_max20)
+        top_experts = tl.where(topk_offs[None, :] == kk, out_idx[:, None], top_experts)
+
+    # step5: renormalize and output
+    lane_unbiased = tl.load(
+        s_score_sigmoid_ptr + rows[:, None] * scores_stride0 + top_experts,
+        mask=(rows[:, None] < row_len) & (topk_offs[None, :] < topk),
+        other=0.0,
+    )
+    topk_sum = tl.full([ROW_PER_CTA], 1e-20, dtype=tl.float32)
+    if renormalize:
+        topk_sum += tl.sum(lane_unbiased, axis=-1)
+    scale = tl.full(
+        [ROW_PER_CTA], routed_scaling_factor.to(tl.float32), dtype=tl.float32
+    )
+    if renormalize:
+        scale /= topk_sum
+    out_offs = rows[:, None] * topk + topk_offs[None, :]
+    out_mask = (rows[:, None] < row_len) & (topk_offs[None, :] < topk)
+    tl.store(topk_values_ptr + out_offs, lane_unbiased * scale[:, None], mask=out_mask)
+    tl.store(topk_indices_ptr + out_offs, top_experts, mask=out_mask)
+
+
+def grouped_topk(
+    scores: torch.Tensor,
+    n_group: int,
+    topk_group: int,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    bias: torch.Tensor,
+    scoring_func: int = 0,
+):
+    logger.debug("GEMS GROUPED TOPK")
+    if scores.ndim != 2:
+        raise ValueError("scores must be a 2D Tensor")
+    num_tokens, num_experts = scores.shape
+    if num_experts % n_group != 0:
+        raise ValueError("num_experts must be divisible by n_group")
+    if n_group > 32:
+        raise ValueError("n_group should be smaller than or equal to 32")
+    if topk > 32:
+        raise ValueError("topk should be smaller than or equal to 32 for now")
+    if scoring_func not in (0, 1):
+        raise ValueError("scoring_func must be 0 (none) or 1 (sigmoid)")
+
+    if bias.ndim != 1:
+        bias = bias.flatten()
+    if len(bias) != num_experts:
+        raise ValueError(
+            f"bias length ({len(bias)}) must match num_experts ({num_experts})"
+        )
+
+    num_experts_per_group = num_experts // n_group
+
+    if scores.dtype == torch.float32:
+        INPUT_DTYPE = tl.float32
+    elif scores.dtype == torch.float16:
+        INPUT_DTYPE = tl.float16
+    elif scores.dtype == torch.bfloat16:
+        INPUT_DTYPE = tl.bfloat16
+    else:
+        raise ValueError(f"Unsupported dtype: {scores.dtype}")
+
+    if (
+        (n_group > 1)
+        & (n_group <= 32)
+        & (num_experts <= 256)
+        & (num_experts_per_group <= 32)
+        & (num_experts_per_group * topk_group <= 128)
+        & (topk <= 8)
+        & (topk_group <= 4)
+    ):
+        # DeepSeek-v3.2
+        topk_values = torch.empty(
+            (num_tokens, topk),
+            device=scores.device,
+            dtype=torch.float32,
+        )
+        topk_indices = torch.empty(
+            (num_tokens, topk),
+            device=scores.device,
+            dtype=torch.int32,
+        )
+        if not HAS_TLE:
+            g_scores_sigmoid = torch.empty(
+                (num_tokens, num_experts),
+                device=scores.device,
+                dtype=torch.float32,
+            )
+            g_scores_bias = torch.empty(
+                (num_tokens, num_experts),
+                device=scores.device,
+                dtype=torch.float32,
+            )
+        else:
+            g_scores_sigmoid = None
+            g_scores_bias = None
+
+        n_group_pad = triton.next_power_of_2(n_group)
+        topk_pad = triton.next_power_of_2(topk)
+        if num_tokens >= MULTI_ROW_THRESHOLD:
+            ROW_PER_CTA = 8
+            grid = (num_tokens + ROW_PER_CTA - 1) // ROW_PER_CTA
+            triton_grouped_topk_fused_kernel_multi_row[(grid,)](
+                scores,
+                topk_values,
+                topk_indices,
+                bias,
+                num_tokens,
+                n_group,
+                topk_group,
+                topk,
+                num_experts,
+                num_experts_per_group,
+                renormalize,
+                routed_scaling_factor,
+                scores.stride(0),
+                g_scores_sigmoid,
+                g_scores_bias,
+                SCORING_FUNC=scoring_func,
+                HAS_TLE=HAS_TLE,
+                NUM_GROUPS_PAD=n_group_pad,
+                TOPK_PAD=topk_pad,
+                FULL_SHAPE=num_experts_per_group == 32 and n_group == n_group_pad,
+                ROW_PER_CTA=ROW_PER_CTA,
+                num_warps=ROW_PER_CTA,
+            )
+        else:
+            triton_grouped_topk_fused_kernel[(num_tokens,)](
+                scores,
+                topk_values,
+                topk_indices,
+                bias,
+                num_tokens,
+                n_group,
+                topk_group,
+                topk,
+                num_experts,
+                num_experts_per_group,
+                renormalize,
+                routed_scaling_factor,
+                scores.stride(0),
+                g_scores_sigmoid,
+                g_scores_bias,
+                SCORING_FUNC=scoring_func,
+                HAS_TLE=HAS_TLE,
+                NUM_GROUPS_PAD=n_group_pad,
+                FULL_SHAPE=num_experts_per_group == 32 and n_group == n_group_pad,
+                num_warps=1,
+            )
+
+        return topk_values, topk_indices
+
+    if scoring_func == 1:
+        from flaggems_vllm.ops.tanh import tanh as gems_tanh
+
+        scores_processed = 0.5 * gems_tanh(0.5 * scores) + 0.5
+    else:
+        scores_processed = scores
+
+    group_scores = torch.empty(
+        (num_tokens, n_group),
+        device=scores.device,
+        dtype=scores.dtype,
+    )
+
+    topk_values = torch.empty(
+        (num_tokens, topk),
+        device=scores.device,
+        dtype=torch.float32,
+    )
+
+    topk_indices = torch.empty(
+        (num_tokens, topk),
+        device=scores.device,
+        dtype=torch.int32,
+    )
+
+    BLOCK1 = triton.next_power_of_2(num_experts_per_group)
+    grid1 = (num_tokens * n_group,)
+
+    topk_with_k2_triton[grid1](
+        scores_processed,
+        bias,
+        group_scores,
+        num_experts_per_group,
+        n_group,
+        scores_processed.stride(0),
+        group_scores.stride(0),
+        BLOCK_SIZE=BLOCK1,
+        INPUT_DTYPE=INPUT_DTYPE,
+    )
+
+    BLOCK_GROUP = triton.next_power_of_2(n_group)
+    BLOCK_EXPERT = triton.next_power_of_2(num_experts)
+    grid2 = (num_tokens,)
+
+    group_idx_and_topk_triton[grid2](
+        scores_processed,
+        group_scores,
+        topk_values,
+        topk_indices,
+        bias,
+        num_tokens,
+        n_group,
+        topk_group,
+        topk,
+        num_experts,
+        num_experts_per_group,
+        routed_scaling_factor,
+        scores_processed.stride(0),
+        group_scores.stride(0),
+        topk_values.stride(0),
+        N_GROUP=n_group,
+        TOPK_GROUP=topk_group,
+        TOPK=topk,
+        BLOCK_GROUP=BLOCK_GROUP,
+        BLOCK_EXPERT=BLOCK_EXPERT,
+        INPUT_DTYPE=INPUT_DTYPE,
+        renormalize=int(renormalize),
+    )
+
+    return topk_values, topk_indices

--- a/tests/test_grouped_topk.py
+++ b/tests/test_grouped_topk.py
@@ -152,13 +152,61 @@ def torch_grouped_topk(
     return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
 
 
-try:
-    import vllm._custom_ops as ops  # noqa: F401
-
-    if hasattr(torch.ops._moe_C, "grouped_topk"):
-        ref_grouped_topk = torch.ops._moe_C.grouped_topk
+def aiter_biased_grouped_topk(
+    scores: torch.Tensor,
+    num_expert_group: int,
+    topk_group: int,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    bias: torch.Tensor,
+    scoring_func: int = 0,
+):
+    if renormalize and scoring_func == 1:
+        num_tokens = scores.size(0)
+        topk_weights = torch.empty(
+            (num_tokens, topk), dtype=torch.float32, device=scores.device
+        )
+        topk_ids = torch.empty(
+            (num_tokens, topk), dtype=torch.int32, device=scores.device
+        )
+        moe_fused_gate(
+            scores.float(),
+            bias.float(),
+            topk_weights,
+            topk_ids,
+            num_expert_group,
+            topk_group,
+            topk=topk,
+            num_fused_shared_experts=0,
+            routed_scaling_factor=routed_scaling_factor,
+        )
+        return topk_weights, topk_ids
     else:
-        ref_grouped_topk = torch_grouped_topk
+        return torch_grouped_topk(
+            scores,
+            num_expert_group,
+            topk_group,
+            topk,
+            renormalize,
+            routed_scaling_factor,
+            bias,
+            scoring_func,
+        )
+
+
+try:
+    if vendor_name == "hygon":
+        from aiter import moe_fused_gate  # noqa: F401
+
+        ref_grouped_topk = aiter_biased_grouped_topk
+    else:
+        import vllm._custom_ops  # noqa: F401
+
+        if hasattr(torch.ops._moe_C, "grouped_topk"):
+            ref_grouped_topk = torch.ops._moe_C.grouped_topk
+        else:
+            ref_grouped_topk = torch_grouped_topk
 except (ImportError, AttributeError):
     ref_grouped_topk = torch_grouped_topk
 

--- a/tests/test_grouped_topk.py
+++ b/tests/test_grouped_topk.py
@@ -26,6 +26,7 @@ from . import conftest as cfg
 random.seed(time.time() // 100)
 
 device = flaggems_vllm.device
+vendor_name = flaggems_vllm.vendor_name
 
 if cfg.QUICK_MODE:
     N_TOKEN_LIST = [8]
@@ -48,25 +49,33 @@ else:
     DTYPE_LIST = [torch.float32]
 
 
-vendor_name = flaggems_vllm.vendor_name
-
-try:
-    if vendor_name == "metax":
-        from vllm_metax._custom_ops import grouped_topk as vllm_grouped_topk
-    else:
-        from vllm._custom_ops import grouped_topk as vllm_grouped_topk
-
-    HAS_VLLM = True
-except (ImportError, AttributeError):
-    HAS_VLLM = False
-    vllm_grouped_topk = None
-
-
-@torch.compile(
-    dynamic=True,
-    backend="inductor",
-    options={"graph_partition": False},
+MAX_IDX = 0xFFFF
+SIGN_MASK_INT32 = torch.tensor(0x80000000, dtype=torch.uint32, device=device).view(
+    torch.int32
 )
+SIGN_MASK_INT64 = torch.tensor(0x80000000, dtype=torch.int64, device=device)
+
+
+def _pack_val_idx_fp32(val: torch.Tensor, idx: torch.Tensor):
+    bits = val.view(torch.int32)
+    sign = bits & SIGN_MASK_INT32
+    key = torch.where(sign != 0, ~bits, bits).to(torch.int64)
+    key = torch.where(sign != 0, key, key | SIGN_MASK_INT64)
+    high = key << 16
+    low = (0xFFFF & (MAX_IDX - idx)).to(torch.int64)
+    return high | low
+
+
+def _unpack_val_idx_fp32(pair: torch.Tensor):
+    key = pair >> 16
+    sign = key & SIGN_MASK_INT64
+    bits = torch.where(sign != 0, key ^ SIGN_MASK_INT64, key).to(torch.int32)
+    bits = torch.where(sign != 0, bits, ~bits)
+    val = bits.view(torch.float32)
+    idx = (MAX_IDX - (pair & 0xFFFF)).to(torch.int64)
+    return val, idx
+
+
 def torch_grouped_topk(
     scores: torch.Tensor,
     num_expert_group: int,
@@ -77,7 +86,10 @@ def torch_grouped_topk(
     bias: torch.Tensor,
     scoring_func: int = 0,
 ):
-    """Adapted from vLLM: vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py"""
+    """
+    Adapted from vLLM: vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
+    Wrap torch.topk with packing and unpacking logic to fix stability issues.
+    """
     scores = scores.float()
     if scoring_func == 1:
         scores = scores.sigmoid()
@@ -90,9 +102,23 @@ def torch_grouped_topk(
     )
 
     use_sorted = True
-    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=use_sorted)[
-        1
-    ]  # [n, top_k_group]
+    tmp_group_ids = torch.arange(
+        0, num_expert_group, dtype=torch.int32, device=scores.device
+    )
+    tmp_group_ids = tmp_group_ids[None, :].expand(num_token, -1)
+    group_pairs = _pack_val_idx_fp32(group_scores, tmp_group_ids)
+    if vendor_name == "mthreads":
+        # muDNN(v3105): ERROR# INVALID_PARAMETER in TopK::Run, Reason: Unsupported in data type: INT64
+        top_group_pairs = torch.topk(
+            group_pairs.cpu(), k=topk_group, dim=-1, sorted=use_sorted
+        )[0].to(scores.device)
+    else:
+        top_group_pairs = torch.topk(
+            group_pairs, k=topk_group, dim=-1, sorted=use_sorted
+        )[0]
+    _top_group_scores, group_idx = _unpack_val_idx_fp32(
+        top_group_pairs
+    )  # [n, top_k_group]
     group_mask = torch.zeros_like(group_scores)  # [n, n_group]
     group_mask.scatter_(1, group_idx, 1)  # [n, n_group]
     score_mask = (
@@ -102,14 +128,21 @@ def torch_grouped_topk(
     )  # [n, e]
     tmp_scores = scores.masked_fill(~score_mask.bool(), float("-inf"))  # [n, e]
 
+    tmp_ids = torch.arange(0, scores.size(1), dtype=torch.int32, device=scores.device)
+    tmp_ids = tmp_ids[None, :].expand(num_token, -1)
+    pairs = _pack_val_idx_fp32(tmp_scores, tmp_ids)
+    if vendor_name == "mthreads":
+        # muDNN(v3105): ERROR# INVALID_PARAMETER in TopK::Run, Reason: Unsupported in data type: INT64
+        top_pairs = torch.topk(pairs.cpu(), k=topk, dim=-1, sorted=use_sorted)[0].to(
+            scores.device
+        )
+    else:
+        top_pairs = torch.topk(pairs, k=topk, dim=-1, sorted=use_sorted)[0]
     if bias is not None:
-        topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=use_sorted)[1]
-        # Use original unbiased scores for the routing weights
+        _, topk_ids = _unpack_val_idx_fp32(top_pairs)
         topk_weights = original_scores.gather(1, topk_ids)
     else:
-        topk_weights, topk_ids = torch.topk(
-            tmp_scores, k=topk, dim=-1, sorted=use_sorted
-        )
+        topk_weights, topk_ids = _unpack_val_idx_fp32(top_pairs)
 
     if renormalize:
         topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
@@ -117,6 +150,17 @@ def torch_grouped_topk(
     if routed_scaling_factor != 1.0:
         topk_weights = topk_weights * routed_scaling_factor
     return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+
+
+try:
+    import vllm._custom_ops as ops  # noqa: F401
+
+    if hasattr(torch.ops._moe_C, "grouped_topk"):
+        ref_grouped_topk = torch.ops._moe_C.grouped_topk
+    else:
+        ref_grouped_topk = torch_grouped_topk
+except (ImportError, AttributeError):
+    ref_grouped_topk = torch_grouped_topk
 
 
 def get_tolerance(dtype, scoring_func, renormalize):
@@ -135,7 +179,6 @@ def get_tolerance(dtype, scoring_func, renormalize):
 
 
 @pytest.mark.grouped_topk
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
 @pytest.mark.parametrize("n_token", N_TOKEN_LIST_DEEPSEEK_V3_2)
 @pytest.mark.parametrize("renormalize", RENORMALIZE_LIST)
 @pytest.mark.parametrize("scoring_func", SCORING_FUNC_LIST)
@@ -147,7 +190,6 @@ def test_grouped_topk_deepseek_v3_2(
     """Test grouped_topk accuracy with configs from DeepSeek-v3.2"""
     torch.manual_seed(42)
     torch.cuda.manual_seed(42)
-    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
 
     n_expert = 256
     n_group = 8
@@ -195,7 +237,6 @@ def test_grouped_topk_deepseek_v3_2(
 
 
 @pytest.mark.grouped_topk
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
 @pytest.mark.parametrize("n_token", N_TOKEN_LIST)
 @pytest.mark.parametrize("n_expert", N_EXPERT_LIST)
 @pytest.mark.parametrize("n_group", N_GROUP_LIST)
@@ -219,7 +260,6 @@ def test_grouped_topk(
 
     torch.manual_seed(45)
     torch.cuda.manual_seed(45)
-    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
 
     topk_group = topk
     routed_scaling_factor = 1.0
@@ -260,7 +300,6 @@ def test_grouped_topk(
 
 
 @pytest.mark.grouped_topk
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
 @pytest.mark.parametrize("n_token", [32, 64])
 @pytest.mark.parametrize("n_expert", [64])
 @pytest.mark.parametrize("n_group", [8])
@@ -282,7 +321,6 @@ def test_grouped_topk_large_scale(
     """Test grouped_topk with larger scale configurations"""
     torch.manual_seed(0)
     torch.cuda.manual_seed(0)
-    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
 
     routed_scaling_factor = 1.0
 
@@ -322,7 +360,6 @@ def test_grouped_topk_large_scale(
 
 
 @pytest.mark.grouped_topk
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
 @pytest.mark.parametrize("routed_scaling_factor", [1.0, 2.5])
 @pytest.mark.parametrize("renormalize", [True, False])
 def test_grouped_topk_scaling_factor(routed_scaling_factor, renormalize):
@@ -330,7 +367,6 @@ def test_grouped_topk_scaling_factor(routed_scaling_factor, renormalize):
 
     torch.manual_seed(45)
     torch.cuda.manual_seed(45)
-    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
 
     dtype = torch.float32
     scores = torch.randn((8, 16), dtype=dtype, device=flaggems_vllm.device)
@@ -362,7 +398,6 @@ def test_grouped_topk_scaling_factor(routed_scaling_factor, renormalize):
 
 
 @pytest.mark.grouped_topk
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
 @pytest.mark.parametrize("renormalize", [True, False])
 @pytest.mark.parametrize("scoring_func", [0, 1])
 def test_grouped_topk_single_token(renormalize, scoring_func):
@@ -370,7 +405,6 @@ def test_grouped_topk_single_token(renormalize, scoring_func):
 
     torch.manual_seed(45)
     torch.cuda.manual_seed(45)
-    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
 
     dtype = torch.float32
     scores = torch.randn((1, 16), dtype=dtype, device=flaggems_vllm.device)
@@ -395,13 +429,11 @@ def test_grouped_topk_single_token(renormalize, scoring_func):
 
 
 @pytest.mark.grouped_topk
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
 @pytest.mark.parametrize("renormalize", [True, False])
 def test_grouped_topk_sigmoid(renormalize):
     """Test grouped_topk with sigmoid scoring function"""
     torch.manual_seed(45)
     torch.cuda.manual_seed(45)
-    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
 
     dtype = torch.float32
     scores = torch.randn((8, 16), dtype=dtype, device=flaggems_vllm.device)

--- a/tests/test_grouped_topk.py
+++ b/tests/test_grouped_topk.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import random
 import time
 
@@ -195,11 +196,71 @@ def aiter_biased_grouped_topk(
         )
 
 
+def is_power_of_two(n):
+    return n > 0 and math.log2(n).is_integer()
+
+
+def mthreads_grouped_topk(
+    scores: torch.Tensor,
+    num_expert_group: int,
+    topk_group: int,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    bias: torch.Tensor,
+    scoring_func: int = 0,
+):
+    """
+    Adapted from vllm-musa: vllm_musa/model_executor/layers/fused_moe/router/grouped_topk_router.py
+    """
+    if (
+        scoring_func == 1
+        and scores.shape[1] % 32 == 0
+        and (
+            scores.shape[1] // num_expert_group <= 32
+            or (num_expert_group == 1 and scores.shape[1] in {160, 256, 384})
+        )
+        and (bias is not None and is_power_of_two(bias.shape[0]))
+    ):
+        # Conditions added relative to vllm-musa:
+        # 1. moe_fused_gate in mate always perform a sigmoid operation
+        # 2. moe_fused_gate in mate requires (num_expert % WARP_SIZE) == 0
+        num_fused_shared_experts = 0
+        apply_routed_scaling_factor_on_output = routed_scaling_factor != 1.0
+        topk_weights, topk_ids = moe_fused_gate(
+            scores.float(),
+            bias.float(),
+            num_expert_group,
+            topk_group,
+            topk,
+            num_fused_shared_experts,
+            routed_scaling_factor if routed_scaling_factor is not None else 1.0,
+            renormalize,
+            apply_routed_scaling_factor_on_output,
+        )
+        return topk_weights, topk_ids
+    else:
+        return torch_grouped_topk(
+            scores,
+            num_expert_group,
+            topk_group,
+            topk,
+            renormalize,
+            routed_scaling_factor,
+            bias,
+            scoring_func,
+        )
+
+
 try:
     if vendor_name == "hygon":
         from aiter import moe_fused_gate  # noqa: F401
 
         ref_grouped_topk = aiter_biased_grouped_topk
+    elif vendor_name == "mthreads":
+        from mate import moe_fused_gate  # noqa: F401
+
+        ref_grouped_topk = mthreads_grouped_topk
     else:
         import vllm._custom_ops  # noqa: F401
 

--- a/tests/test_grouped_topk.py
+++ b/tests/test_grouped_topk.py
@@ -29,6 +29,7 @@ device = flaggems_vllm.device
 
 if cfg.QUICK_MODE:
     N_TOKEN_LIST = [8]
+    N_TOKEN_LIST_DEEPSEEK_V3_2 = [16384]
     N_EXPERT_LIST = [16]
     N_GROUP_LIST = [4]
     TOPK_LIST = [2]
@@ -37,6 +38,7 @@ if cfg.QUICK_MODE:
     DTYPE_LIST = [torch.float32]
 else:
     N_TOKEN_LIST = [1, 3, 8]
+    N_TOKEN_LIST_DEEPSEEK_V3_2 = [1, 8, 32, 64, 128, 256, 496, 512, 16384]
     N_EXPERT_LIST = [16]
     N_EXPERT_LIST = [8, 16]
     N_GROUP_LIST = [2, 4]
@@ -45,13 +47,76 @@ else:
     SCORING_FUNC_LIST = [0, 1]
     DTYPE_LIST = [torch.float32]
 
+
+vendor_name = flaggems_vllm.vendor_name
+
 try:
-    from vllm._custom_ops import grouped_topk as vllm_grouped_topk
+    if vendor_name == "metax":
+        from vllm_metax._custom_ops import grouped_topk as vllm_grouped_topk
+    else:
+        from vllm._custom_ops import grouped_topk as vllm_grouped_topk
 
     HAS_VLLM = True
-except ImportError:
+except (ImportError, AttributeError):
     HAS_VLLM = False
     vllm_grouped_topk = None
+
+
+@torch.compile(
+    dynamic=True,
+    backend="inductor",
+    options={"graph_partition": False},
+)
+def torch_grouped_topk(
+    scores: torch.Tensor,
+    num_expert_group: int,
+    topk_group: int,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    bias: torch.Tensor,
+    scoring_func: int = 0,
+):
+    """Adapted from vLLM: vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py"""
+    scores = scores.float()
+    if scoring_func == 1:
+        scores = scores.sigmoid()
+
+    num_token = scores.size(0)
+    original_scores = scores
+    scores = scores + bias.unsqueeze(0)
+    group_scores = (
+        scores.view(num_token, num_expert_group, -1).topk(2, dim=-1)[0].sum(dim=-1)
+    )
+
+    use_sorted = True
+    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=use_sorted)[
+        1
+    ]  # [n, top_k_group]
+    group_mask = torch.zeros_like(group_scores)  # [n, n_group]
+    group_mask.scatter_(1, group_idx, 1)  # [n, n_group]
+    score_mask = (
+        group_mask.unsqueeze(-1)
+        .expand(num_token, num_expert_group, scores.size(-1) // num_expert_group)
+        .reshape(num_token, -1)
+    )  # [n, e]
+    tmp_scores = scores.masked_fill(~score_mask.bool(), float("-inf"))  # [n, e]
+
+    if bias is not None:
+        topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=use_sorted)[1]
+        # Use original unbiased scores for the routing weights
+        topk_weights = original_scores.gather(1, topk_ids)
+    else:
+        topk_weights, topk_ids = torch.topk(
+            tmp_scores, k=topk, dim=-1, sorted=use_sorted
+        )
+
+    if renormalize:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+
+    if routed_scaling_factor != 1.0:
+        topk_weights = topk_weights * routed_scaling_factor
+    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
 
 
 def get_tolerance(dtype, scoring_func, renormalize):
@@ -71,7 +136,66 @@ def get_tolerance(dtype, scoring_func, renormalize):
 
 @pytest.mark.grouped_topk
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-@pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
+@pytest.mark.parametrize("n_token", N_TOKEN_LIST_DEEPSEEK_V3_2)
+@pytest.mark.parametrize("renormalize", RENORMALIZE_LIST)
+@pytest.mark.parametrize("scoring_func", SCORING_FUNC_LIST)
+def test_grouped_topk_deepseek_v3_2(
+    n_token,
+    renormalize,
+    scoring_func,
+):
+    """Test grouped_topk accuracy with configs from DeepSeek-v3.2"""
+    torch.manual_seed(42)
+    torch.cuda.manual_seed(42)
+    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
+
+    n_expert = 256
+    n_group = 8
+    topk = 8
+    topk_group = 4
+    routed_scaling_factor = 1.0
+    scores_dtype = torch.bfloat16
+    bias_dtype = torch.float32
+
+    scores = torch.randn(
+        (n_token, n_expert), dtype=scores_dtype, device=flaggems_vllm.device
+    )
+    bias = torch.randn((n_expert,), dtype=bias_dtype, device=flaggems_vllm.device)
+
+    ref_topk_weights, ref_topk_ids = ref_grouped_topk(
+        scores.clone(),
+        n_group,
+        topk_group,
+        topk,
+        renormalize,
+        routed_scaling_factor,
+        bias,
+        scoring_func,
+    )
+    ref_topk_weights = utils.to_reference(ref_topk_weights)
+    ref_topk_ids = utils.to_reference(ref_topk_ids)
+
+    with flaggems_vllm.use_gems():
+        res_topk_weights, res_topk_ids = flaggems_vllm.grouped_topk(
+            scores.clone(),
+            n_group,
+            topk_group,
+            topk,
+            renormalize,
+            routed_scaling_factor,
+            bias,
+            scoring_func,
+        )
+
+    utils.gems_assert_equal(res_topk_ids, ref_topk_ids)
+
+    atol, rtol = get_tolerance(ref_topk_weights.dtype, scoring_func, renormalize)
+    res_topk_weights = utils.to_reference(res_topk_weights)
+    torch.testing.assert_close(res_topk_weights, ref_topk_weights, atol=atol, rtol=rtol)
+
+
+@pytest.mark.grouped_topk
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
 @pytest.mark.parametrize("n_token", N_TOKEN_LIST)
 @pytest.mark.parametrize("n_expert", N_EXPERT_LIST)
 @pytest.mark.parametrize("n_group", N_GROUP_LIST)
@@ -95,6 +219,7 @@ def test_grouped_topk(
 
     torch.manual_seed(45)
     torch.cuda.manual_seed(45)
+    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
 
     topk_group = topk
     routed_scaling_factor = 1.0
@@ -102,7 +227,7 @@ def test_grouped_topk(
     scores = torch.randn((n_token, n_expert), dtype=dtype, device=flaggems_vllm.device)
     bias = torch.randn((n_expert,), dtype=dtype, device=flaggems_vllm.device)
 
-    ref_topk_weights, ref_topk_ids = vllm_grouped_topk(
+    ref_topk_weights, ref_topk_ids = ref_grouped_topk(
         scores.clone(),
         n_group,
         topk_group,
@@ -136,7 +261,6 @@ def test_grouped_topk(
 
 @pytest.mark.grouped_topk
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-@pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
 @pytest.mark.parametrize("n_token", [32, 64])
 @pytest.mark.parametrize("n_expert", [64])
 @pytest.mark.parametrize("n_group", [8])
@@ -158,13 +282,14 @@ def test_grouped_topk_large_scale(
     """Test grouped_topk with larger scale configurations"""
     torch.manual_seed(0)
     torch.cuda.manual_seed(0)
+    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
 
     routed_scaling_factor = 1.0
 
     scores = torch.randn((n_token, n_expert), dtype=dtype, device=flaggems_vllm.device)
     bias = torch.randn((n_expert,), dtype=dtype, device=flaggems_vllm.device)
 
-    ref_topk_weights, ref_topk_ids = vllm_grouped_topk(
+    ref_topk_weights, ref_topk_ids = ref_grouped_topk(
         scores.clone(),
         n_group,
         topk_group,
@@ -198,7 +323,6 @@ def test_grouped_topk_large_scale(
 
 @pytest.mark.grouped_topk
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-@pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
 @pytest.mark.parametrize("routed_scaling_factor", [1.0, 2.5])
 @pytest.mark.parametrize("renormalize", [True, False])
 def test_grouped_topk_scaling_factor(routed_scaling_factor, renormalize):
@@ -206,12 +330,13 @@ def test_grouped_topk_scaling_factor(routed_scaling_factor, renormalize):
 
     torch.manual_seed(45)
     torch.cuda.manual_seed(45)
+    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
 
     dtype = torch.float32
     scores = torch.randn((8, 16), dtype=dtype, device=flaggems_vllm.device)
     bias = torch.randn((16,), dtype=dtype, device=flaggems_vllm.device)
 
-    ref_weights, ref_ids = vllm_grouped_topk(
+    ref_weights, ref_ids = ref_grouped_topk(
         scores.clone(), 4, 2, 2, renormalize, routed_scaling_factor, bias, 0
     )
     ref_weights = utils.to_reference(ref_weights)
@@ -238,7 +363,6 @@ def test_grouped_topk_scaling_factor(routed_scaling_factor, renormalize):
 
 @pytest.mark.grouped_topk
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-@pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
 @pytest.mark.parametrize("renormalize", [True, False])
 @pytest.mark.parametrize("scoring_func", [0, 1])
 def test_grouped_topk_single_token(renormalize, scoring_func):
@@ -246,12 +370,13 @@ def test_grouped_topk_single_token(renormalize, scoring_func):
 
     torch.manual_seed(45)
     torch.cuda.manual_seed(45)
+    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
 
     dtype = torch.float32
     scores = torch.randn((1, 16), dtype=dtype, device=flaggems_vllm.device)
     bias = torch.randn((16,), dtype=dtype, device=flaggems_vllm.device)
 
-    ref_weights, ref_ids = vllm_grouped_topk(
+    ref_weights, ref_ids = ref_grouped_topk(
         scores.clone(), 4, 2, 2, renormalize, 1.0, bias, scoring_func
     )
     ref_weights = utils.to_reference(ref_weights)
@@ -271,18 +396,18 @@ def test_grouped_topk_single_token(renormalize, scoring_func):
 
 @pytest.mark.grouped_topk
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-@pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
 @pytest.mark.parametrize("renormalize", [True, False])
 def test_grouped_topk_sigmoid(renormalize):
     """Test grouped_topk with sigmoid scoring function"""
     torch.manual_seed(45)
     torch.cuda.manual_seed(45)
+    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
 
     dtype = torch.float32
     scores = torch.randn((8, 16), dtype=dtype, device=flaggems_vllm.device)
     bias = torch.randn((16,), dtype=dtype, device=flaggems_vllm.device)
 
-    ref_weights, ref_ids = vllm_grouped_topk(
+    ref_weights, ref_ids = ref_grouped_topk(
         scores.clone(), 4, 2, 2, renormalize, 1.0, bias, 1
     )
     ref_weights = utils.to_reference(ref_weights)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Performance Optimization

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

- port kernel "grouped_topk_fused_small_expert_count_kernel" from vLLM
- replace benchmark test shapes with top-hit shapes from DeepSeek-v3.2
- add correctness test for top-hit shapes from DeepSeek-v3.2
- port torch implementation from vLLM as vllm-uninstalled fallback in correctness test
- enable tests for the metax backend
- implement grouped_topk for ASCEND backend based on common implementation, remove INT64 usage
- add torch reference implementation for benchmarking (mthreads, hygon, ascend)
- mitigate torch.topk non-stability in correctness tests


also pick following PR in FlagGems for benchmark test:
- Change test count to time (https://github.com/flagos-ai/FlagGems/pull/4338)
- Add cudagraph benchmark mode (https://github.com/flagos-ai/FlagGems/pull/4321)
- [Ascend] Update benchmark do_bench to do_bench_npu on ascend (https://github.com/flagos-ai/FlagGems/pull/4857)
- [Ascend] Fix input param of do_bench_npu (https://github.com/flagos-ai/FlagGems/pull/5451)

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
common config from DeepSeek-v3.2: 

| num_experts | n_group | topk_group | topk | scores_dtype | bias_dtype |
| --- | --- | --- | --- | --- | --- | 
| 256 | 8 | 4 | 8 | bfloat16 | float32 |

- backend nvidia

device: NVIDIA H800
vLLM version: 0.23.0
flagtree version: 0.6.0
test command: `pytest benchmark/test_grouped_topk.py -s --mode=cudagraph`
speedup vs C in vLLM (min: 1.012, max: 1.974, avg: 1.331):
| num_tokens | renormalize=False, scoring_func=0 |  renormalize=True, scoring_func=0 | renormalize=True, scoring_func=1 |
| --- | --- | --- | --- |
| 1 | 1.012 | 1.325 | 1.320 |
| 8 | 1.071 | 1.323 | 1.322 |
| 32 | 1.082 | 1.327 | 1.326 |
| 64 | 1.080 | 1.315 | 1.313 |
| 128 | 1.083 | 1.322 | 1.321 |
| 256 | 1.099 | 1.330 | 1.334 |
| 496 | 1.145 | 1.372 | 1.396 |
| 512 | 1.156 | 1.375 | 1.400 |
| 16384 | 1.890 | 1.974 | 1.926 |

- backend metax

device: MetaX C550
vLLM version: 0.21.0
vLLM-metax version: 0.21.0
flagtree version: 0.6.1a2+metax3.6
test command: `pytest benchmark/test_grouped_topk.py -s --mode=cudagraph`
speedup vs C in vLLM-metax (min: 1.432, max: 5.077, avg: 2.059):
| num_tokens | renormalize=False, scoring_func=0 |  renormalize=True, scoring_func=0 | renormalize=True, scoring_func=1 |
| --- | --- | --- | --- |
| 1 | 1.490 | 1.496 | 1.446 |
| 8 | 1.479 | 1.492 | 1.452 |
| 32 | 1.473 | 1.485 | 1.432 |
| 64 | 1.481 | 1.487 | 1.437 |
| 128 | 1.552 | 1.594 | 1.579 |
| 256 | 1.755 | 1.844 | 1.805 |
| 496 | 2.136 | 2.265 | 2.216 |
| 512 | 2.122 | 2.281 | 2.210 |
| 16384 | 4.565 | 4.948 | 5.077 |

- backend thead

device: PPU-ZW810E
vLLM-version: 0.19.0+cu130
flagtree version: 0.6.1+ppu3.6
test command: `pytest benchmark/test_grouped_topk.py -s --mode=cudagraph`
speedup vs C in vLLM (min: 1.842, max: 5.965, avg: 2.872):
| num_tokens | renormalize=False, scoring_func=0 |  renormalize=True, scoring_func=0 | renormalize=True, scoring_func=1 |
| --- | --- | --- | --- |
| 1 | 1.937 | 2.359 | 2.109 |
| 8 | 1.864 | 2.188 | 2.078 |
| 32 | 1.893 | 2.211 | 1.982 |
| 64 | 1.842 | 2.104 | 1.982 |
| 128 | 2.157 | 2.553 | 2.247 |
| 256 | 2.187 | 2.385 | 2.213 |
| 496 | 3.541 | 3.885 | 3.781 |
| 512 | 3.661 | 3.895 | 3.891 |
| 16384 | 5.387 | 5.965 | 5.266 |

- backend mthreads

device: MTT S5000
flagtree version: 0.6.2a2+mthreads3.6
test command: `pytest benchmark/test_grouped_topk.py -s`  (mode=cudagraph throws "Failed: Tried to instantiate dummy base class Stream")
speedup vs C (min: 1.149, max: 3.262, avg: 1.546):
| num_tokens | renormalize=True, scoring_func=1 |
| --- | --- |
| 1 | 3.262 |
| 8 | 1.223 |
| 32 | 1.638 |
| 64 | 1.446 |
| 128 | 1.479 |
| 256 | 1.273 |
| 496 | 1.220 |
| 512 | 1.229 |
| 16384 | 1.149 |

- backend hygon

device: bw1000
flagtree version: 0.6.1a1+hcu3.6
aiter version: 0.1.3+das.opt1.dtk2604.torch2100.2606172003.g0a655d
test command: `pytest benchmark/test_grouped_topk.py -s --mode=cudagraph`
speedup vs C (min: 1.142, max: 7.166, avg: 5.069):
| num_tokens | renormalize=True, scoring_func=1 |
| --- | --- |
| 1 | 7.166 |
| 8 | 6.757 |
| 32 | 6.768 |
| 64 | 6.662 |
| 128 | 6.690 |
| 256 | 4.630 |
| 496 | 2.911 |
| 512 | 2.900 |
| 16384 | 1.142 |

- backend ascend

device: Ascend910_9382 (910c)
flagtree version: 0.6.0+ascend.gitca1dd135
test command: `pytest benchmark/test_grouped_topk.py -s`  (mode=cudagraph not supported)
speedup vs torch (min: 0.506, max: 9.821, avg: 4.646):
| num_tokens | renormalize=False, scoring_func=0 |  renormalize=True, scoring_func=0 | renormalize=True, scoring_func=1 |
| --- | --- | --- | --- |
| 1 | 5.030 | 5.346 | 5.515 |
| 8 | 6.136 | 6.752 | 6.611 |
| 32 | 8.305 | 9.240 | 9.821 |
| 64 | 5.730 | 5.763 | 7.375 |
| 128 | 5.156 | 5.520 | 6.108 |
| 256 | 3.484 | 3.762 | 3.997 |
| 496 | 2.230 | 2.421 | 2.531 |
| 512 | 2.231 | 2.392 | 2.483 |
| 16384 | 0.506 | 0.511 | 0.510 |

