### PR TITLE
Rename fused_marlin_moe kernels by precision scheme and split benchmarks

### DIFF
--- a/benchmark/test_fused_marlin_moe_w4a16_int4.py
+++ b/benchmark/test_fused_marlin_moe_w4a16_int4.py
@@ -94,10 +94,7 @@ def _marlin_quantize_per_expert(w_fp):
     for e in range(E):
         # marlin_quantize expects (in_dim, out_dim)
         _, qw, sc, _, _, _ = marlin_quantize(
-            w_fp[e].T.contiguous(),
-            VLLM_QUANT_TYPE,
-            GROUP_SIZE,
-            act_order=False,
+            w_fp[e].T.contiguous(), VLLM_QUANT_TYPE, GROUP_SIZE, act_order=False
         )
         qweight_l.append(qw)
         scales_l.append(sc)
@@ -106,9 +103,9 @@ def _marlin_quantize_per_expert(w_fp):
     return qweight, scales
 
 
-class FusedMarlinMoEBenchmark(base.Benchmark):
+class FusedMarlinMoEW4A16INT4Benchmark(base.Benchmark):
     """
-    Benchmark for fused_marlin_moe (W4A16 INT4 fused-dequant MoE GEMM).
+    Benchmark for fused_marlin_moe W4A16 INT4 (fused-dequant MoE GEMM).
 
     Compares FlagGems' Triton wna16 kernel against vLLM's Marlin CUDA kernel.
     Both consume per-group-128 GPTQ uint4b8 weights (different packed layouts).
@@ -118,15 +115,45 @@ class FusedMarlinMoEBenchmark(base.Benchmark):
         super().__init__(op_name=op_name, torch_op=torch_op, dtypes=dtypes)
 
     def set_shapes(self, shape_file_path=None):
+        # The three production MoE architectures from profile_fused_marlin_moe.py
+        # over the decode token range (1 .. 256).
         self.shapes = [
-            # Mixtral-8x7B-like
+            # Mixtral-8x7B
             (1, 8, 4096, 14336, 2),
+            (4, 8, 4096, 14336, 2),
+            (8, 8, 4096, 14336, 2),
             (16, 8, 4096, 14336, 2),
+            (32, 8, 4096, 14336, 2),
             (64, 8, 4096, 14336, 2),
-            # DeepSeek-V3-like (TP=8 shard)
+            (128, 8, 4096, 14336, 2),
+            (256, 8, 4096, 14336, 2),
+            # DeepSeek-V3 (TP=8 shard)
             (1, 256, 7168, 2048, 8),
+            (4, 256, 7168, 2048, 8),
+            (8, 256, 7168, 2048, 8),
             (16, 256, 7168, 2048, 8),
+            (32, 256, 7168, 2048, 8),
             (64, 256, 7168, 2048, 8),
+            (128, 256, 7168, 2048, 8),
+            (256, 256, 7168, 2048, 8),
+            # Qwen3-5-397B-A17B
+            (1, 512, 4096, 1024, 10),
+            (4, 512, 4096, 1024, 10),
+            (8, 512, 4096, 1024, 10),
+            (16, 512, 4096, 1024, 10),
+            (32, 512, 4096, 1024, 10),
+            (64, 512, 4096, 1024, 10),
+            (128, 512, 4096, 1024, 10),
+            (256, 512, 4096, 1024, 10),
+            # DeepSeek-V4-Flash
+            (1, 256, 4096, 2048, 6),
+            (4, 256, 4096, 2048, 6),
+            (8, 256, 4096, 2048, 6),
+            (16, 256, 4096, 2048, 6),
+            (32, 256, 4096, 2048, 6),
+            (64, 256, 4096, 2048, 6),
+            (128, 256, 4096, 2048, 6),
+            (256, 256, 4096, 2048, 6),
         ]
 
     def get_input_iter(self, cur_dtype):
@@ -254,17 +281,16 @@ def _gems_call(
 
 @pytest.mark.fused_marlin_moe
 @pytest.mark.skipif(
-    not HAS_VLLM_FUSED_MARLIN_MOE,
-    reason="vllm not installed; baseline unavailable",
+    not HAS_VLLM_FUSED_MARLIN_MOE, reason="vllm not installed; baseline unavailable"
 )
 @pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires NVIDIA Hopper architecture")
-def test_fused_marlin_moe():
+def test_fused_marlin_moe_w4a16_int4():
     """
     Benchmark FlagGems fused_marlin_moe (Triton wna16) vs vLLM fused_marlin_moe
     (CUDA Marlin). Both run GPTQ uint4b8 + per-group-128 W4A16 GEMM.
     """
-    bench = FusedMarlinMoEBenchmark(
-        op_name="fused_marlin_moe",
+    bench = FusedMarlinMoEW4A16INT4Benchmark(
+        op_name="fused_marlin_moe_w4a16_int4",
         torch_op=_vllm_baseline,
         dtypes=[torch.bfloat16],
     )

--- a/benchmark/test_fused_marlin_moe_w4a16_mxfp4.py
+++ b/benchmark/test_fused_marlin_moe_w4a16_mxfp4.py
@@ -1,0 +1,282 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+# vLLM imports (baseline). Optional: when vllm is not installed (e.g. in CI),
+# the entire benchmark is skipped via the skipif marker below.
+try:
+    import vllm._custom_ops as vllm_ops
+    from vllm.model_executor.layers.fused_moe.fused_marlin_moe import (
+        fused_marlin_moe as vllm_fused_marlin_moe,
+    )
+    from vllm.model_executor.layers.quantization.utils.marlin_utils import (
+        marlin_permute_scales,
+    )
+    from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
+        mxfp4_marlin_process_scales,
+    )
+    from vllm.scalar_type import scalar_types
+
+    VLLM_QUANT_TYPE_FP4 = scalar_types.float4_e2m1f
+    HAS_VLLM_FUSED_MARLIN_MOE = True
+except ImportError:
+    HAS_VLLM_FUSED_MARLIN_MOE = False
+
+import flaggems_vllm
+
+# FlagGems wrapper under test
+from flaggems_vllm.ops.fused_marlin_moe import QUANT_TYPE_FP4_E2M1
+from flaggems_vllm.ops.fused_marlin_moe import fused_marlin_moe as gems_fused_marlin_moe
+
+from . import base
+
+
+def is_cuda_available():
+    if flaggems_vllm.device != "cuda":
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    sm_version_num = major * 10 + minor
+    return sm_version_num >= 90 and sm_version_num < 100
+
+
+CUDA_AVAILABLE = is_cuda_available()
+
+# =============================================================================
+# MXFP4 (FP4 E2M1 + per-32 E8M0) benchmark: FlagGems Triton vs vLLM Marlin.
+# Both consume the same FP4 weights + E8M0 scale in their respective layouts.
+# =============================================================================
+MXFP4_GROUP_SIZE = 32
+_E2M1_POS = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]
+_E2M1_MID = [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0]
+_E2M1_MAX = 6.0
+
+
+def _quantize_mxfp4_2d(w_2d, group_size):
+    """Round-to-nearest MXFP4. Returns nibbles (uint8 [0,15]) + E8M0 scale."""
+    out_dim, in_dim = w_2d.shape
+    ng = in_dim // group_size
+    device = w_2d.device
+    wg = w_2d.reshape(out_dim, ng, group_size).to(torch.float32)
+    amax = wg.abs().amax(dim=-1, keepdim=True)
+    exp = torch.ceil(torch.log2((amax / _E2M1_MAX).clamp(min=1e-30))).clamp(-127, 127)
+    scale = torch.exp2(exp)
+    e8m0_byte = (exp + 127.0).to(torch.uint8)
+    wn = wg / scale
+    sign = wn < 0
+    a = wn.abs().clamp(max=_E2M1_MAX)
+    mag = torch.bucketize(a, torch.tensor(_E2M1_MID, device=device))
+    nibbles = (sign.to(torch.uint8) * 8 + mag.to(torch.uint8)).reshape(out_dim, in_dim)
+    scale_e8m0 = e8m0_byte.squeeze(-1).view(torch.float8_e8m0fnu)
+    return nibbles, scale_e8m0
+
+
+def _mxfp4_quantize_per_expert(w_fp):
+    """FlagGems MXFP4 layout: packed uint8 (E, out, in//2) + E8M0 scale."""
+    E, out_dim, in_dim = w_fp.shape
+    w_q = torch.empty(E, out_dim, in_dim // 2, device=w_fp.device, dtype=torch.uint8)
+    scales = torch.empty(
+        E,
+        out_dim,
+        in_dim // MXFP4_GROUP_SIZE,
+        device=w_fp.device,
+        dtype=torch.float8_e8m0fnu,
+    )
+    for e in range(E):
+        nib, sc = _quantize_mxfp4_2d(w_fp[e], MXFP4_GROUP_SIZE)
+        w_q[e] = nib[:, 1::2] * 16 + nib[:, ::2]
+        scales[e] = sc
+    return w_q, scales
+
+
+def _marlin_mxfp4_quantize_per_expert(w_fp, dtype):
+    """vLLM Marlin MXFP4 layout from the same nibbles/scale (numerically aligned)."""
+    E, out_dim, in_dim = w_fp.shape
+    qweight_l, scales_l = [], []
+    for e in range(E):
+        nib, sc = _quantize_mxfp4_2d(w_fp[e], MXFP4_GROUP_SIZE)
+        packed = (nib[:, 1::2] * 16 + nib[:, ::2]).to(torch.uint8)
+        perm = torch.empty(0, dtype=torch.int, device=w_fp.device)
+        qw = vllm_ops.gptq_marlin_repack(
+            packed.view(torch.int32).T.contiguous(), perm, in_dim, out_dim, 4, False
+        )
+        ms = marlin_permute_scales(
+            sc.T.to(dtype), in_dim, out_dim, MXFP4_GROUP_SIZE, False
+        )
+        ms = mxfp4_marlin_process_scales(ms, input_dtype=None).to(torch.float8_e8m0fnu)
+        qweight_l.append(qw)
+        scales_l.append(ms)
+    return torch.stack(qweight_l, 0).contiguous(), torch.stack(scales_l, 0).contiguous()
+
+
+class FusedMarlinMoEW4A16MXFP4Benchmark(base.Benchmark):
+    """MXFP4 (FP4 E2M1 + E8M0) MoE: FlagGems Triton vs vLLM Marlin."""
+
+    def __init__(self, op_name, torch_op, dtypes):
+        super().__init__(op_name=op_name, torch_op=torch_op, dtypes=dtypes)
+
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = [
+            # Mixtral-8x7B
+            (1, 8, 4096, 14336, 2),
+            (16, 8, 4096, 14336, 2),
+            (64, 8, 4096, 14336, 2),
+            (256, 8, 4096, 14336, 2),
+            # DeepSeek-V3 (TP=8 shard)
+            (1, 256, 7168, 2048, 8),
+            (16, 256, 7168, 2048, 8),
+            (64, 256, 7168, 2048, 8),
+            (256, 256, 7168, 2048, 8),
+            # Qwen3-5-397B-A17B
+            (1, 512, 4096, 1024, 10),
+            (16, 512, 4096, 1024, 10),
+            (64, 512, 4096, 1024, 10),
+            (256, 512, 4096, 1024, 10),
+            # DeepSeek-V4-Flash
+            (1, 256, 4096, 2048, 6),
+            (16, 256, 4096, 2048, 6),
+            (64, 256, 4096, 2048, 6),
+            (256, 256, 4096, 2048, 6),
+        ]
+
+    def get_input_iter(self, cur_dtype):
+        for config in self.shapes:
+            yield from self._gen(config, cur_dtype)
+
+    def _gen(self, config, dtype):
+        num_tokens, num_experts, hidden_size, intermediate_size, topk = config
+        device = flaggems_vllm.device
+
+        hidden_states = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype)
+        w1_fp = (
+            torch.randn(
+                num_experts,
+                intermediate_size * 2,
+                hidden_size,
+                device=device,
+                dtype=dtype,
+            )
+            / 10.0
+        )
+        w2_fp = (
+            torch.randn(
+                num_experts, hidden_size, intermediate_size, device=device, dtype=dtype
+            )
+            / 10.0
+        )
+
+        w1_q_fg, w1_scale_fg = _mxfp4_quantize_per_expert(w1_fp)
+        w2_q_fg, w2_scale_fg = _mxfp4_quantize_per_expert(w2_fp)
+        w1_q_marlin, w1_scale_marlin = _marlin_mxfp4_quantize_per_expert(w1_fp, dtype)
+        w2_q_marlin, w2_scale_marlin = _marlin_mxfp4_quantize_per_expert(w2_fp, dtype)
+
+        del w1_fp, w2_fp
+        torch.cuda.empty_cache()
+
+        gating = torch.randn(
+            num_tokens, num_experts, device=device, dtype=torch.float32
+        )
+        topk_weights, topk_ids = torch.topk(torch.softmax(gating, dim=-1), topk, dim=-1)
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+
+        yield (
+            hidden_states,
+            w1_q_fg,
+            w2_q_fg,
+            w1_scale_fg,
+            w2_scale_fg,
+            w1_q_marlin,
+            w2_q_marlin,
+            w1_scale_marlin,
+            w2_scale_marlin,
+            topk_weights,
+            topk_ids,
+        )
+
+
+def _vllm_baseline_mxfp4(
+    hidden_states,
+    w1_q_fg,
+    w2_q_fg,
+    w1_scale_fg,
+    w2_scale_fg,
+    w1_q_marlin,
+    w2_q_marlin,
+    w1_scale_marlin,
+    w2_scale_marlin,
+    topk_weights,
+    topk_ids,
+):
+    """Baseline: vLLM's CUDA Marlin fused_marlin_moe (MXFP4)."""
+    return vllm_fused_marlin_moe(
+        hidden_states=hidden_states,
+        w1=w1_q_marlin,
+        w2=w2_q_marlin,
+        bias1=None,
+        bias2=None,
+        w1_scale=w1_scale_marlin,
+        w2_scale=w2_scale_marlin,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        quant_type_id=VLLM_QUANT_TYPE_FP4.id,
+    )
+
+
+def _gems_call_mxfp4(
+    hidden_states,
+    w1_q_fg,
+    w2_q_fg,
+    w1_scale_fg,
+    w2_scale_fg,
+    w1_q_marlin,
+    w2_q_marlin,
+    w1_scale_marlin,
+    w2_scale_marlin,
+    topk_weights,
+    topk_ids,
+):
+    """FlagGems' Triton MXFP4 fused_marlin_moe."""
+    return gems_fused_marlin_moe(
+        hidden_states=hidden_states,
+        w1=w1_q_fg,
+        w2=w2_q_fg,
+        bias1=None,
+        bias2=None,
+        w1_scale=w1_scale_fg,
+        w2_scale=w2_scale_fg,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        quant_type_id=QUANT_TYPE_FP4_E2M1,
+        group_size=MXFP4_GROUP_SIZE,
+    )
+
+
+@pytest.mark.fused_marlin_moe
+@pytest.mark.skipif(
+    not HAS_VLLM_FUSED_MARLIN_MOE, reason="vllm not installed; baseline unavailable"
+)
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires NVIDIA Hopper architecture")
+def test_fused_marlin_moe_w4a16_mxfp4():
+    """
+    Benchmark FlagGems MXFP4 fused_marlin_moe (Triton) vs vLLM MXFP4
+    fused_marlin_moe (CUDA Marlin). Both run FP4 E2M1 + per-32 E8M0 W4A16 GEMM.
+    """
+    bench = FusedMarlinMoEW4A16MXFP4Benchmark(
+        op_name="fused_marlin_moe_w4a16_mxfp4",
+        torch_op=_vllm_baseline_mxfp4,
+        dtypes=[torch.bfloat16],
+    )
+    bench.set_gems(_gems_call_mxfp4)
+    bench.run()

--- a/benchmark/test_fused_marlin_moe_w8a16_int8.py
+++ b/benchmark/test_fused_marlin_moe_w8a16_int8.py
@@ -1,0 +1,256 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+# vLLM imports (baseline). Optional: when vllm is not installed (e.g. in CI),
+# the entire benchmark is skipped via the skipif marker below.
+try:
+    from vllm.model_executor.layers.fused_moe.fused_marlin_moe import (
+        fused_marlin_moe as vllm_fused_marlin_moe,
+    )
+    from vllm.model_executor.layers.quantization.utils.marlin_utils_test import (
+        marlin_quantize,
+    )
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        quantize_weights,
+    )
+    from vllm.scalar_type import scalar_types
+
+    VLLM_QUANT_TYPE_INT8 = scalar_types.uint8b128
+    HAS_VLLM_FUSED_MARLIN_MOE = True
+except ImportError:
+    HAS_VLLM_FUSED_MARLIN_MOE = False
+
+import flaggems_vllm
+
+# FlagGems wrapper under test
+from flaggems_vllm.ops.fused_marlin_moe import QUANT_TYPE_UINT8B128
+from flaggems_vllm.ops.fused_marlin_moe import fused_marlin_moe as gems_fused_marlin_moe
+
+from . import base
+
+
+def is_cuda_available():
+    if flaggems_vllm.device != "cuda":
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    sm_version_num = major * 10 + minor
+    return sm_version_num >= 90 and sm_version_num < 100
+
+
+CUDA_AVAILABLE = is_cuda_available()
+
+GROUP_SIZE = 128
+
+
+def _wna16_quantize_per_expert_int8(w_fp):
+    """
+    Per-expert GPTQ-style INT8 quantization for FlagGems wna16 kernel layout.
+    INT8 is one byte per element — no nibble packing — so K-dim stays in_dim.
+
+    Input  w_fp: (E, out_dim, in_dim), bf16/fp16
+    Output w_q:   (E, out_dim, in_dim), uint8
+           scales: (E, out_dim, in_dim // GROUP_SIZE), same dtype as w_fp
+    """
+    E, out_dim, in_dim = w_fp.shape
+    assert in_dim % GROUP_SIZE == 0
+    w_q = torch.empty(E, out_dim, in_dim, device=w_fp.device, dtype=torch.uint8)
+    scales = torch.empty(
+        E, out_dim, in_dim // GROUP_SIZE, device=w_fp.device, dtype=w_fp.dtype
+    )
+    for e in range(E):
+        _, q_e, sc_e, _ = quantize_weights(
+            w_fp[e].T, VLLM_QUANT_TYPE_INT8, GROUP_SIZE, False, False
+        )
+        q_e = q_e.T.contiguous().to(torch.uint8)
+        sc_e = sc_e.T
+        w_q[e] = q_e
+        scales[e] = sc_e
+    return w_q, scales
+
+
+def _marlin_quantize_per_expert_int8(w_fp):
+    """Per-expert Marlin-layout INT8 quantization for vLLM's fused_marlin_moe."""
+    qweight_l, scales_l = [], []
+    E = w_fp.shape[0]
+    for e in range(E):
+        _, qw, sc, _, _, _ = marlin_quantize(
+            w_fp[e].T.contiguous(), VLLM_QUANT_TYPE_INT8, GROUP_SIZE, act_order=False
+        )
+        qweight_l.append(qw)
+        scales_l.append(sc)
+    qweight = torch.stack(qweight_l, dim=0).contiguous()
+    scales = torch.stack(scales_l, dim=0).contiguous()
+    return qweight, scales
+
+
+class FusedMarlinMoEW8A16INT8Benchmark(base.Benchmark):
+    """
+    Benchmark for fused_marlin_moe W8A16 INT8 (fused-dequant MoE GEMM).
+    Sister of FusedMarlinMoEW4A16INT4Benchmark (W4A16 INT4).
+    """
+
+    def __init__(self, op_name, torch_op, dtypes):
+        super().__init__(op_name=op_name, torch_op=torch_op, dtypes=dtypes)
+
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = [
+            # Mixtral-8x7B-like
+            (1, 8, 4096, 14336, 2),
+            (16, 8, 4096, 14336, 2),
+            (64, 8, 4096, 14336, 2),
+            # DeepSeek-V3-like (TP=8 shard)
+            (1, 256, 7168, 2048, 8),
+            (16, 256, 7168, 2048, 8),
+            (64, 256, 7168, 2048, 8),
+        ]
+
+    def get_input_iter(self, cur_dtype):
+        for config in self.shapes:
+            yield from self._gen(config, cur_dtype)
+
+    def _gen(self, config, dtype):
+        num_tokens, num_experts, hidden_size, intermediate_size, topk = config
+        device = flaggems_vllm.device
+
+        hidden_states = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype)
+
+        w1_fp = (
+            torch.randn(
+                num_experts,
+                intermediate_size * 2,
+                hidden_size,
+                device=device,
+                dtype=dtype,
+            )
+            / 10.0
+        )
+        w2_fp = (
+            torch.randn(
+                num_experts,
+                hidden_size,
+                intermediate_size,
+                device=device,
+                dtype=dtype,
+            )
+            / 10.0
+        )
+
+        # FlagGems wna16 INT8 layout (unpacked)
+        w1_q_wna16, w1_scale_wna16 = _wna16_quantize_per_expert_int8(w1_fp)
+        w2_q_wna16, w2_scale_wna16 = _wna16_quantize_per_expert_int8(w2_fp)
+
+        # vLLM Marlin INT8 layout
+        w1_q_marlin, w1_scale_marlin = _marlin_quantize_per_expert_int8(w1_fp)
+        w2_q_marlin, w2_scale_marlin = _marlin_quantize_per_expert_int8(w2_fp)
+
+        del w1_fp, w2_fp
+        torch.cuda.empty_cache()
+
+        gating = torch.randn(
+            num_tokens, num_experts, device=device, dtype=torch.float32
+        )
+        topk_weights, topk_ids = torch.topk(torch.softmax(gating, dim=-1), topk, dim=-1)
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+
+        yield (
+            hidden_states,
+            w1_q_wna16,
+            w2_q_wna16,
+            w1_scale_wna16,
+            w2_scale_wna16,
+            w1_q_marlin,
+            w2_q_marlin,
+            w1_scale_marlin,
+            w2_scale_marlin,
+            topk_weights,
+            topk_ids,
+        )
+
+
+def _vllm_baseline_int8(
+    hidden_states,
+    w1_q_wna16,
+    w2_q_wna16,
+    w1_scale_wna16,
+    w2_scale_wna16,
+    w1_q_marlin,
+    w2_q_marlin,
+    w1_scale_marlin,
+    w2_scale_marlin,
+    topk_weights,
+    topk_ids,
+):
+    """Baseline: vLLM's CUDA Marlin fused_marlin_moe (INT8)."""
+    return vllm_fused_marlin_moe(
+        hidden_states=hidden_states,
+        w1=w1_q_marlin,
+        w2=w2_q_marlin,
+        bias1=None,
+        bias2=None,
+        w1_scale=w1_scale_marlin,
+        w2_scale=w2_scale_marlin,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        quant_type_id=VLLM_QUANT_TYPE_INT8.id,
+    )
+
+
+def _gems_call_int8(
+    hidden_states,
+    w1_q_wna16,
+    w2_q_wna16,
+    w1_scale_wna16,
+    w2_scale_wna16,
+    w1_q_marlin,
+    w2_q_marlin,
+    w1_scale_marlin,
+    w2_scale_marlin,
+    topk_weights,
+    topk_ids,
+):
+    """FlagGems' Triton wna16 fused_marlin_moe W8A16."""
+    return gems_fused_marlin_moe(
+        hidden_states=hidden_states,
+        w1=w1_q_wna16,
+        w2=w2_q_wna16,
+        bias1=None,
+        bias2=None,
+        w1_scale=w1_scale_wna16,
+        w2_scale=w2_scale_wna16,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        quant_type_id=QUANT_TYPE_UINT8B128,
+    )
+
+
+@pytest.mark.fused_marlin_moe
+@pytest.mark.skipif(
+    not HAS_VLLM_FUSED_MARLIN_MOE, reason="vllm not installed; baseline unavailable"
+)
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires NVIDIA Hopper architecture")
+def test_fused_marlin_moe_w8a16_int8():
+    """
+    Benchmark FlagGems fused_marlin_moe W8A16 (Triton wna16) vs vLLM
+    fused_marlin_moe W8A16 (CUDA Marlin). Both run GPTQ uint8b128 + per-group-128.
+    """
+    bench = FusedMarlinMoEW8A16INT8Benchmark(
+        op_name="fused_marlin_moe_w8a16_int8",
+        torch_op=_vllm_baseline_int8,
+        dtypes=[torch.bfloat16],
+    )
+    bench.set_gems(_gems_call_int8)
+    bench.run()

