### PR TITLE
Allow maintainers to opt fork PRs into H20 via ci/nvidia label

### DIFF
--- a/.github/MULTI_BACKEND_CI.md
+++ b/.github/MULTI_BACKEND_CI.md
@@ -15,6 +15,10 @@ benchmark merely because FlagGems can create its vendor environment.
   deliberate maintainer-approved validation run.
 - `ci/benchmark` enables the selected core benchmarks. Benchmarks also run on
   `main` pushes or when `run_benchmarks` is selected in `workflow_dispatch`.
+- `ci/nvidia` opts a fork pull request into the persistent H20 nvidia lane.
+  Only repository collaborators with write access can add the label; treat it
+  as an explicit maintainer trust decision before running fork-controlled
+  code on H20. Same-repository pull requests do not need this label.
 - `workflow_dispatch` can select all non-NVIDIA backends with
   `run_non_nvidia`; it also runs the H20 preflight/baseline so the result has
   a known reference lane.
@@ -23,7 +27,8 @@ benchmark merely because FlagGems can create its vendor environment.
   has passed its individual validation.
 - Fork pull requests may enter selected non-NVIDIA self-hosted jobs without a
   per-run maintainer gate. H20 remains restricted to same-repository pull
-  requests, and Dependabot pull requests remain excluded.
+  requests by default, or to fork pull requests labeled `ci/nvidia`.
+  Dependabot pull requests remain excluded.
 - Treat every file in a fork checkout as arbitrary code, including workflow
   files, local actions, package build hooks, setup scripts, and tests. Every
   non-NVIDIA runner exposed to this public repository must therefore be a
@@ -53,6 +58,7 @@ vendor/Thead
 vendor/TsingMicro
 ci/all-vendors
 ci/benchmark
+ci/nvidia
 ```
 
 `vendor/Thead` follows the backend registry exactly; do not use

--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -215,12 +215,15 @@ jobs:
   nvidia-tests:
     name: nvidia tests and benchmarks
     needs: select-targets
-    # Never execute fork-controlled code on the persistent H20 runner.
+    # Default: never execute fork-controlled code on the persistent H20 runner.
+    # Maintainers may opt in a fork PR with the write-gated `ci/nvidia` label
+    # (same trust model as `ci/benchmark` / `ci/all-vendors`).
     if: >-
       needs.select-targets.outputs.should_run == 'true'
       && (github.event_name != 'pull_request'
-          || (github.event.pull_request.head.repo.full_name == github.repository
-              && github.event.pull_request.user.login != 'dependabot[bot]'))
+          || (github.event.pull_request.user.login != 'dependabot[bot]'
+              && (github.event.pull_request.head.repo.full_name == github.repository
+                  || contains(github.event.pull_request.labels.*.name, 'ci/nvidia'))))
     runs-on: h20
     timeout-minutes: 60
     env:
@@ -331,8 +334,9 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           NVIDIA_RUN_ALLOWED: >-
             ${{ github.event_name != 'pull_request'
-                || (github.event.pull_request.head.repo.full_name == github.repository
-                    && github.event.pull_request.user.login != 'dependabot[bot]') }}
+                || (github.event.pull_request.user.login != 'dependabot[bot]'
+                    && (github.event.pull_request.head.repo.full_name == github.repository
+                        || contains(github.event.pull_request.labels.*.name, 'ci/nvidia'))) }}
           NON_NVIDIA_RUN_ALLOWED: >-
             ${{ github.event_name != 'pull_request'
                 || github.event.pull_request.user.login != 'dependabot[bot]' }}

--- a/tools/test_ci_helpers.py
+++ b/tools/test_ci_helpers.py
@@ -582,6 +582,9 @@ class CiWorkflowPolicyTest(unittest.TestCase):
         repository_guard = (
             "github.event.pull_request.head.repo.full_name == github.repository"
         )
+        nvidia_label_opt_in = (
+            "contains(github.event.pull_request.labels.*.name, 'ci/nvidia')"
+        )
         nvidia_job = workflow.split("  nvidia-tests:", maxsplit=1)[1].split(
             "  non-nvidia-tests:", maxsplit=1
         )[0]
@@ -590,7 +593,9 @@ class CiWorkflowPolicyTest(unittest.TestCase):
         )[0]
 
         self.assertIn(repository_guard, nvidia_job)
+        self.assertIn(nvidia_label_opt_in, nvidia_job)
         self.assertNotIn(repository_guard, non_nvidia_job)
+        self.assertNotIn(nvidia_label_opt_in, non_nvidia_job)
         self.assertIn(author_guard, nvidia_job)
         self.assertIn(author_guard, non_nvidia_job)
         self.assertNotIn("github.actor != 'dependabot[bot]'", workflow)


### PR DESCRIPTION
## Summary
- Keep the default ban on running fork-controlled code on the persistent H20 runner.
- Add write-gated label `ci/nvidia` so maintainers can explicitly opt a fork PR into the nvidia tests lane (same trust model as `ci/benchmark` / `ci/all-vendors`).
- Mirror the gate in `multi-backend-summary` and document the label.

## Usage
On a fork PR: add label `ci/nvidia` (triggers `labeled` → re-run). Add `ci/benchmark` as well if performance benches are needed.

## Test plan
- [x] `python -m unittest discover -s tools -p 'test_ci_*.py'`
- [ ] Merge, then label a fork PR with `ci/nvidia` and confirm nvidia job runs instead of skip
