### PR TITLE
absolute import

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,4 +25,5 @@
 /tools/select_backends.py @huangyiqun @0x45f
 /tools/select_tests.py @huangyiqun @0x45f
 /tools/setup.sh @huangyiqun @0x45f
+/tools/test_ci_absolute_imports.py @huangyiqun @0x45f
 /tools/test_ci_helpers.py @huangyiqun @0x45f

--- a/.github/MULTI_BACKEND_CI.md
+++ b/.github/MULTI_BACKEND_CI.md
@@ -8,9 +8,11 @@ benchmark merely because FlagGems can create its vendor environment.
 
 - Pull requests select a non-NVIDIA backend either through the exact `label`
   values in FlagGems' pinned `.github/backends.json` or by changing a path
-  under `src/flaggems_vllm/runtime/backend/_<vendor>/`. Path inference lets a
-  fork test the backend implementation it changes without waiting for a
-  maintainer to add a routing label.
+  under `src/flaggems_vllm/runtime/backend/_<vendor>/`. Automatic path
+  inference is limited to profiles with `auto_select: true` in the local
+  capability policy, so a runner/profile must pass explicit bring-up before
+  becoming an automatic required check. An exact vendor label still schedules
+  an unvalidated profile for an explicit bring-up or revalidation run.
 - `ci/all-vendors` selects every enabled non-NVIDIA backend. Use it only for a
   deliberate maintainer-approved validation run.
 - Pull requests run correctness tests only. Selected core benchmarks run on
@@ -46,6 +48,7 @@ The repository must provide these labels (spelling and case are significant):
 
 ```text
 vendor/Ascend
+vendor/Cambricon
 vendor/Enflame
 vendor/Hygon
 vendor/Iluvatar
@@ -54,26 +57,32 @@ vendor/MetaX
 vendor/MooreThreads
 vendor/SpaceMit
 vendor/Sunrise
-vendor/Thead
+vendor/THead
 vendor/TsingMicro
 ci/all-vendors
 ci/nvidia
 ```
 
-`vendor/Thead` follows the backend registry exactly; do not use
-`vendor/THead`.
+`vendor/THead` follows the backend registry exactly; do not use
+`vendor/Thead`.
 
 ## Capability rollout
 
-`.github/backend-capabilities.json` is fail closed. Unknown backends receive an
-empty operator allowlist and cannot run benchmarks. The setup action still runs
-`tools/check_backend_env.py`, which verifies imports, the configured vendor,
-device discovery, and a small float32 allocation/addition.
+`.github/backend-capabilities.json` is fail closed. Unknown backends are not
+automatically selected by backend source-path changes, receive an empty
+operator allowlist, and cannot run benchmarks. Exact vendor labels,
+`ci/all-vendors`, and the explicit all-backend workflow dispatch bypass only
+the automatic-selection gate; the setup and portable preflight remain
+mandatory. The setup action runs `tools/check_backend_env.py`, which verifies
+imports, the configured vendor, device discovery, and a small float32
+allocation/addition.
 
-After a backend passes the preflight on a trusted same-repository branch, add
-only tests confirmed on that hardware to its `tests_allow` list. Enable and
-allowlist benchmarks separately after correctness is stable. The NVIDIA H20
-profile is the only initial `allow_all_tests` profile.
+After a backend passes the preflight on a trusted same-repository branch, set
+`auto_select: true` and add only tests confirmed on that hardware to its
+`tests_allow` list. Enable and allowlist benchmarks separately after
+correctness is stable. Automatic selection also requires the self-hosted
+runner to satisfy the disposable/no-secrets trust boundary described below.
+The NVIDIA H20 profile is the only initial `allow_all_tests` profile.
 
 `iluvatar` currently allows only `tests/test_mul.py` so PR #50 can provide its
 first hardware validation; a failure must be fixed or the candidate removed,
@@ -99,8 +108,9 @@ FlagGems remains the source of truth for backend profiles and runner routing:
    `$GITHUB_WORKSPACE/.ci/flaggems`, and the physical vendor environment at
    `$GITHUB_WORKSPACE/.ci/flaggems/.venv`; a root `.venv` symlink exists only
    for compatibility with the reusable workflow.
-4. `.github/backend-capabilities.json` records only the FlagGems-vllm tests
-   proven on each backend. It is not a second backend registry.
+4. `.github/backend-capabilities.json` records automatic-routing readiness and
+   the FlagGems-vllm tests proven on each backend. It is not a second backend
+   registry.
 
 Do not add a hand-maintained vendor matrix or copy vendor setup scripts into
 FlagGems-vllm. Add or change a backend in FlagGems first, then advance all

--- a/.github/actions/setup-flaggems/action.yml
+++ b/.github/actions/setup-flaggems/action.yml
@@ -27,7 +27,7 @@ runs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: flagos-ai/FlagGems
-        ref: b10f1d47401b2df7166ac0aff8958128338ed237
+        ref: 42d396ff8270f7b051f478217929f75484e53ef4
         path: .ci/flaggems
         persist-credentials: false
 

--- a/.github/backend-capabilities.json
+++ b/.github/backend-capabilities.json
@@ -53,9 +53,6 @@
       "benchmarks_enabled": true,
       "allow_all_benchmarks": true
     },
-    "thead": {
-      "auto_select": true
-    },
     "tsingmicro": {
       "auto_select": true
     }

--- a/.github/backend-capabilities.json
+++ b/.github/backend-capabilities.json
@@ -1,6 +1,7 @@
 {
   "schema_version": 1,
   "defaults": {
+    "auto_select": false,
     "allow_all_tests": false,
     "tests_allow": [],
     "benchmarks_enabled": false,
@@ -8,10 +9,25 @@
     "benchmarks_allow": []
   },
   "backends": {
+    "ascend-cann850": {
+      "auto_select": true
+    },
+    "ascend-cann900": {
+      "auto_select": true
+    },
+    "hygon": {
+      "auto_select": true
+    },
     "iluvatar": {
       "tests_allow": [
         "tests/test_mul.py"
       ]
+    },
+    "metax-maca3720": {
+      "auto_select": true
+    },
+    "metax-maca3810": {
+      "auto_select": true
     },
     "mthreads-musa520": {
       "tests_allow": [
@@ -36,6 +52,12 @@
       "allow_all_tests": true,
       "benchmarks_enabled": true,
       "allow_all_benchmarks": true
+    },
+    "thead": {
+      "auto_select": true
+    },
+    "tsingmicro": {
+      "auto_select": true
     }
   }
 }

--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -202,6 +202,7 @@ jobs:
           set -euo pipefail
           args=(
             --registry .ci/flaggems-registry/.github/backends.json
+            --capabilities .github/backend-capabilities.json
             --labels-json "${PR_LABELS_JSON:-null}"
             --changed-files changed_files.bin
             --format github

--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -182,7 +182,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: flagos-ai/FlagGems
-          ref: b10f1d47401b2df7166ac0aff8958128338ed237
+          ref: 42d396ff8270f7b051f478217929f75484e53ef4
           sparse-checkout: .github/backends.json
           sparse-checkout-cone-mode: false
           path: .ci/flaggems-registry
@@ -297,7 +297,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.select-targets.outputs.non_nvidia_matrix) }}
-    uses: flagos-ai/FlagGems/.github/workflows/backend-test.yaml@b10f1d47401b2df7166ac0aff8958128338ed237
+    uses: flagos-ai/FlagGems/.github/workflows/backend-test.yaml@42d396ff8270f7b051f478217929f75484e53ef4
     with:
       backend: ${{ matrix.backend }}
       runner_label: ${{ matrix.runner_label }}

