### PR TITLE
[KMCompiler][bugfix] triton.language.math has no attribute 'pow'

### DIFF
--- a/src/flaggems_vllm/runtime/backend/_ascend/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_ascend/__init__.py
@@ -14,12 +14,26 @@
 
 from backend_utils import VendorDescriptor
 
+
+def get_triton_extra_name():
+    try:
+        import triton
+        from packaging import version
+
+        if version.parse(triton.__version__) < version.parse("3.2.0"):
+            return "ascend"
+        else:
+            return "cann"
+    except Exception:
+        return "ascend"
+
+
 vendor_info = VendorDescriptor(
     vendor_name="ascend",
     device_name="npu",
     device_query_cmd="npu-smi info",
     dispatch_key="PrivateUse1",
-    triton_extra_name="ascend",
+    triton_extra_name=get_triton_extra_name(),
     fp64_enabled=False,
 )
 


### PR DESCRIPTION
<!--
 Copyright 2026 FlagOS Contributors

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->

### PR Category
 Operator

### Type of Change
Bug Fix

### Description
When executing FlagGems-vllm functional test commands on the Ascend platform, for example pytest -sv tests/test_per_token_quant_fp8.py, the following error message appears:
```
ImportError while loading conftest '/workspace/AI/FlagGems-vllm/tests/conftest.py'.
tests/conftest.py:27: in <module>
    import flaggems_vllm
src/flaggems_vllm/__init__.py:21: in <module>
    import flaggems_vllm.ops as _ops_module
src/flaggems_vllm/ops/__init__.py:68: in <module>
    from flaggems_vllm.ops.geglu import dgeglu, geglu
src/flaggems_vllm/ops/geglu.py:26: in <module>
    pow = tl_extra_shim.pow
E   AttributeError: module 'triton.language.math' has no attribute 'pow'

``` 
The root cause of this error does not lie in the per_token_group_quant_fp8 test itself, but in the fact that the flaggems_vllm package already crashes during the import phase. In the \_\_init\_\_.py file of the _ascend backend, triton_extra_name is hardcoded to "ascend". When the Triton version used by FlagGems-vllm is greater than 3.2, the Ascend math library directory has been renamed to cann, causing libdevice to fail loading. The get_triton_extra_name function was ported from FlagGems to index the math library name according to the Triton version.


### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