--- a/src/flaggems_vllm/ops/fused_marlin_moe.py
+++ b/src/flaggems_vllm/ops/fused_marlin_moe.py
@@ -88,13 +88,13 @@ def _is_hopper() -> bool:
     return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 9
 
 
-class _W4A16KernelPolicy(NamedTuple):
+class _W4A16Int4KernelPolicy(NamedTuple):
     block_m: int
     use_fused_gemm1_silu: bool
     move_router_weight_before_gemm2: bool
 
 
-class _MXFP4KernelPolicy(NamedTuple):
+class _W4A16Mxfp4KernelPolicy(NamedTuple):
     block_m: int
     use_fused_gemm1_silu: bool
     align_mode: "_MXFP4AlignMode"
@@ -170,14 +170,14 @@ def _select_block_m(
     return 64
 
 
-def _select_w4a16_kernel_policy(
+def _select_w4a16_int4_kernel_policy(
     device: torch.device,
     M: int,
     E: int,
     top_k: int,
     swap_ab: bool,
     apply_router_weight_on_input: bool,
-) -> _W4A16KernelPolicy:
+) -> _W4A16Int4KernelPolicy:
     device_info = _get_device_info(device)
 
     # Base tiling policy. Full Hopper uses a smaller cutoff because it has
@@ -210,20 +210,20 @@ def _select_w4a16_kernel_policy(
         use_fused_gemm1_silu and not apply_router_weight_on_input and M >= 512
     )
 
-    return _W4A16KernelPolicy(
+    return _W4A16Int4KernelPolicy(
         block_m=block_m,
         use_fused_gemm1_silu=use_fused_gemm1_silu,
         move_router_weight_before_gemm2=move_router_weight_before_gemm2,
     )
 
 
-def _select_mxfp4_kernel_policy(
+def _select_w4a16_mxfp4_kernel_policy(
     device: torch.device,
     M: int,
     E: int,
     top_k: int,
     swap_ab: bool,
-) -> _MXFP4KernelPolicy:
+) -> _W4A16Mxfp4KernelPolicy:
     device_info = _get_device_info(device)
     is_reduced_hopper = (
         device_info.is_hopper and not device_info.has_full_hopper_sm_count
@@ -248,7 +248,7 @@ def _select_mxfp4_kernel_policy(
     else:
         align_mode = _MXFP4AlignMode.default
 
-    return _MXFP4KernelPolicy(
+    return _W4A16Mxfp4KernelPolicy(
         block_m=block_m,
         use_fused_gemm1_silu=is_reduced_hopper and M > 1,
         align_mode=align_mode,
@@ -345,7 +345,7 @@ def _cached_pack_scale(s: torch.Tensor, cached: bool) -> torch.Tensor:
     return packed
 
 
-def w4a16_pack(
+def w4a16_int4_pack(
     w1: torch.Tensor,
     w2: torch.Tensor,
     w1_scale: Optional[torch.Tensor] = None,
@@ -437,7 +437,7 @@ def _cached_pack_scale_e8m0_fold(s, compute_dtype, cached: bool) -> torch.Tensor
     return packed
 
 
-def mxfp4_pack(
+def w4a16_mxfp4_pack(
     w1,
     w2,
     w1_scale,
@@ -821,38 +821,16 @@ def _write_zeros_to_output(
     tl.store(c_ptrs, accumulator, mask=c_mask)
 
 
-@triton.autotune(
-    configs=[
-        triton.Config(
-            {"BLOCK_SIZE_N": 64, "GROUP_SIZE_M": 1}, num_warps=4, num_stages=4
-        ),
-        triton.Config(
-            {"BLOCK_SIZE_N": 128, "GROUP_SIZE_M": 1}, num_warps=4, num_stages=4
-        ),
-        triton.Config(
-            {"BLOCK_SIZE_N": 128, "GROUP_SIZE_M": 4}, num_warps=4, num_stages=4
-        ),
-        triton.Config(
-            {"BLOCK_SIZE_N": 128, "GROUP_SIZE_M": 4}, num_warps=8, num_stages=3
-        ),
-        triton.Config(
-            {"BLOCK_SIZE_N": 256, "GROUP_SIZE_M": 4}, num_warps=8, num_stages=3
-        ),
-        triton.Config(
-            {"BLOCK_SIZE_N": 256, "GROUP_SIZE_M": 4}, num_warps=8, num_stages=2
-        ),
-    ],
-    key=[
-        "N",
-        "K",
-        "EM",
-        "BLOCK_SIZE_M",
-        "MUL_ROUTED_WEIGHT",
-        "top_k",
-    ],
+@libentry()
+@libtuner(
+    configs=runtime.get_tuned_config("fused_marlin_moe_w4a16_int4"),
+    key=["N", "K", "EM", "BLOCK_SIZE_M", "MUL_ROUTED_WEIGHT", "top_k"],
+    strategy=["align32", "align32", "align32", "align32", "default", "default"],
+    flagtune_op_name="fused_marlin_moe_w4a16_int4",
+    flagtune_expand_op_name="fused_marlin_moe_w4a16_int4",
 )
 @triton.jit
-def _w4a16_moe_gemm_kernel(
+def _w4a16_int4_moe_gemm_kernel(
     a_ptr,
     b_ptr,
     c_ptr,
@@ -990,27 +968,9 @@ def _w4a16_moe_gemm_kernel(
     tl.store(c_ptrs, accumulator, mask=c_mask)
 
 
-@triton.autotune(
-    configs=[
-        triton.Config(
-            {"BLOCK_SIZE_N": 64, "GROUP_SIZE_M": 1}, num_warps=4, num_stages=4
-        ),
-        triton.Config(
-            {"BLOCK_SIZE_N": 128, "GROUP_SIZE_M": 1}, num_warps=4, num_stages=4
-        ),
-        triton.Config(
-            {"BLOCK_SIZE_N": 128, "GROUP_SIZE_M": 4}, num_warps=4, num_stages=4
-        ),
-        triton.Config(
-            {"BLOCK_SIZE_N": 128, "GROUP_SIZE_M": 4}, num_warps=8, num_stages=3
-        ),
-        triton.Config(
-            {"BLOCK_SIZE_N": 256, "GROUP_SIZE_M": 4}, num_warps=8, num_stages=3
-        ),
-        triton.Config(
-            {"BLOCK_SIZE_N": 256, "GROUP_SIZE_M": 4}, num_warps=8, num_stages=2
-        ),
-    ],
+@libentry()
+@libtuner(
+    configs=runtime.get_tuned_config("fused_marlin_moe_w4a16_int4_gemm_silu"),
     key=[
         "N",
         "K",
@@ -1020,9 +980,20 @@ def _w4a16_moe_gemm_kernel(
         "APPLY_ROUTER_WEIGHT_AFTER_SILU",
         "top_k",
     ],
+    strategy=[
+        "align32",
+        "align32",
+        "align32",
+        "align32",
+        "default",
+        "default",
+        "default",
+    ],
+    flagtune_op_name="fused_marlin_moe_w4a16_int4_gemm_silu",
+    flagtune_expand_op_name="fused_marlin_moe_w4a16_int4_gemm_silu",
 )
 @triton.jit
-def _w4a16_moe_gemm_silu_kernel(
+def _w4a16_int4_moe_gemm_silu_kernel(
     a_ptr,
     b_ptr,
     c_ptr,
@@ -1193,7 +1164,7 @@ def _w4a16_moe_gemm_silu_kernel(
     tl.store(c_ptrs, accumulator, mask=c_mask)
 
 
-def _invoke_w4a16_moe_gemm(
+def _invoke_w4a16_int4_moe_gemm(
     A: torch.Tensor,  # (M, K) for GEMM1, (M*top_k, K) for GEMM2
     B: torch.Tensor,  # (E, K//8, N) int32
     C: torch.Tensor,  # (M, top_k, N) or (M*top_k, N) view
@@ -1229,7 +1200,7 @@ def _invoke_w4a16_moe_gemm(
         triton.cdiv(EM, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
     )
 
-    _w4a16_moe_gemm_kernel[grid](
+    _w4a16_int4_moe_gemm_kernel[grid](
         A,
         B,
         C,
@@ -1262,7 +1233,7 @@ def _invoke_w4a16_moe_gemm(
     )
 
 
-def _invoke_w4a16_moe_gemm_silu(
+def _invoke_w4a16_int4_moe_gemm_silu(
     A: torch.Tensor,
     B: torch.Tensor,
     C: torch.Tensor,
@@ -1291,7 +1262,7 @@ def _invoke_w4a16_moe_gemm_silu(
         triton.cdiv(EM, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
     )
 
-    _w4a16_moe_gemm_silu_kernel[grid](
+    _w4a16_int4_moe_gemm_silu_kernel[grid](
         A,
         B,
         C,
@@ -1329,7 +1300,7 @@ def _invoke_w4a16_moe_gemm_silu(
     )
 
 
-def fused_moe_w4a16_gptq(
+def fused_marlin_moe_w4a16_int4(
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
     w2: torch.Tensor,
@@ -1373,7 +1344,7 @@ def fused_moe_w4a16_gptq(
     else:
         compute_type = tl.bfloat16
 
-    w1_packed, w2_packed, w1_scale_packed, w2_scale_packed = w4a16_pack(
+    w1_packed, w2_packed, w1_scale_packed, w2_scale_packed = w4a16_int4_pack(
         w1,
         w2,
         w1_scale,
@@ -1382,7 +1353,7 @@ def fused_moe_w4a16_gptq(
         cached=True,
     )
 
-    policy = _select_w4a16_kernel_policy(
+    policy = _select_w4a16_int4_kernel_policy(
         hidden_states.device,
         M,
         E,
@@ -1424,7 +1395,7 @@ def fused_moe_w4a16_gptq(
     )
 
     if use_fused_gemm1_silu:
-        _invoke_w4a16_moe_gemm_silu(
+        _invoke_w4a16_int4_moe_gemm_silu(
             A=hidden_states,
             B=w1_packed,
             C=intermediate_cache2,
@@ -1447,7 +1418,7 @@ def fused_moe_w4a16_gptq(
         )
     else:
         assert intermediate_cache1 is not None
-        _invoke_w4a16_moe_gemm(
+        _invoke_w4a16_int4_moe_gemm(
             A=hidden_states,
             B=w1_packed,
             C=intermediate_cache1,
@@ -1473,7 +1444,7 @@ def fused_moe_w4a16_gptq(
     else:
         out_hidden_states = torch.empty_like(hidden_states)
 
-    _invoke_w4a16_moe_gemm(
+    _invoke_w4a16_int4_moe_gemm(
         A=intermediate_cache2,
         B=w2_packed,
         C=intermediate_cache3,
@@ -1498,14 +1469,14 @@ def fused_moe_w4a16_gptq(
 
 @libentry()
 @libtuner(
-    configs=runtime.get_tuned_config("fused_marlin_moe_mxfp4"),
+    configs=runtime.get_tuned_config("fused_marlin_moe_w4a16_mxfp4"),
     key=["N", "K", "EM_BUCKET", "BLOCK_SIZE_M", "SWAP_AB"],
     strategy=["align32", "align32", "align32", "align32", "default"],
-    flagtune_op_name="fused_marlin_moe_mxfp4",
-    flagtune_expand_op_name="fused_marlin_moe_mxfp4",
+    flagtune_op_name="fused_marlin_moe_w4a16_mxfp4",
+    flagtune_expand_op_name="fused_marlin_moe_w4a16_mxfp4",
 )
 @triton.jit
-def _mxfp4_moe_gemm_kernel(
+def _w4a16_mxfp4_moe_gemm_kernel(
     a_ptr,
     b_ptr,
     c_ptr,
@@ -1657,14 +1628,14 @@ def _mxfp4_moe_gemm_kernel(
 
 @libentry()
 @libtuner(
-    configs=runtime.get_tuned_config("fused_marlin_moe_mxfp4_gemm_silu"),
+    configs=runtime.get_tuned_config("fused_marlin_moe_w4a16_mxfp4_gemm_silu"),
     key=["N", "K", "BLOCK_SIZE_M", "SWAP_AB"],
     strategy=["align32", "align32", "align32", "default"],
-    flagtune_op_name="fused_marlin_moe_mxfp4_gemm_silu",
-    flagtune_expand_op_name="fused_marlin_moe_mxfp4_gemm_silu",
+    flagtune_op_name="fused_marlin_moe_w4a16_mxfp4_gemm_silu",
+    flagtune_expand_op_name="fused_marlin_moe_w4a16_mxfp4_gemm_silu",
 )
 @triton.jit
-def _mxfp4_moe_gemm_silu_kernel(
+def _w4a16_mxfp4_moe_gemm_silu_kernel(
     a_ptr,
     b_ptr,
     c_ptr,
@@ -1863,7 +1834,7 @@ def _mxfp4_moe_gemm_silu_kernel(
     tl.store(c_ptrs, accumulator, mask=c_mask)
 
 
-def _invoke_mxfp4_moe_gemm(
+def _invoke_w4a16_mxfp4_moe_gemm(
     A,
     B,
     C,
@@ -1901,7 +1872,7 @@ def _invoke_mxfp4_moe_gemm(
         triton.cdiv(EM, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
     )
 
-    _mxfp4_moe_gemm_kernel[grid](
+    _w4a16_mxfp4_moe_gemm_kernel[grid](
         A,
         B,
         C,
@@ -1936,7 +1907,7 @@ def _invoke_mxfp4_moe_gemm(
     )
 
 
-def _invoke_mxfp4_moe_gemm_silu(
+def _invoke_w4a16_mxfp4_moe_gemm_silu(
     A,
     B,
     C,
@@ -1966,7 +1937,7 @@ def _invoke_mxfp4_moe_gemm_silu(
         triton.cdiv(EM, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
     )
 
-    _mxfp4_moe_gemm_silu_kernel[grid](
+    _w4a16_mxfp4_moe_gemm_silu_kernel[grid](
         A,
         B,
         C,
@@ -2000,7 +1971,7 @@ def _invoke_mxfp4_moe_gemm_silu(
     )
 
 
-def fused_moe_mxfp4(
+def fused_marlin_moe_w4a16_mxfp4(
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
     w2: torch.Tensor,
@@ -2049,7 +2020,7 @@ def fused_moe_mxfp4(
         and _e8m0_fold_safe(w2_scale, hidden_states.dtype)
     )
 
-    w1_packed, w2_packed, w1_scale_packed, w2_scale_packed = mxfp4_pack(
+    w1_packed, w2_packed, w1_scale_packed, w2_scale_packed = w4a16_mxfp4_pack(
         w1,
         w2,
         w1_scale,
@@ -2060,7 +2031,7 @@ def fused_moe_mxfp4(
         fold_scale=fold_scale,
     )
 
-    policy = _select_mxfp4_kernel_policy(
+    policy = _select_w4a16_mxfp4_kernel_policy(
         hidden_states.device,
         M,
         E,
@@ -2095,7 +2066,7 @@ def fused_moe_mxfp4(
     )
 
     if use_fused_gemm1_silu:
-        _invoke_mxfp4_moe_gemm_silu(
+        _invoke_w4a16_mxfp4_moe_gemm_silu(
             A=hidden_states,
             B=w1_packed,
             C=intermediate_cache2,
@@ -2115,7 +2086,7 @@ def fused_moe_mxfp4(
         )
     else:
         assert intermediate_cache1 is not None
-        _invoke_mxfp4_moe_gemm(
+        _invoke_w4a16_mxfp4_moe_gemm(
             A=hidden_states,
             B=w1_packed,
             C=intermediate_cache1,
@@ -2138,7 +2109,7 @@ def fused_moe_mxfp4(
         up = intermediate_cache1[:, intermediate_size:]
         silu_and_mul_out(gate, up, intermediate_cache2)
 
-    _invoke_mxfp4_moe_gemm(
+    _invoke_w4a16_mxfp4_moe_gemm(
         A=intermediate_cache2,
         B=w2_packed,
         C=intermediate_cache3,
@@ -2504,7 +2475,7 @@ def fused_marlin_moe(
         and w1_scale.dtype == hidden_states.dtype
         and w2_scale.dtype == hidden_states.dtype
     ):
-        result = fused_moe_w4a16_gptq(
+        result = fused_marlin_moe_w4a16_int4(
             hidden_states=hidden_states,
             w1=w1,
             w2=w2,
@@ -2540,7 +2511,7 @@ def fused_marlin_moe(
                 "MXFP4 fast path requires Hopper, bf16/fp16 activations, uint8 "
                 "packed weights, no bias/zeros/expert_map."
             )
-        result = fused_moe_mxfp4(
+        result = fused_marlin_moe_w4a16_mxfp4(
             hidden_states=hidden_states,
             w1=w1,
             w2=w2,

--- a/src/flaggems_vllm/runtime/backend/_nvidia/hopper/general_ops_hopper_expand.yaml
+++ b/src/flaggems_vllm/runtime/backend/_nvidia/hopper/general_ops_hopper_expand.yaml
@@ -163,7 +163,71 @@ mv:
       stride_an: default
       stride_am: default
       dtype: default
-fused_marlin_moe_mxfp4:
+fused_marlin_moe_w4a16_int4:
+  - config:
+    param_map:
+      META:
+        BLOCK_SIZE_N: block_size_n
+        GROUP_SIZE_M: group_size_m
+      num_stages: stages
+      num_warps: warps
+      maxnreg: maxnreg
+    block_size_n:
+      - 64
+      - 128
+      - 256
+    group_size_m:
+      - 1
+      - 4
+    stages:
+      - 2
+      - 3
+      - 4
+    warps:
+      - 4
+    maxnreg:
+      - 96
+      - 255
+  - strategy:
+      N: align32
+      K: align32
+      EM: align32
+      BLOCK_SIZE_M: align32
+      MUL_ROUTED_WEIGHT: default
+      top_k: default
+fused_marlin_moe_w4a16_int4_gemm_silu:
+  - config:
+    param_map:
+      META:
+        BLOCK_SIZE_N: block_size_n
+        GROUP_SIZE_M: group_size_m
+      num_stages: stages
+      num_warps: warps
+      maxnreg: maxnreg
+    block_size_n:
+      - 64
+      - 128
+    group_size_m:
+      - 1
+      - 4
+    stages:
+      - 2
+      - 3
+      - 4
+    warps:
+      - 4
+    maxnreg:
+      - 96
+      - 255
+  - strategy:
+      N: align32
+      K: align32
+      EM: align32
+      BLOCK_SIZE_M: align32
+      APPLY_ROUTER_WEIGHT_BEFORE_SILU: default
+      APPLY_ROUTER_WEIGHT_AFTER_SILU: default
+      top_k: default
+fused_marlin_moe_w4a16_mxfp4:
   - config:
     param_map:
       META:
@@ -200,7 +264,7 @@ fused_marlin_moe_mxfp4:
       EM_BUCKET: align32
       BLOCK_SIZE_M: align32
       SWAP_AB: default
-fused_marlin_moe_mxfp4_gemm_silu:
+fused_marlin_moe_w4a16_mxfp4_gemm_silu:
   - config:
     param_map:
       META:

--- a/src/flaggems_vllm/runtime/backend/_nvidia/tune_configs.yaml
+++ b/src/flaggems_vllm/runtime/backend/_nvidia/tune_configs.yaml
@@ -374,7 +374,43 @@ compute_global_topk_indices_and_lens:
       TPP: 1
     num_warps: 2
     num_stages: 3
-fused_marlin_moe_mxfp4:
+fused_marlin_moe_w4a16_int4:
+  - META: {BLOCK_SIZE_N: 64, GROUP_SIZE_M: 4}
+    num_warps: 4
+    num_stages: 2
+    maxnreg: 96
+  - META: {BLOCK_SIZE_N: 256, GROUP_SIZE_M: 1}
+    num_warps: 4
+    num_stages: 3
+    maxnreg: 96
+  - META: {BLOCK_SIZE_N: 64, GROUP_SIZE_M: 4}
+    num_warps: 4
+    num_stages: 3
+    maxnreg: 96
+  - META: {BLOCK_SIZE_N: 64, GROUP_SIZE_M: 1}
+    num_warps: 4
+    num_stages: 4
+    maxnreg: 96
+  - META: {BLOCK_SIZE_N: 64, GROUP_SIZE_M: 1}
+    num_warps: 4
+    num_stages: 4
+    maxnreg: 255
+
+fused_marlin_moe_w4a16_int4_gemm_silu:
+  - META: {BLOCK_SIZE_N: 64, GROUP_SIZE_M: 4}
+    num_warps: 4
+    num_stages: 4
+    maxnreg: 255
+  - META: {BLOCK_SIZE_N: 64, GROUP_SIZE_M: 4}
+    num_warps: 4
+    num_stages: 3
+    maxnreg: 96
+  - META: {BLOCK_SIZE_N: 128, GROUP_SIZE_M: 1}
+    num_warps: 4
+    num_stages: 2
+    maxnreg: 96
+
+fused_marlin_moe_w4a16_mxfp4:
   - gen: true
     param_map:
       META:
@@ -423,7 +459,7 @@ fused_marlin_moe_mxfp4:
     stages: [2, 3, 4]
     warps: [4, 8]
 
-fused_marlin_moe_mxfp4_gemm_silu:
+fused_marlin_moe_w4a16_mxfp4_gemm_silu:
   - META: {BLOCK_SIZE_N: 32, GROUP_SIZE_M: 1}
     num_warps: 2
     num_stages: 4
@@ -465,3 +501,7 @@ fused_marlin_moe_mxfp4_gemm_silu:
     num_stages: 4
     maxnreg: 255
   - META: {BLOCK_SIZE_N: 256, GROUP_SIZE_M: 4}
+    num_warps: 8
+    num_stages: 3
+    maxnreg: 255
+

--- a/src/flaggems_vllm/runtime/backend/_nvidia/tune_configs.yaml
+++ b/src/flaggems_vllm/runtime/backend/_nvidia/tune_configs.yaml
@@ -504,4 +504,3 @@ fused_marlin_moe_w4a16_mxfp4_gemm_silu:
     num_warps: 8
     num_stages: 3
     maxnreg: 255
-

--- a/src/flaggems_vllm/runtime/common.py
+++ b/src/flaggems_vllm/runtime/common.py
@@ -48,14 +48,31 @@ DEFAULT_STRATEGIES = {
     "bmm": ["align32", "align32", "align32", "align32", "align32"],
     "bmm_sqmma": ["align32", "align32", "align32"],
     "compute_global_topk_indices_and_lens": ["align32", "align32"],
-    "fused_marlin_moe_mxfp4": [
+    "fused_marlin_moe_w4a16_int4": [
+        "align32",
+        "align32",
+        "align32",
+        "align32",
+        "default",
+        "default",
+    ],
+    "fused_marlin_moe_w4a16_int4_gemm_silu": [
+        "align32",
+        "align32",
+        "align32",
+        "align32",
+        "default",
+        "default",
+        "default",
+    ],
+    "fused_marlin_moe_w4a16_mxfp4": [
         "align32",
         "align32",
         "align32",
         "align32",
         "default",
     ],
-    "fused_marlin_moe_mxfp4_gemm_silu": [
+    "fused_marlin_moe_w4a16_mxfp4_gemm_silu": [
         "align32",
         "align32",
         "align32",
@@ -108,14 +125,31 @@ OP_KEY_ORDERS = {
     "bmm_sqmma": ["M", "N", "K"],
     "baddbmm": ["M", "N", "K"],
     "compute_global_topk_indices_and_lens": ["topk", "num_tokens"],
-    "fused_marlin_moe_mxfp4": [
+    "fused_marlin_moe_w4a16_int4": [
+        "N",
+        "K",
+        "EM",
+        "BLOCK_SIZE_M",
+        "MUL_ROUTED_WEIGHT",
+        "top_k",
+    ],
+    "fused_marlin_moe_w4a16_int4_gemm_silu": [
+        "N",
+        "K",
+        "EM",
+        "BLOCK_SIZE_M",
+        "APPLY_ROUTER_WEIGHT_BEFORE_SILU",
+        "APPLY_ROUTER_WEIGHT_AFTER_SILU",
+        "top_k",
+    ],
+    "fused_marlin_moe_w4a16_mxfp4": [
         "N",
         "K",
         "EM_BUCKET",
         "BLOCK_SIZE_M",
         "SWAP_AB",
     ],
-    "fused_marlin_moe_mxfp4_gemm_silu": [
+    "fused_marlin_moe_w4a16_mxfp4_gemm_silu": [
         "N",
         "K",
         "BLOCK_SIZE_M",

--- a/src/flaggems_vllm/runtime/configloader.py
+++ b/src/flaggems_vllm/runtime/configloader.py
@@ -264,7 +264,12 @@ class ConfigLoader(object):
                 for w in ranges["w"]
             ]
 
-        if op_name == "fused_marlin_moe_mxfp4":
+        if op_name in (
+            "fused_marlin_moe_w4a16_int4",
+            "fused_marlin_moe_w4a16_int4_gemm_silu",
+            "fused_marlin_moe_w4a16_mxfp4",
+            "fused_marlin_moe_w4a16_mxfp4_gemm_silu",
+        ):
             maxnreg_values = ranges.get("maxnreg", [None])
             return [
                 triton.Config(
@@ -274,28 +279,8 @@ class ConfigLoader(object):
                     },
                     num_stages=s,
                     num_warps=w,
+                    maxnreg=maxnreg,
                     pre_hook=pre_hook,
-                    **({} if maxnreg is None else {"maxnreg": maxnreg}),
-                )
-                for block_size_n in ranges["BLOCK_SIZE_N"]
-                for group_size_m in ranges["GROUP_SIZE_M"]
-                for s in ranges["s"]
-                for w in ranges["w"]
-                for maxnreg in maxnreg_values
-            ]
-
-        if op_name == "fused_marlin_moe_mxfp4_gemm_silu":
-            maxnreg_values = ranges.get("maxnreg", [None])
-            return [
-                triton.Config(
-                    {
-                        "BLOCK_SIZE_N": block_size_n,
-                        "GROUP_SIZE_M": group_size_m,
-                    },
-                    num_stages=s,
-                    num_warps=w,
-                    pre_hook=pre_hook,
-                    **({} if maxnreg is None else {"maxnreg": maxnreg}),
                 )
                 for block_size_n in ranges["BLOCK_SIZE_N"]
                 for group_size_m in ranges["GROUP_SIZE_M"]
@@ -492,14 +477,28 @@ class ConfigLoader(object):
                 "bmm", expand_yaml_path=self._get_expand_config_path("bmm")
             ),
             "bmm_sqmma": self._build_single_expand_spec("bmm_sqmma"),
-            "fused_marlin_moe_mxfp4": self._build_single_expand_spec(
-                "fused_marlin_moe_mxfp4",
-                expand_yaml_path=self._get_expand_config_path("fused_marlin_moe_mxfp4"),
-            ),
-            "fused_marlin_moe_mxfp4_gemm_silu": self._build_single_expand_spec(
-                "fused_marlin_moe_mxfp4_gemm_silu",
+            "fused_marlin_moe_w4a16_int4": self._build_single_expand_spec(
+                "fused_marlin_moe_w4a16_int4",
                 expand_yaml_path=self._get_expand_config_path(
-                    "fused_marlin_moe_mxfp4_gemm_silu"
+                    "fused_marlin_moe_w4a16_int4"
+                ),
+            ),
+            "fused_marlin_moe_w4a16_int4_gemm_silu": self._build_single_expand_spec(
+                "fused_marlin_moe_w4a16_int4_gemm_silu",
+                expand_yaml_path=self._get_expand_config_path(
+                    "fused_marlin_moe_w4a16_int4_gemm_silu"
+                ),
+            ),
+            "fused_marlin_moe_w4a16_mxfp4": self._build_single_expand_spec(
+                "fused_marlin_moe_w4a16_mxfp4",
+                expand_yaml_path=self._get_expand_config_path(
+                    "fused_marlin_moe_w4a16_mxfp4"
+                ),
+            ),
+            "fused_marlin_moe_w4a16_mxfp4_gemm_silu": self._build_single_expand_spec(
+                "fused_marlin_moe_w4a16_mxfp4_gemm_silu",
+                expand_yaml_path=self._get_expand_config_path(
+                    "fused_marlin_moe_w4a16_mxfp4_gemm_silu"
                 ),
             ),
             "gemv": self._build_single_expand_spec("gemv"),

--- a/src/flaggems_vllm/runtime/flagtune.py
+++ b/src/flaggems_vllm/runtime/flagtune.py
@@ -175,12 +175,22 @@ register_flagtune_op(
     description="matrix-vector multiplication",
 )
 register_flagtune_op(
-    "fused_marlin_moe_mxfp4",
+    "fused_marlin_moe_w4a16_int4",
+    default=False,
+    description="W4A16 INT4 fused Marlin MoE GEMM",
+)
+register_flagtune_op(
+    "fused_marlin_moe_w4a16_int4_gemm_silu",
+    default=False,
+    description="W4A16 INT4 fused Marlin MoE GEMM with SiLU",
+)
+register_flagtune_op(
+    "fused_marlin_moe_w4a16_mxfp4",
     default=False,
     description="MXFP4 fused Marlin MoE GEMM",
 )
 register_flagtune_op(
-    "fused_marlin_moe_mxfp4_gemm_silu",
+    "fused_marlin_moe_w4a16_mxfp4_gemm_silu",
     default=False,
     description="MXFP4 fused Marlin MoE GEMM with SiLU",
 )

--- a/tests/test_fused_marlin_moe.py
+++ b/tests/test_fused_marlin_moe.py
@@ -29,9 +29,25 @@ import pytest
 import torch
 
 import flaggems_vllm
-from flaggems_vllm.ops.fused_marlin_moe import QUANT_TYPE_UINT4B8, fused_marlin_moe
+from flaggems_vllm.ops.fused_marlin_moe import (
+    QUANT_TYPE_FP4_E2M1,
+    QUANT_TYPE_UINT4B8,
+    QUANT_TYPE_UINT8B128,
+    fused_marlin_moe,
+)
 
-pytestmark = pytest.mark.fused_marlin_moe
+from . import conftest as cfg
+
+
+def _is_hopper():
+    # The W4A16 fast-path kernel's bf16 dequant uses sm_90-only PTX
+    # (sub.bf16x2 / mul.bf16); the fast path is gated to Hopper.
+    if flaggems_vllm.device != "cuda":
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    sm = major * 10 + minor
+    return 90 <= sm < 100
+
 
 # -----------------------------------------------------------------------------
 # Local GPTQ uint4b8 quantization helper (self-contained, no vllm dependency).
@@ -78,6 +94,48 @@ def _gptq_quantize_uint4b8(w_2d, group_size):
     return w_ref, w_q_unsigned, scales
 
 
+QUANT_TYPE_UINT8B128_TAG = "uint8b128"
+
+
+def _gptq_quantize_uint8b128(w_2d, group_size):
+    """
+    Symmetric per-group INT8 quantization with +128 offset (GPTQ uint8b128).
+
+    Sister function to _gptq_quantize_uint4b8. Self-contained replacement for
+    vllm.quantize_weights(w, scalar_types.uint8b128, group_size, False, False).
+    Produces unpacked integer codes (each cell a byte in [1, 255], i.e.
+    signed [-127, 127] shifted by +128) plus the exact dequantized FP
+    reference, in the layout fused_moe_kernel_gptq_awq's W8A16 branch consumes
+    (no nibble packing — one byte per element).
+
+    Args:
+        w_2d: (out_dim, in_dim), fp16 or bf16.
+        group_size: int, must divide in_dim.
+
+    Returns:
+        w_ref:  (out_dim, in_dim), same dtype.  Dequantized reference values.
+        w_q_unsigned: (out_dim, in_dim), uint8.  Each cell in [1, 255].
+        scales: (out_dim, in_dim // group_size), same dtype as w_2d.
+    """
+    out_dim, in_dim = w_2d.shape
+    assert in_dim % group_size == 0
+    ng = in_dim // group_size
+
+    w_grouped = w_2d.reshape(out_dim, ng, group_size).to(torch.float32)
+    max_abs = w_grouped.abs().amax(dim=-1, keepdim=True)
+    # scale = max_abs / 127 (symmetric INT8 range [-127, 127] after +128 -> [1, 255])
+    scales_fp = (max_abs / 127.0).clamp(min=1e-8)
+
+    w_q_signed = torch.round(w_grouped / scales_fp).clamp(-127, 127)
+    w_ref_grouped = (w_q_signed * scales_fp).to(w_2d.dtype)
+    w_q_unsigned = (w_q_signed + 128).clamp(0, 255).to(torch.uint8)
+
+    w_ref = w_ref_grouped.reshape(out_dim, in_dim)
+    w_q_unsigned = w_q_unsigned.reshape(out_dim, in_dim)
+    scales = scales_fp.squeeze(-1).to(w_2d.dtype)
+    return w_ref, w_q_unsigned, scales
+
+
 # -----------------------------------------------------------------------------
 # Shape configs.
 # Tuple format: (num_tokens, num_experts, hidden_size, intermediate_size, topk)
@@ -92,18 +150,29 @@ QUICK_CONFIGS = [
     (32, 8, 128, 256, 4),
 ]
 
-FULL_CONFIGS = QUICK_CONFIGS + [
-    (64, 8, 256, 512, 2),
-    (128, 16, 128, 256, 4),
-    # Mixtral-8x7B-like
-    (1, 8, 4096, 14336, 2),
-    (16, 8, 4096, 14336, 2),
-    (64, 8, 4096, 14336, 2),
-    # DeepSeek-V3-like (TP=8 shard)
-    (1, 256, 7168, 2048, 8),
-    (16, 256, 7168, 2048, 8),
-    (64, 256, 7168, 2048, 8),
-]
+if cfg.QUICK_MODE:
+    FULL_CONFIGS = QUICK_CONFIGS[:2]
+else:
+    FULL_CONFIGS = QUICK_CONFIGS + [
+        (64, 8, 256, 512, 2),
+        (128, 16, 128, 256, 4),
+        # Mixtral-8x7B-like
+        (1, 8, 4096, 14336, 2),
+        (16, 8, 4096, 14336, 2),
+        (64, 8, 4096, 14336, 2),
+        # DeepSeek-V3-like (TP=8 shard)
+        (1, 256, 7168, 2048, 8),
+        (16, 256, 7168, 2048, 8),
+        (64, 256, 7168, 2048, 8),
+        # Qwen3-5-397B-A17B
+        (1, 512, 4096, 1024, 10),
+        (16, 512, 4096, 1024, 10),
+        (64, 512, 4096, 1024, 10),
+        # DeepSeek-V4-Flash
+        (1, 256, 4096, 2048, 6),
+        (16, 256, 4096, 2048, 6),
+        (64, 256, 4096, 2048, 6),
+    ]
 
 GROUP_SIZE = 128
 
@@ -146,14 +215,43 @@ def _quantize_moe_weight(w_fp, group_size):
     return w_q, w_ref, scales
 
 
-def _make_inputs(
-    num_tokens,
-    num_experts,
-    hidden_size,
-    intermediate_size,
-    topk,
-    dtype,
-    device,
+def _quantize_moe_weight_int8(w_fp, group_size):
+    """
+    Per-expert GPTQ uint8b128 quantization. Sister of _quantize_moe_weight
+    (which is INT4 packed). INT8 weights are one byte per element — no
+    nibble packing — so the output K-dim is in_dim, not in_dim // 2.
+
+    Args:
+        w_fp: (E, out_dim, in_dim), fp16 or bf16.
+
+    Returns:
+        w_q:    (E, out_dim, in_dim), uint8   (each cell in [1, 255])
+        w_ref:  (E, out_dim, in_dim), same dtype as w_fp
+        scales: (E, out_dim, in_dim // group_size), same dtype as w_fp
+    """
+    E, out_dim, in_dim = w_fp.shape
+    assert (
+        in_dim % group_size == 0
+    ), f"in_dim={in_dim} not divisible by group_size={group_size}"
+    w_q = torch.empty(E, out_dim, in_dim, device=w_fp.device, dtype=torch.uint8)
+    w_ref = torch.empty_like(w_fp)
+    scales = torch.empty(
+        E,
+        out_dim,
+        in_dim // group_size,
+        device=w_fp.device,
+        dtype=w_fp.dtype,
+    )
+    for e in range(E):
+        ref_e, q_e, sc_e = _gptq_quantize_uint8b128(w_fp[e], group_size)
+        w_q[e] = q_e
+        w_ref[e] = ref_e
+        scales[e] = sc_e
+    return w_q, w_ref, scales
+
+
+def _make_inputs_w4a16_int4(
+    num_tokens, num_experts, hidden_size, intermediate_size, topk, dtype, device
 ):
     """
     Build all tensors for one test case.
@@ -166,10 +264,13 @@ def _make_inputs(
         w1_scale, w2_scale     3D scales matching w1_q/w2_q
     """
     torch.manual_seed(0)
-    hidden_states = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype)
+    # Match vLLM's test_fused_marlin_moe magnitude (test_moe.py): A, w1, w2 are
+    # all scaled by 1/10 so output magnitudes stay small enough for the fixed
+    # atol=4e-2 check (and the INT4 quant grid stays well-conditioned).
+    hidden_states = (
+        torch.randn(num_tokens, hidden_size, device=device, dtype=dtype) / 10.0
+    )
 
-    # Match vLLM's magnitude (test_moe_vllm.py line 569-570): /10 keeps the
-    # quantization grid well-conditioned for INT4.
     w1_fp = (
         torch.randn(
             num_experts,
@@ -212,35 +313,207 @@ def _make_inputs(
     )
 
 
-def _reference_swiglu_moe(hidden_states, w1_ref, w2_ref, topk_weights, topk_ids):
-    """Naive but obviously-correct SwiGLU MoE reference, using dequantized weights."""
-    M, _ = hidden_states.shape
+def _make_inputs_w8a16_int8(
+    num_tokens, num_experts, hidden_size, intermediate_size, topk, dtype, device
+):
+    """
+    Build all tensors for one W8A16 test case. Sister of _make_inputs_w4a16_int4.
+
+    Returns:
+        hidden_states          (M, K)        fp16/bf16
+        w1_q, w2_q             unpacked uint8     -> wrapper input
+        w1_ref, w2_ref         fp16/bf16          -> reference GEMM input
+        topk_weights, topk_ids
+        w1_scale, w2_scale     3D scales matching w1_q/w2_q
+    """
+    torch.manual_seed(0)
+    hidden_states = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype)
+
+    w1_fp = (
+        torch.randn(
+            num_experts,
+            intermediate_size * 2,
+            hidden_size,
+            device=device,
+            dtype=dtype,
+        )
+        / 10.0
+    )
+    w2_fp = (
+        torch.randn(
+            num_experts,
+            hidden_size,
+            intermediate_size,
+            device=device,
+            dtype=dtype,
+        )
+        / 10.0
+    )
+
+    w1_q, w1_ref, w1_scale = _quantize_moe_weight_int8(w1_fp, GROUP_SIZE)
+    w2_q, w2_ref, w2_scale = _quantize_moe_weight_int8(w2_fp, GROUP_SIZE)
+
+    gating = torch.randn(num_tokens, num_experts, device=device, dtype=torch.float32)
+    topk_weights, topk_ids = torch.topk(torch.softmax(gating, dim=-1), topk, dim=-1)
+    topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+    topk_weights = topk_weights.to(dtype)
+
+    return (
+        hidden_states,
+        w1_q,
+        w2_q,
+        w1_ref,
+        w2_ref,
+        topk_weights,
+        topk_ids,
+        w1_scale,
+        w2_scale,
+    )
+
+
+# -----------------------------------------------------------------------------
+# MXFP4 (E2M1 weight + per-32 E8M0 scale) round-to-nearest quantization.
+# -----------------------------------------------------------------------------
+MXFP4_GROUP_SIZE = 32
+_E2M1_POS = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]
+_E2M1_MID = [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0]
+_E2M1_MAX = 6.0
+
+
+def _quantize_mxfp4(w_2d, group_size):
+    """Round-to-nearest MXFP4. Returns w_ref (dequant), nibbles (uint8 [0,15]),
+    scale_e8m0 (out, in // group_size)."""
+    out_dim, in_dim = w_2d.shape
+    ng = in_dim // group_size
+    device = w_2d.device
+    wg = w_2d.reshape(out_dim, ng, group_size).to(torch.float32)
+    amax = wg.abs().amax(dim=-1, keepdim=True)
+    # E8M0 scale = 2^ceil(log2(amax / 6)) so amax / scale <= 6 (FP4 max).
+    exp = torch.ceil(torch.log2((amax / _E2M1_MAX).clamp(min=1e-30))).clamp(-127, 127)
+    scale = torch.exp2(exp)
+    e8m0_byte = (exp + 127.0).to(torch.uint8)
+    wn = wg / scale
+    sign = wn < 0
+    a = wn.abs().clamp(max=_E2M1_MAX)
+    mag = torch.bucketize(a, torch.tensor(_E2M1_MID, device=device))  # 0..7
+    q = torch.tensor(_E2M1_POS, device=device)[mag]
+    ref = torch.where(sign, -q, q) * scale
+    nibbles = (sign.to(torch.uint8) * 8 + mag.to(torch.uint8)).reshape(out_dim, in_dim)
+    w_ref = ref.reshape(out_dim, in_dim).to(w_2d.dtype)
+    scale_e8m0 = e8m0_byte.squeeze(-1).view(torch.float8_e8m0fnu)
+    return w_ref, nibbles, scale_e8m0
+
+
+def _quantize_moe_weight_mxfp4(w_fp, group_size):
+    """Per-expert MXFP4 in FlagGems layout (packed two nibbles/byte + E8M0 scale)."""
+    E, out_dim, in_dim = w_fp.shape
+    w_q = torch.empty(E, out_dim, in_dim // 2, device=w_fp.device, dtype=torch.uint8)
+    w_ref = torch.empty_like(w_fp)
+    scales = torch.empty(
+        E,
+        out_dim,
+        in_dim // group_size,
+        device=w_fp.device,
+        dtype=torch.float8_e8m0fnu,
+    )
+    for e in range(E):
+        ref_e, nib_e, sc_e = _quantize_mxfp4(w_fp[e], group_size)
+        w_q[e] = nib_e[:, 1::2] * 16 + nib_e[:, ::2]
+        w_ref[e] = ref_e
+        scales[e] = sc_e
+    return w_q, w_ref, scales
+
+
+def _make_inputs_w4a16_mxfp4(
+    num_tokens, num_experts, hidden_size, intermediate_size, topk, dtype, device
+):
+    torch.manual_seed(0)
+    hidden_states = (
+        torch.randn(num_tokens, hidden_size, device=device, dtype=dtype) / 10.0
+    )
+    w1_fp = (
+        torch.randn(
+            num_experts, intermediate_size * 2, hidden_size, device=device, dtype=dtype
+        )
+        / 10.0
+    )
+    w2_fp = (
+        torch.randn(
+            num_experts, hidden_size, intermediate_size, device=device, dtype=dtype
+        )
+        / 10.0
+    )
+    w1_q, w1_ref, w1_scale = _quantize_moe_weight_mxfp4(w1_fp, MXFP4_GROUP_SIZE)
+    w2_q, w2_ref, w2_scale = _quantize_moe_weight_mxfp4(w2_fp, MXFP4_GROUP_SIZE)
+
+    gating = torch.randn(num_tokens, num_experts, device=device, dtype=torch.float32)
+    topk_weights, topk_ids = torch.topk(torch.softmax(gating, dim=-1), topk, dim=-1)
+    topk_weights = (topk_weights / topk_weights.sum(dim=-1, keepdim=True)).to(dtype)
+    return (
+        hidden_states,
+        w1_q,
+        w2_q,
+        w1_ref,
+        w2_ref,
+        topk_weights,
+        topk_ids,
+        w1_scale,
+        w2_scale,
+    )
+
+
+def compute_max_diff(output, output_ref):
+    """vLLM's Marlin accuracy metric (mean relative error), from
+    vllm/tests/kernels/utils.py; test_marlin_gemm.py asserts it < 0.04."""
+    return torch.mean(torch.abs(output - output_ref)) / torch.mean(
+        torch.abs(output_ref)
+    )
+
+
+def _reference_swiglu_moe(
+    hidden_states,
+    w1_ref,
+    w2_ref,
+    topk_weights,
+    topk_ids,
+    apply_router_weight_on_input=False,
+):
+    """fp32 dequant-SwiGLU MoE ground truth (weights cast per-expert to avoid a
+    full fp32 copy of the (E, *, *) tensors)."""
+    M, K = hidden_states.shape
     _, two_N, _ = w1_ref.shape
     N = two_N // 2
     topk = topk_ids.shape[1]
-    out = torch.zeros_like(hidden_states)
+    hs = hidden_states.float()
+    tw = topk_weights.float()
+    out = torch.zeros(M, K, device=hidden_states.device, dtype=torch.float32)
     for m in range(M):
+        x = hs[m]
         for k in range(topk):
             e = topk_ids[m, k].item()
-            w_topk = topk_weights[m, k]
-            x = hidden_states[m]
-            gate_up = w1_ref[e] @ x
+            route_weight = tw[m, k]
+            route_input = route_weight * x if apply_router_weight_on_input else x
+            gate_up = w1_ref[e].float() @ route_input
             gate, up = gate_up[:N], gate_up[N:]
             act = torch.nn.functional.silu(gate) * up
-            y = w2_ref[e] @ act
-            out[m] += w_topk.to(y.dtype) * y
+            y = w2_ref[e].float() @ act
+            out[m] += y if apply_router_weight_on_input else route_weight * y
     return out
 
 
-@pytest.mark.skip(reason="Issue #3441: The operator is not stable.")
-@pytest.mark.parametrize("config", QUICK_CONFIGS)
+@pytest.mark.skipif(
+    not _is_hopper(),
+    reason="W4A16 fast path uses Hopper-only bf16 SIMD PTX (sm_90+)",
+)
+@pytest.mark.parametrize("config", FULL_CONFIGS)
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-def test_fused_marlin_moe_vs_ref(config, dtype):
+@pytest.mark.parametrize("apply_router_weight_on_input", [False, True])
+def test_fused_marlin_moe_w4a16_int4(config, dtype, apply_router_weight_on_input):
     """Compare fused_marlin_moe (packed INT4) against PyTorch reference (dequant)."""
     num_tokens, num_experts, hidden_size, intermediate_size, topk = config
     device = flaggems_vllm.device
 
-    hs, w1_q, w2_q, w1_ref, w2_ref, tw, ti, w1s, w2s = _make_inputs(
+    hs, w1_q, w2_q, w1_ref, w2_ref, tw, ti, w1s, w2s = _make_inputs_w4a16_int4(
         num_tokens,
         num_experts,
         hidden_size,
@@ -261,13 +534,95 @@ def test_fused_marlin_moe_vs_ref(config, dtype):
         topk_weights=tw,
         topk_ids=ti,
         quant_type_id=QUANT_TYPE_UINT4B8,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+    )
+    ref = _reference_swiglu_moe(
+        hs,
+        w1_ref,
+        w2_ref,
+        tw,
+        ti,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+    )
+    torch.cuda.synchronize()
+
+    max_diff = compute_max_diff(result.float(), ref)
+    assert max_diff < 0.04, f"max_diff={max_diff:.4f}"
+
+
+@pytest.mark.parametrize("config", QUICK_CONFIGS)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_fused_marlin_moe_w8a16_int8(config, dtype):
+    """Compare fused_marlin_moe (unpacked INT8) against PyTorch reference (dequant)."""
+    num_tokens, num_experts, hidden_size, intermediate_size, topk = config
+    device = flaggems_vllm.device
+
+    hs, w1_q, w2_q, w1_ref, w2_ref, tw, ti, w1s, w2s = _make_inputs_w8a16_int8(
+        num_tokens,
+        num_experts,
+        hidden_size,
+        intermediate_size,
+        topk,
+        dtype,
+        device,
+    )
+    result = fused_marlin_moe(
+        hidden_states=hs,
+        w1=w1_q,
+        w2=w2_q,
+        bias1=None,
+        bias2=None,
+        w1_scale=w1s,
+        w2_scale=w2s,
+        topk_weights=tw,
+        topk_ids=ti,
+        quant_type_id=QUANT_TYPE_UINT8B128,
+    )
+    ref = _reference_swiglu_moe(hs, w1_ref, w2_ref, tw, ti)
+    torch.cuda.synchronize()
+    # INT8 should be tighter than INT4; same vLLM Marlin metric.
+    max_diff = compute_max_diff(result.float(), ref)
+    assert max_diff < 0.04, f"max_diff={max_diff:.4f}"
+
+
+@pytest.mark.skipif(
+    not _is_hopper(),
+    reason="MXFP4 fast path uses Hopper-only bf16/fp16 SIMD PTX (sm_90+)",
+)
+@pytest.mark.parametrize("config", FULL_CONFIGS)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_fused_marlin_moe_w4a16_mxfp4(config, dtype):
+    """Compare fused_marlin_moe (MXFP4) against PyTorch reference (dequant)."""
+    num_tokens, num_experts, hidden_size, intermediate_size, topk = config
+    device = flaggems_vllm.device
+
+    hs, w1_q, w2_q, w1_ref, w2_ref, tw, ti, w1s, w2s = _make_inputs_w4a16_mxfp4(
+        num_tokens,
+        num_experts,
+        hidden_size,
+        intermediate_size,
+        topk,
+        dtype,
+        device,
+    )
+    result = fused_marlin_moe(
+        hidden_states=hs,
+        w1=w1_q,
+        w2=w2_q,
+        bias1=None,
+        bias2=None,
+        w1_scale=w1s,
+        w2_scale=w2s,
+        topk_weights=tw,
+        topk_ids=ti,
+        quant_type_id=QUANT_TYPE_FP4_E2M1,
+        group_size=MXFP4_GROUP_SIZE,
     )
     ref = _reference_swiglu_moe(hs, w1_ref, w2_ref, tw, ti)
     torch.cuda.synchronize()
 
-    rtol = 1e-1
-    atol = max(5e-2, ref.abs().max().item() * 1e-3)
-    torch.testing.assert_close(result, ref, rtol=rtol, atol=atol)
+    max_diff = compute_max_diff(result.float(), ref)
+    assert max_diff < 0.04, f"max_diff={max_diff:.4f}"
 
 
 # -----------------------------------------------------------------------------
@@ -275,10 +630,10 @@ def test_fused_marlin_moe_vs_ref(config, dtype):
 # -----------------------------------------------------------------------------
 
 
-def _minimal_args(device="cuda", dtype=torch.bfloat16):
+def _minimal_args(device=flaggems_vllm.device, dtype=torch.bfloat16):
     """Smallest valid arg bundle, used to probe rejection paths."""
     M, K, N, E, topk = 4, 128, 256, 4, 2
-    return _make_inputs(M, E, K, N, topk, dtype, device)
+    return _make_inputs_w4a16_int4(M, E, K, N, topk, dtype, device)
 
 
 def test_rejects_unsupported_quant_type():


### PR DESCRIPTION
Sync flagos-ai/FlagGems#5437: standardize W4A16 INT4/MXFP4 naming, split per-precision benchmarks, and wire INT4 kernels into flagtune with H20-tuned config spaces.

### PR Category
Operator | OP Test | Benchmark

### Type of Change
Refactor

### Issue

N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

No perf impact expected (identifier-only rename). Verified on H20 (sm90): 119 unit tests collected, per-precision subset + guard tests all pass; renamed tune keys load correctly via libtuner.