--- a/src/flaggems_vllm/ops/FLA/chunk_gdn2.py
+++ b/src/flaggems_vllm/ops/FLA/chunk_gdn2.py
@@ -32,12 +32,12 @@ import torch.nn.functional as F
 import triton
 import triton.language as tl
 
+from flaggems_vllm.ops.FLA.gdn2_native.chunk_fwd import chunk_gdn2_fwd
+
 # 此仓库的pre index的入口参数没有BT，不支持varlen
 from flaggems_vllm.ops.FLA.index import prepare_chunk_indices, prepare_chunk_offsets
 from flaggems_vllm.ops.FLA.triton_ops_helper import autotune_cache_kwargs, exp2
 from flaggems_vllm.utils.triton_version_utils import has_triton_tle
-
-from .gdn2_native.chunk_fwd import chunk_gdn2_fwd
 
 LN2 = 0.6931471805599453
 RCP_LN2 = 1.4426950408889634

--- a/src/flaggems_vllm/ops/FLA/gdn2_native/chunk_fwd.py
+++ b/src/flaggems_vllm/ops/FLA/gdn2_native/chunk_fwd.py
@@ -12,9 +12,8 @@ import torch
 from flaggems_vllm.ops.FLA.chunk_delta_h import chunk_gated_delta_rule_fwd_h
 from flaggems_vllm.ops.FLA.chunk_gla import chunk_gla_fwd_o_gk
 from flaggems_vllm.ops.FLA.cumsum import chunk_local_cumsum
-
-from .chunk_intra import chunk_gdn2_fwd_intra
-from .gate import kda_gate_chunk_cumsum
+from flaggems_vllm.ops.FLA.gdn2_native.chunk_intra import chunk_gdn2_fwd_intra
+from flaggems_vllm.ops.FLA.gdn2_native.gate import kda_gate_chunk_cumsum
 
 LN2 = 0.6931471805599453
 RCP_LN2 = 1.4426950408889634

--- a/src/flaggems_vllm/ops/FLA/gdn2_native/chunk_intra.py
+++ b/src/flaggems_vllm/ops/FLA/gdn2_native/chunk_intra.py
@@ -24,11 +24,12 @@ import torch
 import triton
 import triton.language as tl
 
+from flaggems_vllm.ops.FLA.gdn2_native.chunk_intra_token_parallel import (
+    chunk_gdn2_fwd_intra_token_parallel,
+)
+from flaggems_vllm.ops.FLA.gdn2_native.wy_fast import recompute_w_u_fwd_gdn2
 from flaggems_vllm.ops.FLA.index import prepare_chunk_indices
 from flaggems_vllm.ops.FLA.triton_ops_helper import autotune_cache_kwargs, exp2
-
-from .chunk_intra_token_parallel import chunk_gdn2_fwd_intra_token_parallel
-from .wy_fast import recompute_w_u_fwd_gdn2
 
 IS_TF32_SUPPORTED = (
     torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 8

--- a/src/flaggems_vllm/runtime/backend/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/__init__.py
@@ -17,12 +17,23 @@ import functools
 import importlib
 import inspect
 import os
-import sys
 from pathlib import Path
 
 from ..common import vendors
 from . import backend_utils
 from .backend_utils import BackendEventBase
+
+_BACKEND_PACKAGE = __name__
+
+
+def _get_vendor_module_name(vendor_name):
+    """Return the package-qualified module name for a vendor backend."""
+    if not vendor_name:
+        raise ValueError("vendor_name is required")
+    vendor_module_name = vendor_name.rsplit(".", 1)[-1]
+    if not vendor_module_name.startswith("_"):
+        vendor_module_name = "_" + vendor_module_name
+    return f"{_BACKEND_PACKAGE}.{vendor_module_name}"
 
 
 class BackendState:
@@ -111,11 +122,7 @@ class TritonVersionEvent(BackendEventBase):
 
     def get_version_spec_module(self):
         module_name = f"triton_{self.version}"
-        path_dir = os.path.dirname(self.dir)
-        sys.path.insert(0, str(path_dir))
-        version_module = importlib.import_module(module_name)
-        sys.path.remove(str(path_dir))
-        return version_module
+        return importlib.import_module(f"{_state.vendor_module.__name__}.{module_name}")
 
     def get_ops(self, *args, **kwargs):
         return self.get_version_ops()
@@ -167,9 +174,11 @@ class BackendArchEvent(BackendEventBase):
         try:
             heuristic_module = self.arch_module
         except Exception:  # noqa E722
-            sys.path.insert(0, str(self.current_arch_path))
-            heuristic_module = importlib.import_module("heuristics_config_utils")
-            sys.path.remove(str(self.current_arch_path))
+            module_name = (
+                f"{_state.vendor_module.__name__}.{self.arch}."
+                "heuristics_config_utils"
+            )
+            heuristic_module = importlib.import_module(module_name)
         return getattr(heuristic_module, "HEURISTICS_CONFIGS", None)
 
     def get_autotune_configs(self):
@@ -213,11 +222,8 @@ class BackendArchEvent(BackendEventBase):
 
     def get_arch_module(self):
         """Load backend.<arch>"""
-        path_dir = os.path.dirname(self.current_arch_path)
-        sys.path.insert(0, str(path_dir))
-        current_arch_module = importlib.import_module(self.arch)
-        sys.path.remove(str(path_dir))
-        return current_arch_module
+        module_name = f"{_state.vendor_module.__name__}.{self.arch}"
+        return importlib.import_module(module_name)
 
     def get_ops(self, *args, **kwargs):
         """Provide a unified interface for the upper layer"""
@@ -225,15 +231,14 @@ class BackendArchEvent(BackendEventBase):
 
     def get_arch_ops(self):
         arch_specialized_ops = []
-        sys.path.append(self.current_arch_path)
         ops_module = getattr(self.arch_module, "ops", None)
+        module_name = f"{self.arch_module.__name__}.ops"
         try:
             if ops_module is None:
-                ops_module = importlib.import_module(f"{self.arch}.ops")
+                ops_module = importlib.import_module(module_name)
         except Exception:
             try:
-                sys.path.append(self.current_arch_path)
-                ops_module = importlib.import_module(f"{self.arch}.ops")
+                ops_module = importlib.import_module(module_name)
                 arch_specialized_ops.extend(self.get_functions_from_module(ops_module))
             except Exception as err_msg:
                 self.error_msgs.append(err_msg)
@@ -280,11 +285,16 @@ def _import_module_safe(module_name, vendor_name, module_type):
 def import_vendor_extra_lib(vendor_name=None):
     if _state.vendor_extra_lib_imported:
         return
+    vendor_module_name = (
+        _state.vendor_module.__name__
+        if vendor_name is None and _state.vendor_module is not None
+        else _get_vendor_module_name(vendor_name)
+    )
     _state.ops_module = _import_module_safe(
-        f"_{vendor_name}.ops", vendor_name, "common"
+        f"{vendor_module_name}.ops", vendor_name, "common"
     )
     _state.fused_module = _import_module_safe(
-        f"_{vendor_name}.fused", vendor_name, "fused"
+        f"{vendor_module_name}.fused", vendor_name, "fused"
     )
     _state.vendor_extra_lib_imported = True
 
@@ -375,20 +385,17 @@ fn = torch.{_state.device_name}
 
 
 def get_vendor_module(vendor_name, query=False):
-    def get_module(vendor_name):
-        current_file_path = os.path.abspath(__file__)
-        current_dir_path = os.path.dirname(current_file_path)
-        sys.path.append(current_dir_path)
-        return importlib.import_module(vendor_name)
+    if not query and _state.vendor_module is not None:
+        return _state.vendor_module
 
+    module_name = _get_vendor_module_name(vendor_name)
     if query:
         # The query path returns the requested vendor module directly.
-        return get_module(vendor_name)
+        return importlib.import_module(module_name)
 
     global vendor_module
-    if _state.vendor_module is None:
-        _state.vendor_module = get_module("_" + vendor_name)
-        vendor_module = _state.vendor_module
+    _state.vendor_module = importlib.import_module(module_name)
+    vendor_module = _state.vendor_module
     return _state.vendor_module
 
 
@@ -451,7 +458,7 @@ def get_heuristic_config(vendor_name=None):
     global heuristic_config_module
     config_name = "heuristics_config_utils"
     vendor_name = vendor_name or "nvidia"
-    mod_name = f"_{vendor_name}.{config_name}"
+    mod_name = f"{_get_vendor_module_name(vendor_name)}.{config_name}"
     _state.heuristic_config_module = importlib.import_module(mod_name)
     heuristic_config_module = _state.heuristic_config_module
     return getattr(_state.heuristic_config_module, "HEURISTICS_CONFIGS", None)

--- a/src/flaggems_vllm/runtime/backend/_aipu/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_aipu/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from backend_utils import VendorDescriptor
+from flaggems_vllm.runtime.backend.backend_utils import VendorDescriptor
 
 vendor_info = VendorDescriptor(
     vendor_name="aipu",

--- a/src/flaggems_vllm/runtime/backend/_amd/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_amd/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from backend_utils import VendorDescriptor
+from flaggems_vllm.runtime.backend.backend_utils import VendorDescriptor
 
 vendor_info = VendorDescriptor(
     vendor_name="amd",

--- a/src/flaggems_vllm/runtime/backend/_arm/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_arm/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from backend_utils import VendorDescriptor
+from flaggems_vllm.runtime.backend.backend_utils import VendorDescriptor
 
 vendor_info = VendorDescriptor(
     vendor_name="arm",

--- a/src/flaggems_vllm/runtime/backend/_ascend/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_ascend/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from backend_utils import VendorDescriptor
+from flaggems_vllm.runtime.backend.backend_utils import VendorDescriptor
 
 
 def get_triton_extra_name():

--- a/src/flaggems_vllm/runtime/backend/_ascend/ops/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_ascend/ops/__init__.py
@@ -13,8 +13,14 @@
 # limitations under the License.
 
 
-from .fused_moe import fused_experts_impl, inplace_fused_experts, outplace_fused_experts
-from .scaled_int8_quant import scaled_int8_quant
+from flaggems_vllm.runtime.backend._ascend.ops.fused_moe import (
+    fused_experts_impl,
+    inplace_fused_experts,
+    outplace_fused_experts,
+)
+from flaggems_vllm.runtime.backend._ascend.ops.scaled_int8_quant import (
+    scaled_int8_quant,
+)
 
 __all__ = [
     "fused_experts_impl",

--- a/src/flaggems_vllm/runtime/backend/_cambricon/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_cambricon/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from backend_utils import VendorDescriptor
+from flaggems_vllm.runtime.backend.backend_utils import VendorDescriptor
 
 vendor_info = VendorDescriptor(
     vendor_name="cambricon",

--- a/src/flaggems_vllm/runtime/backend/_enflame/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_enflame/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from backend_utils import VendorDescriptor
+from flaggems_vllm.runtime.backend.backend_utils import VendorDescriptor
 
 vendor_info = VendorDescriptor(
     vendor_name="enflame",

--- a/src/flaggems_vllm/runtime/backend/_enflame/ops/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_enflame/ops/__init__.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
-from .scaled_int8_quant import scaled_int8_quant
+from flaggems_vllm.runtime.backend._enflame.ops.scaled_int8_quant import (
+    scaled_int8_quant,
+)
 
 __all__ = ["scaled_int8_quant"]

--- a/src/flaggems_vllm/runtime/backend/_hygon/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_hygon/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from backend_utils import VendorDescriptor
+from flaggems_vllm.runtime.backend.backend_utils import VendorDescriptor
 
 vendor_info = VendorDescriptor(
     vendor_name="hygon",

--- a/src/flaggems_vllm/runtime/backend/_hygon/ops/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_hygon/ops/__init__.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .fused_moe import (  # noqa: F401
+from flaggems_vllm.runtime.backend._hygon.ops.fused_moe import (  # noqa: F401
     fused_experts_impl,
     inplace_fused_experts,
     outplace_fused_experts,
 )
-from .per_token_group_quant_fp8 import SUPPORTED_FP8_DTYPE, per_token_group_quant_fp8
-from .scaled_int8_quant import scaled_int8_quant
-from .triton_scaled_mm import triton_scaled_mm
+from flaggems_vllm.runtime.backend._hygon.ops.per_token_group_quant_fp8 import (
+    SUPPORTED_FP8_DTYPE,
+    per_token_group_quant_fp8,
+)
+from flaggems_vllm.runtime.backend._hygon.ops.scaled_int8_quant import scaled_int8_quant
+from flaggems_vllm.runtime.backend._hygon.ops.triton_scaled_mm import triton_scaled_mm
 
 __all__ = [
     "SUPPORTED_FP8_DTYPE",

--- a/src/flaggems_vllm/runtime/backend/_iluvatar/ops/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_iluvatar/ops/__init__.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
-from .scaled_int8_quant import scaled_int8_quant
+from flaggems_vllm.runtime.backend._iluvatar.ops.scaled_int8_quant import (
+    scaled_int8_quant,
+)
 
 __all__ = ["scaled_int8_quant"]

--- a/src/flaggems_vllm/runtime/backend/_kunlunxin/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_kunlunxin/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from backend_utils import VendorDescriptor
+from flaggems_vllm.runtime.backend.backend_utils import VendorDescriptor
 
 vendor_info = VendorDescriptor(
     vendor_name="kunlunxin",

--- a/src/flaggems_vllm/runtime/backend/_kunlunxin/ops/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_kunlunxin/ops/__init__.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
-from .scaled_int8_quant import scaled_int8_quant
+from flaggems_vllm.runtime.backend._kunlunxin.ops.scaled_int8_quant import (
+    scaled_int8_quant,
+)
 
 __all__ = ["scaled_int8_quant"]

--- a/src/flaggems_vllm/runtime/backend/_metax/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from backend_utils import VendorDescriptor
+from flaggems_vllm.runtime.backend.backend_utils import VendorDescriptor
 
 vendor_info = VendorDescriptor(
     vendor_name="metax",

--- a/src/flaggems_vllm/runtime/backend/_metax/fused/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/fused/__init__.py
@@ -3,8 +3,14 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 
-from .fused_moe import fused_experts_impl, inplace_fused_experts, outplace_fused_experts
-from .gdn_chunk import chunk_gated_delta_rule_fwd
+from flaggems_vllm.runtime.backend._metax.fused.fused_moe import (
+    fused_experts_impl,
+    inplace_fused_experts,
+    outplace_fused_experts,
+)
+from flaggems_vllm.runtime.backend._metax.fused.gdn_chunk import (
+    chunk_gated_delta_rule_fwd,
+)
 
 __all__ = [
     "fused_experts_impl",

--- a/src/flaggems_vllm/runtime/backend/_metax/fused/fused_moe.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/fused/fused_moe.py
@@ -7,8 +7,7 @@ import contextlib
 import threading
 
 import flaggems_vllm.ops.fused_moe as generic_fused_moe
-
-from .moe_sum import moe_sum as metax_moe_sum
+from flaggems_vllm.runtime.backend._metax.fused.moe_sum import moe_sum as metax_moe_sum
 
 _PATCH_LOCK = threading.RLock()
 _GENERIC_GET_DEFAULT_CONFIG = generic_fused_moe.get_default_config

--- a/src/flaggems_vllm/runtime/backend/_metax/ops/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/ops/__init__.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .per_token_group_quant_fp8 import SUPPORTED_FP8_DTYPE, per_token_group_quant_fp8
-from .scaled_int8_quant import scaled_int8_quant
+from flaggems_vllm.runtime.backend._metax.ops.per_token_group_quant_fp8 import (
+    SUPPORTED_FP8_DTYPE,
+    per_token_group_quant_fp8,
+)
+from flaggems_vllm.runtime.backend._metax.ops.scaled_int8_quant import scaled_int8_quant
 
 __all__ = [
     "SUPPORTED_FP8_DTYPE",

--- a/src/flaggems_vllm/runtime/backend/_mthreads/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_mthreads/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from backend_utils import VendorDescriptor
+from flaggems_vllm.runtime.backend.backend_utils import VendorDescriptor
 
 vendor_info = VendorDescriptor(
     vendor_name="mthreads",

--- a/src/flaggems_vllm/runtime/backend/_mthreads/fused/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_mthreads/fused/__init__.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .fused_moe import fused_experts_impl, inplace_fused_experts, outplace_fused_experts
+from flaggems_vllm.runtime.backend._mthreads.fused.fused_moe import (
+    fused_experts_impl,
+    inplace_fused_experts,
+    outplace_fused_experts,
+)
 
 __all__ = [
     "fused_experts_impl",

--- a/src/flaggems_vllm/runtime/backend/_mthreads/fused/fused_moe.py
+++ b/src/flaggems_vllm/runtime/backend/_mthreads/fused/fused_moe.py
@@ -17,8 +17,9 @@ import threading
 from typing import Any
 
 import flaggems_vllm.ops.fused_moe as generic_fused_moe
-
-from .moe_sum import moe_sum as mthreads_moe_sum
+from flaggems_vllm.runtime.backend._mthreads.fused.moe_sum import (
+    moe_sum as mthreads_moe_sum,
+)
 
 _PATCH_LOCK = threading.RLock()
 _GENERIC_GET_DEFAULT_CONFIG = generic_fused_moe.get_default_config

--- a/src/flaggems_vllm/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_mthreads/ops/__init__.py
@@ -12,8 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .per_token_group_quant_fp8 import SUPPORTED_FP8_DTYPE, per_token_group_quant_fp8
-from .scaled_int8_quant import scaled_int8_quant
+from flaggems_vllm.runtime.backend._mthreads.ops.per_token_group_quant_fp8 import (
+    SUPPORTED_FP8_DTYPE,
+    per_token_group_quant_fp8,
+)
+from flaggems_vllm.runtime.backend._mthreads.ops.scaled_int8_quant import (
+    scaled_int8_quant,
+)
 
 __all__ = [
     "SUPPORTED_FP8_DTYPE",

--- a/src/flaggems_vllm/runtime/backend/_nvidia/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_nvidia/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from backend_utils import VendorDescriptor  # noqa: E402
+from flaggems_vllm.runtime.backend.backend_utils import VendorDescriptor
 
 vendor_info = VendorDescriptor(
     vendor_name="nvidia",

--- a/src/flaggems_vllm/runtime/backend/_spacemit/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_spacemit/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from backend_utils import VendorDescriptor
+from flaggems_vllm.runtime.backend.backend_utils import VendorDescriptor
 
 vendor_info = VendorDescriptor(
     vendor_name="spacemit",

--- a/src/flaggems_vllm/runtime/backend/_sunrise/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_sunrise/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from backend_utils import VendorDescriptor
+from flaggems_vllm.runtime.backend.backend_utils import VendorDescriptor
 
 vendor_info = VendorDescriptor(
     vendor_name="sunrise",

--- a/src/flaggems_vllm/runtime/backend/_thead/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_thead/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from backend_utils import VendorDescriptor
+from flaggems_vllm.runtime.backend.backend_utils import VendorDescriptor
 
 vendor_info = VendorDescriptor(
     vendor_name="thead",

--- a/src/flaggems_vllm/runtime/backend/_tsingmicro/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_tsingmicro/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from backend_utils import VendorDescriptor
+from flaggems_vllm.runtime.backend.backend_utils import VendorDescriptor
 
 vendor_info = VendorDescriptor(
     vendor_name="tsingmicro",

--- a/src/flaggems_vllm/runtime/backend/device_finder.py
+++ b/src/flaggems_vllm/runtime/backend/device_finder.py
@@ -31,7 +31,6 @@ class DeviceDetector:
 
     def __new__(cls, *args, **kargs):
         if cls._instance is None:
-            cls._instance = super(DeviceDetector, cls).__new__(cls)
             cls._instance = super().__new__(cls)
         return cls._instance
 

--- a/tools/check_backend_env.py
+++ b/tools/check_backend_env.py
@@ -62,12 +62,32 @@ def main() -> int:
     import flaggems_vllm
     from flaggems_vllm import runtime
 
+    expected_vendor = args.expected_vendor.lower()
+    expected_vendor_module = f"flaggems_vllm.runtime.backend._{expected_vendor}"
+    vendor_module = runtime.backend.get_backend_state().vendor_module
+    descriptor_type = type(runtime.device.info)
+
     print("flaggems_vllm:", flaggems_vllm.__version__)
     print("vendor:", flaggems_vllm.vendor_name)
+    print("vendor module:", vendor_module.__name__)
     print("device:", flaggems_vllm.device)
     print("device count:", runtime.device.device_count)
 
-    expected_vendor = args.expected_vendor.lower()
+    if vendor_module.__name__ != expected_vendor_module:
+        raise RuntimeError(
+            "vendor backend module collision: "
+            f"expected {expected_vendor_module!r}, got {vendor_module.__name__!r} "
+            f"from {getattr(vendor_module, '__file__', None)!r}"
+        )
+    if not isinstance(
+        runtime.device.info, runtime.backend.backend_utils.VendorDescriptor
+    ):
+        raise RuntimeError(
+            "vendor descriptor module collision: "
+            "expected a flaggems_vllm VendorDescriptor, "
+            f"got {descriptor_type.__module__}.{descriptor_type.__name__}"
+        )
+
     configured_vendor = os.environ.get("FLAGGEMS_VENDOR", "").lower()
     if configured_vendor != expected_vendor:
         raise RuntimeError(

--- a/tools/prepare-flaggems-ci-env.sh
+++ b/tools/prepare-flaggems-ci-env.sh
@@ -86,6 +86,19 @@ export HOME="${home_dir}"
 export FLAGGEMS_DIR="${flaggems_dir}"
 export FLAGGEMS_VENV="${flaggems_venv}"
 
+# Vendor runners often reach package mirrors through proxies. Keep retries
+# bounded, but allow runner owners to override both values when necessary.
+export UV_HTTP_RETRIES="${UV_HTTP_RETRIES:-5}"
+export UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-60}"
+if [[ ! "${UV_HTTP_RETRIES}" =~ ^[0-9]+$ ]]; then
+  echo "Invalid UV_HTTP_RETRIES value: ${UV_HTTP_RETRIES}" >&2
+  exit 2
+fi
+if [[ ! "${UV_HTTP_TIMEOUT}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Invalid UV_HTTP_TIMEOUT value: ${UV_HTTP_TIMEOUT}" >&2
+  exit 2
+fi
+
 # Respect valid runner-specific uv locations. If an inherited XDG/uv override
 # points to an unusable path, redirect only that uv store into the selected
 # writable HOME. This avoids probing one directory while uv writes elsewhere.
@@ -118,6 +131,8 @@ fi
   printf 'HOME=%s\n' "${HOME}"
   printf 'FLAGGEMS_DIR=%s\n' "${FLAGGEMS_DIR}"
   printf 'FLAGGEMS_VENV=%s\n' "${FLAGGEMS_VENV}"
+  printf 'UV_HTTP_RETRIES=%s\n' "${UV_HTTP_RETRIES}"
+  printf 'UV_HTTP_TIMEOUT=%s\n' "${UV_HTTP_TIMEOUT}"
   if [[ "${write_uv_cache_override}" == true ]]; then
     printf 'UV_CACHE_DIR=%s\n' "${UV_CACHE_DIR}"
   fi

--- a/tools/select_backends.py
+++ b/tools/select_backends.py
@@ -56,6 +56,33 @@ def load_registry(path: Path) -> list[dict[str, Any]]:
     return registry
 
 
+def load_auto_selected_backends(path: Path) -> set[str]:
+    """Return backends approved for automatic path-based CI routing."""
+    config = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(config, dict) or config.get("schema_version") != 1:
+        raise ValueError("backend capabilities must use schema_version 1")
+
+    defaults = config.get("defaults")
+    backends = config.get("backends")
+    if not isinstance(defaults, dict) or not isinstance(backends, dict):
+        raise ValueError("backend capabilities require defaults and backends objects")
+
+    default = defaults.get("auto_select")
+    if default is not False:
+        raise ValueError("defaults.auto_select must be false")
+
+    selected = set()
+    for backend, override in backends.items():
+        if not isinstance(backend, str) or not isinstance(override, dict):
+            raise ValueError("backend capability entries must be named objects")
+        value = override.get("auto_select", default)
+        if not isinstance(value, bool):
+            raise ValueError(f"auto_select for {backend!r} must be a boolean")
+        if value:
+            selected.add(backend)
+    return selected
+
+
 def parse_labels(value: str) -> set[str]:
     labels = json.loads(value)
     if labels is None:
@@ -90,18 +117,26 @@ def select_backends(
     labels: set[str],
     all_enabled: bool,
     changed_files: set[str] | None = None,
+    *,
+    auto_selected_backends: set[str],
 ) -> list[dict[str, str]]:
     changed_files = changed_files or set()
+    registry_backends = {entry["backend"] for entry in registry}
+    unknown_backends = auto_selected_backends - registry_backends
+    if unknown_backends:
+        unknown = ", ".join(sorted(unknown_backends))
+        raise ValueError(f"auto-selected backends missing from registry: {unknown}")
+
     selected = []
     for entry in registry:
         backend = entry["backend"]
         if not entry["enabled"] or backend.startswith("nvidia"):
             continue
-        if (
-            not all_enabled
-            and entry["label"] not in labels
-            and not backend_changed(backend, changed_files)
-        ):
+        explicitly_selected = all_enabled or entry["label"] in labels
+        automatically_selected = backend_changed(backend, changed_files) and (
+            backend in auto_selected_backends
+        )
+        if not explicitly_selected and not automatically_selected:
             continue
 
         selected.append(
@@ -119,6 +154,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--registry", required=True, type=Path)
     parser.add_argument("--labels-json", default="[]")
     parser.add_argument("--changed-files", type=Path)
+    parser.add_argument("--capabilities", required=True, type=Path)
     parser.add_argument("--all-enabled", action="store_true")
     parser.add_argument("--format", choices=("github", "json", "list"), default="list")
     return parser.parse_args()
@@ -126,11 +162,13 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    auto_selected_backends = load_auto_selected_backends(args.capabilities)
     selected = select_backends(
         load_registry(args.registry),
         parse_labels(args.labels_json),
         args.all_enabled,
         read_changed_files(args.changed_files),
+        auto_selected_backends=auto_selected_backends,
     )
     matrix = {"include": selected}
 

--- a/tools/test_ci_absolute_imports.py
+++ b/tools/test_ci_absolute_imports.py
@@ -1,0 +1,221 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = REPO_ROOT / "src/flaggems_vllm"
+BACKEND_ROOT = PACKAGE_ROOT / "runtime/backend"
+CANONICAL_PACKAGE = "flaggems_vllm"
+
+
+def production_operator_files() -> list[Path]:
+    """Return operator sources and the vendor packages that register them."""
+    paths = set((PACKAGE_ROOT / "ops").rglob("*.py"))
+    paths.add(PACKAGE_ROOT / "ops_moe_mxq.py")
+    for vendor_root in BACKEND_ROOT.glob("_*"):
+        if vendor_root.is_dir():
+            paths.update(vendor_root.rglob("*.py"))
+    return sorted(paths)
+
+
+def repository_module_names() -> set[str]:
+    """Return names that would be ambiguous when imported without a package."""
+    names = {CANONICAL_PACKAGE}
+    for source in PACKAGE_ROOT.rglob("*.py"):
+        if source.name == "__init__.py":
+            names.add(source.parent.name)
+        else:
+            names.add(source.stem)
+    return names
+
+
+def non_absolute_internal_imports(
+    source: str,
+    internal_names: set[str],
+) -> list[tuple[int, str]]:
+    """Find relative imports and bare imports that match repository modules."""
+    lines = source.splitlines()
+    violations = []
+    for node in ast.walk(ast.parse(source)):
+        imported_modules: list[str]
+        if isinstance(node, ast.ImportFrom):
+            if node.level:
+                violations.append((node.lineno, lines[node.lineno - 1].strip()))
+                continue
+            imported_modules = [node.module or ""]
+        elif isinstance(node, ast.Import):
+            imported_modules = [alias.name for alias in node.names]
+        else:
+            continue
+
+        for module_name in imported_modules:
+            if module_name == CANONICAL_PACKAGE or module_name.startswith(
+                f"{CANONICAL_PACKAGE}."
+            ):
+                continue
+            if module_name.partition(".")[0] in internal_names:
+                violations.append((node.lineno, lines[node.lineno - 1].strip()))
+                break
+    return violations
+
+
+class AbsoluteOperatorImportTest(unittest.TestCase):
+    def test_production_operator_imports_are_package_qualified(self):
+        internal_names = repository_module_names()
+        violations = []
+        for path in production_operator_files():
+            source = path.read_text(encoding="utf-8")
+            for line_number, statement in non_absolute_internal_imports(
+                source, internal_names
+            ):
+                relative_path = path.relative_to(REPO_ROOT)
+                violations.append(f"{relative_path}:{line_number}: {statement}")
+
+        self.assertEqual(
+            violations,
+            [],
+            "Production operators must use absolute 'flaggems_vllm.*' imports:\n"
+            + "\n".join(violations),
+        )
+
+    def test_scanner_rejects_relative_and_bare_repository_imports(self):
+        source = "\n".join(
+            (
+                "from .scaled_int8_quant import scaled_int8_quant",
+                "from backend_utils import VendorDescriptor",
+                "import flaggems_vllm.ops",
+                "import torch",
+            )
+        )
+
+        self.assertEqual(
+            non_absolute_internal_imports(
+                source,
+                {"backend_utils", "scaled_int8_quant"},
+            ),
+            [
+                (1, "from .scaled_int8_quant import scaled_int8_quant"),
+                (2, "from backend_utils import VendorDescriptor"),
+            ],
+        )
+
+
+class CanonicalBackendLoaderTest(unittest.TestCase):
+    module_names = ("backend_utils", "_nvidia")
+
+    def setUp(self):
+        self.saved_modules = {
+            name: module
+            for name, module in sys.modules.items()
+            if name == CANONICAL_PACKAGE
+            or name.startswith(f"{CANONICAL_PACKAGE}.")
+            or name in self.module_names
+        }
+        self._remove_test_modules()
+
+    def tearDown(self):
+        self._remove_test_modules()
+        sys.modules.update(self.saved_modules)
+
+    def _remove_test_modules(self):
+        for name in list(sys.modules):
+            if (
+                name == CANONICAL_PACKAGE
+                or name.startswith(f"{CANONICAL_PACKAGE}.")
+                or name in self.module_names
+            ):
+                sys.modules.pop(name, None)
+
+    @staticmethod
+    def _package(name: str, path: Path) -> types.ModuleType:
+        module = types.ModuleType(name)
+        module.__package__ = name
+        module.__path__ = [str(path)]
+        return module
+
+    def test_vendor_loader_ignores_bare_module_sentinels(self):
+        sys_path_before = tuple(sys.path)
+        package = self._package(CANONICAL_PACKAGE, PACKAGE_ROOT)
+        runtime = self._package(
+            f"{CANONICAL_PACKAGE}.runtime", PACKAGE_ROOT / "runtime"
+        )
+        sys.modules[package.__name__] = package
+        sys.modules[runtime.__name__] = runtime
+
+        common = types.ModuleType(f"{CANONICAL_PACKAGE}.runtime.common")
+        common.vendors = types.SimpleNamespace(get_all_vendors=lambda: {})
+        sys.modules[common.__name__] = common
+
+        canonical_backend_utils = types.ModuleType(
+            f"{CANONICAL_PACKAGE}.runtime.backend.backend_utils"
+        )
+        canonical_backend_utils.BackendEventBase = object
+        canonical_backend_utils.VendorDescriptor = lambda **values: (
+            types.SimpleNamespace(**values)
+        )
+        sys.modules[canonical_backend_utils.__name__] = canonical_backend_utils
+
+        bare_backend_utils = types.ModuleType("backend_utils")
+
+        def reject_bare_backend_utils(**_values):
+            self.fail("vendor package imported the bare backend_utils sentinel")
+
+        bare_backend_utils.VendorDescriptor = reject_bare_backend_utils
+        sys.modules[bare_backend_utils.__name__] = bare_backend_utils
+
+        bare_vendor = types.ModuleType("_nvidia")
+        bare_vendor.vendor_info = object()
+        sys.modules[bare_vendor.__name__] = bare_vendor
+
+        module_name = f"{CANONICAL_PACKAGE}.runtime.backend"
+        module_path = BACKEND_ROOT / "__init__.py"
+        spec = importlib.util.spec_from_file_location(
+            module_name,
+            module_path,
+            submodule_search_locations=[str(BACKEND_ROOT)],
+        )
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        backend = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = backend
+        spec.loader.exec_module(backend)
+
+        loaded_vendor = backend.get_vendor_module("nvidia", query=True)
+        loaded_vendor_with_prefix = backend.get_vendor_module("_nvidia", query=True)
+        state_vendor = backend.get_vendor_module("nvidia")
+
+        self.assertEqual(
+            loaded_vendor.__name__,
+            f"{CANONICAL_PACKAGE}.runtime.backend._nvidia",
+        )
+        self.assertIs(loaded_vendor_with_prefix, loaded_vendor)
+        self.assertIs(state_vendor, loaded_vendor)
+        self.assertIs(backend.get_vendor_info(), loaded_vendor.vendor_info)
+        self.assertIsNot(loaded_vendor, bare_vendor)
+        self.assertEqual(loaded_vendor.vendor_info.vendor_name, "nvidia")
+        self.assertIs(sys.modules["backend_utils"], bare_backend_utils)
+        self.assertIs(sys.modules["_nvidia"], bare_vendor)
+        self.assertEqual(tuple(sys.path), sys_path_before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_ci_helpers.py
+++ b/tools/test_ci_helpers.py
@@ -413,6 +413,8 @@ class PrepareFlagGemsCiEnvironmentTest(unittest.TestCase):
         inherited_home_is_valid: bool = True,
         passwd_home_is_valid: bool = True,
         uv_overrides_are_invalid: bool = False,
+        uv_http_retries: str | None = None,
+        uv_http_timeout: str | None = None,
     ):
         temporary_directory = tempfile.TemporaryDirectory()
         self.addCleanup(temporary_directory.cleanup)
@@ -457,8 +459,14 @@ class PrepareFlagGemsCiEnvironmentTest(unittest.TestCase):
             "XDG_DATA_HOME",
             "UV_CACHE_DIR",
             "UV_PYTHON_INSTALL_DIR",
+            "UV_HTTP_RETRIES",
+            "UV_HTTP_TIMEOUT",
         ):
             environment.pop(name, None)
+        if uv_http_retries is not None:
+            environment["UV_HTTP_RETRIES"] = uv_http_retries
+        if uv_http_timeout is not None:
+            environment["UV_HTTP_TIMEOUT"] = uv_http_timeout
         if uv_overrides_are_invalid:
             invalid_cache = root / "invalid-uv-cache"
             invalid_python = root / "invalid-uv-python"
@@ -498,9 +506,14 @@ class PrepareFlagGemsCiEnvironmentTest(unittest.TestCase):
             "FLAGGEMS_DIR": workspace / ".ci/flaggems",
             "FLAGGEMS_VENV": workspace / ".ci/flaggems/.venv",
         }
-        self.assertEqual(set(values), set(expected))
+        self.assertEqual(
+            set(values),
+            {*expected, "UV_HTTP_RETRIES", "UV_HTTP_TIMEOUT"},
+        )
         for name, path in expected.items():
             self.assertEqual(Path(values[name]), path)
+        self.assertEqual(values["UV_HTTP_RETRIES"], "5")
+        self.assertEqual(values["UV_HTTP_TIMEOUT"], "60")
         self.assertTrue((inherited_home / ".local/bin").is_dir())
         self.assertTrue((inherited_home / ".cache/uv").is_dir())
         self.assertTrue((inherited_home / ".local/share/uv/python").is_dir())
@@ -518,6 +531,25 @@ class PrepareFlagGemsCiEnvironmentTest(unittest.TestCase):
             Path(values["UV_PYTHON_INSTALL_DIR"]),
             inherited_home / ".local/share/uv/python",
         )
+
+    def test_preserves_explicit_uv_http_settings(self):
+        result, values, *_ = self.run_helper(
+            "iluvatar",
+            uv_http_retries="7",
+            uv_http_timeout="90",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(values["UV_HTTP_RETRIES"], "7")
+        self.assertEqual(values["UV_HTTP_TIMEOUT"], "90")
+
+    def test_rejects_invalid_uv_http_settings(self):
+        result, values, *_ = self.run_helper(
+            "iluvatar",
+            uv_http_retries="not-a-number",
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("Invalid UV_HTTP_RETRIES", result.stderr)
+        self.assertEqual(values, {})
 
     def test_uses_passwd_home_when_inherited_home_is_invalid(self):
         result, values, _, _, _, passwd_home = self.run_helper(

--- a/tools/test_ci_helpers.py
+++ b/tools/test_ci_helpers.py
@@ -149,13 +149,19 @@ class SelectBackendsTest(unittest.TestCase):
 
     def test_pr_label_selects_only_matching_backend(self):
         selected = select_backends.select_backends(
-            self.registry, {"vendor/Ascend"}, all_enabled=False
+            self.registry,
+            {"vendor/Ascend"},
+            all_enabled=False,
+            auto_selected_backends=set(),
         )
         self.assertEqual([entry["backend"] for entry in selected], ["ascend-cann850"])
 
     def test_all_enabled_still_excludes_nvidia(self):
         selected = select_backends.select_backends(
-            self.registry, set(), all_enabled=True
+            self.registry,
+            set(),
+            all_enabled=True,
+            auto_selected_backends=set(),
         )
         self.assertEqual(
             [entry["backend"] for entry in selected],
@@ -168,11 +174,133 @@ class SelectBackendsTest(unittest.TestCase):
             set(),
             all_enabled=False,
             changed_files={"src/flaggems_vllm/runtime/backend/_kunlunxin/ops/mul.py"},
+            auto_selected_backends={"kunlunxin"},
         )
         self.assertEqual(
             [entry["backend"] for entry in selected],
             ["kunlunxin"],
         )
+
+    def test_path_inference_selects_only_preflight_verified_backends(self):
+        selected = select_backends.select_backends(
+            self.registry,
+            set(),
+            all_enabled=False,
+            changed_files={
+                "src/flaggems_vllm/runtime/backend/_ascend/ops/mul.py",
+                "src/flaggems_vllm/runtime/backend/_kunlunxin/ops/mul.py",
+            },
+            auto_selected_backends={"ascend-cann850"},
+        )
+        self.assertEqual(
+            [entry["backend"] for entry in selected],
+            ["ascend-cann850"],
+        )
+
+    def test_exact_label_overrides_automatic_selection_readiness(self):
+        selected = select_backends.select_backends(
+            self.registry,
+            {"vendor/Kunlunxin"},
+            all_enabled=False,
+            auto_selected_backends=set(),
+        )
+        self.assertEqual(
+            [entry["backend"] for entry in selected],
+            ["kunlunxin"],
+        )
+
+    def test_all_enabled_overrides_automatic_selection_readiness(self):
+        selected = select_backends.select_backends(
+            self.registry,
+            set(),
+            all_enabled=True,
+            auto_selected_backends=set(),
+        )
+        self.assertEqual(
+            [entry["backend"] for entry in selected],
+            ["ascend-cann850", "kunlunxin"],
+        )
+
+    def test_loads_auto_selected_backends_from_capabilities(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            path = Path(temporary_directory) / "capabilities.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "defaults": {"auto_select": False},
+                        "backends": {
+                            "ascend-cann850": {"auto_select": True},
+                            "kunlunxin": {},
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                select_backends.load_auto_selected_backends(path),
+                {"ascend-cann850"},
+            )
+
+    def test_capabilities_must_default_to_fail_closed(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            path = Path(temporary_directory) / "capabilities.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "defaults": {"auto_select": True},
+                        "backends": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "must be false"):
+                select_backends.load_auto_selected_backends(path)
+
+    def test_capabilities_reject_non_boolean_backend_override(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            path = Path(temporary_directory) / "capabilities.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "defaults": {"auto_select": False},
+                        "backends": {"kunlunxin": {"auto_select": "yes"}},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "must be a boolean"):
+                select_backends.load_auto_selected_backends(path)
+
+    def test_unknown_auto_selected_backend_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "missing from registry"):
+            select_backends.select_backends(
+                self.registry,
+                set(),
+                all_enabled=False,
+                auto_selected_backends={"misspelled-backend"},
+            )
+
+    def test_explicit_selection_cannot_enable_disabled_or_nvidia_backends(self):
+        registry = [
+            {
+                "backend": "disabled-vendor",
+                "runner_label": "disabled",
+                "label": "vendor/Disabled",
+                "gpu_check": "",
+                "enabled": False,
+            },
+            self.registry[2],
+        ]
+        selected = select_backends.select_backends(
+            registry,
+            {"vendor/Disabled", "vendor/NVIDIA"},
+            all_enabled=True,
+            auto_selected_backends=set(),
+        )
+        self.assertEqual(selected, [])
 
     def test_unrelated_source_change_does_not_select_a_vendor(self):
         selected = select_backends.select_backends(
@@ -180,6 +308,7 @@ class SelectBackendsTest(unittest.TestCase):
             set(),
             all_enabled=False,
             changed_files={"src/flaggems_vllm/ops/mul.py"},
+            auto_selected_backends=set(),
         )
         self.assertEqual(selected, [])
 
@@ -283,9 +412,10 @@ class IluvatarForkSelectionIntegrationTest(TemporaryRepositoryTestCase):
 
         selected_backends = select_backends.select_backends(
             registry,
-            set(),
+            {"vendor/Iluvatar"},
             all_enabled=False,
             changed_files=set(changed_files),
+            auto_selected_backends=set(),
         )
         _, selected_tests, _ = select_tests.select_targets(
             self.repo_root, changed_files
@@ -622,6 +752,16 @@ class SetupFlagGemsActionContractTest(unittest.TestCase):
 
 
 class CiWorkflowPolicyTest(unittest.TestCase):
+    def test_backend_path_routing_uses_local_preflight_readiness(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        workflow = (repo_root / ".github/workflows/basic-ci.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            "--capabilities .github/backend-capabilities.json",
+            workflow,
+        )
+
     def test_all_backend_fanout_requires_an_explicit_request(self):
         repo_root = Path(__file__).resolve().parents[1]
         workflow = (repo_root / ".github/workflows/basic-ci.yml").read_text(


### PR DESCRIPTION
<!--
 Copyright 2026 FlagOS Contributors

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->

### PR Category

Operator / CI/CD

### Type of Change

Bug Fix

### Description

#### Problem

FlagGems and FlagGems-vLLM contain modules with overlapping names, including `backend_utils`, `_<vendor>`, vendor ops, architecture-specific packages, and Triton-version modules.

Previously, FlagGems-vLLM added backend directories to `sys.path` and dynamically imported these modules using unqualified names. Because Python caches modules by name in `sys.modules`, importing `flag_gems` first could cause FlagGems-vLLM to reuse modules belonging to FlagGems.

The issue was exposed when FlagGems 5.0.0 provided a foreign `VendorInfoBase` without `fp64_enabled`:

```text
AttributeError: 'VendorInfoBase' object has no attribute 'fp64_enabled'
```

Changing only `from backend_utils import ...` is insufficient because the vendor package itself, such as `_nvidia`, may already have been cached by FlagGems. The dynamic vendor, ops, fused, architecture, heuristic, and Triton-version loaders must also use package-qualified names.

#### Changes

- Use `flaggems_vllm.*` package-qualified imports for internal imports in operator sources and vendor backend packages.
- Load backend modules through canonical names such as:
  - `flaggems_vllm.runtime.backend._<vendor>`
  - `flaggems_vllm.runtime.backend._<vendor>.ops`
  - `flaggems_vllm.runtime.backend._<vendor>.fused`
  - package-qualified architecture, heuristic, and Triton-version modules
- Remove backend loader mutations of `sys.path`.
- Normalize both `nvidia` and `_nvidia` vendor-name inputs.
- Preserve backend state reuse and query behavior.
- Remove a redundant `DeviceDetector.__new__` assignment.
- Add regression coverage that:
  - rejects relative or bare internal imports in production operator/vendor sources;
  - preloads foreign `backend_utils` and `_nvidia` modules and verifies that the canonical FlagGems-vLLM modules are still selected;
  - verifies that foreign `sys.modules` entries and `sys.path` remain unchanged.
- Extend hardware preflight checks to validate the canonical vendor module and `VendorDescriptor` type after importing `flag_gems` first.
- Synchronize the FlagGems CI registry, setup, and reusable-workflow pins.
- Add bounded, configurable `uv` download retries and timeouts.
- Make automatic multi-backend routing fail closed: only profiles with validated runner readiness are selected automatically. Other enabled profiles remain available through their exact vendor label or manual all-backend dispatch.

#### Result

FlagGems-vLLM no longer resolves vendor backend modules from FlagGems when both packages coexist in the same Python process.

No operator kernel or computation-path behavior is changed.

### Issue

N/A

### Validation

- `python -m unittest discover -s tools -p 'test_ci_*.py'`
  - 54 tests passed
- Absolute-import AST guard passed
- Canonical backend-loader collision regression passed
- Code style, target selection, and multi-backend summary passed
- Setup and portable import/device/tensor preflight passed on:
  - Ascend CANN 8.5
  - Ascend CANN 9.0
  - Hygon
  - MetaX MACA 3.7.2
  - MetaX MACA 3.8.1
  - TsingMicro
- Final CI run: [GitHub Actions](https://github.com/flagos-ai/FlagGems-vllm/actions/runs/32370926502)

The hardware lanes above validated backend setup and portable preflight; they did not run operator benchmarks. NVIDIA was skipped by the fork trust policy.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

N/A. This change affects Python module resolution and CI validation only.