### PR TITLE
[MetaX] Add Native Sparse Attention operators

### DIFF
--- a/src/flaggems_vllm/runtime/backend/_metax/ops/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/ops/__init__.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from flaggems_vllm.runtime.backend._metax.ops.parallel_nsa import parallel_nsa
+from flaggems_vllm.runtime.backend._metax.ops.parallel_nsa_compression import (
+    parallel_nsa_compression,
+)
 from flaggems_vllm.runtime.backend._metax.ops.per_token_group_quant_fp8 import (
     SUPPORTED_FP8_DTYPE,
     per_token_group_quant_fp8,
@@ -20,6 +24,8 @@ from flaggems_vllm.runtime.backend._metax.ops.scaled_int8_quant import scaled_in
 
 __all__ = [
     "SUPPORTED_FP8_DTYPE",
+    "parallel_nsa",
+    "parallel_nsa_compression",
     "per_token_group_quant_fp8",
     "scaled_int8_quant",
 ]

--- a/src/flaggems_vllm/runtime/backend/_metax/ops/parallel_nsa.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/ops/parallel_nsa.py
@@ -1,0 +1,1185 @@
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import os
+import warnings
+
+import torch
+import triton
+import triton.language as tl
+
+from flaggems_vllm.ops.FLA.bwd_preprocess import parallel_attn_bwd_preprocess
+from flaggems_vllm.ops.FLA.index import (
+    prepare_chunk_indices,
+    prepare_chunk_offsets,
+    prepare_lens,
+    prepare_token_indices,
+)
+from flaggems_vllm.ops.FLA.mean_pooling import mean_pooling
+from .parallel_nsa_compression import parallel_nsa_compression
+from flaggems_vllm.ops.FLA.triton_ops_helper import autotune_cache_kwargs, exp, log
+from flaggems_vllm.ops.FLA.utils import _bitonic_merge, check_shared_mem, input_guard
+
+try:
+    HAS_TLE = False
+    import triton.experimental.tle.language as tle  # noqa: F401
+
+    HAS_TLE = True
+except ImportError:
+    tle = None
+    HAS_TLE = False
+
+try:
+    from flash_attn import flash_attn_func, flash_attn_varlen_func
+except ImportError:
+    warnings.warn(
+        "Flash Attention is not installed. Please install it via `pip install flash-attn --no-build-isolation`",
+        category=ImportWarning,
+    )
+    flash_attn_func = None
+    flash_attn_varlen_func = None
+
+
+# ===========================================================================
+# Top-K selection kernel
+# ===========================================================================
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4]],
+    key=["BS", "BK"],
+    **autotune_cache_kwargs,
+)
+@triton.jit
+def parallel_nsa_kernel_topk(
+    q,
+    k,
+    lse,
+    scale,
+    block_indices,
+    cu_seqlens,
+    token_indices,
+    chunk_offsets,
+    T,
+    H: tl.constexpr,
+    HQ: tl.constexpr,
+    G: tl.constexpr,
+    K: tl.constexpr,
+    S: tl.constexpr,
+    BC: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(
+            token_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+        boc = tl.load(chunk_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_b * T, i_b * T + T
+        boc = i_b * tl.cdiv(T, BS)
+
+    p_q = tl.make_block_ptr(
+        q + (bos + i_t) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0)
+    )
+
+    # the Q block is kept in the shared memory throughout the whole kernel
+    # [G, BK]
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = (b_q * scale).to(b_q.dtype)
+
+    # the number of compression representations in total
+    TC = tl.cdiv(T, BS)
+    # the number of compression representations required to iterate over
+    # incomplete compression blocks are not included
+    NC = (i_t + 1) // BS
+    ################################
+    # 1. lse computation
+    ################################
+    if lse is not None:
+        b_lse = tl.load(lse + (bos + i_t) * HQ + i_h * G + tl.arange(0, G))
+    else:
+        # max scores for the current block
+        b_m = tl.full([G], float("-inf"), dtype=tl.float32)
+        # lse = log(acc) + m
+        b_acc = tl.zeros([G], dtype=tl.float32)
+        for i_c in range(0, NC, BC):
+            o_c = i_c + tl.arange(0, BC)
+
+            p_k = tl.make_block_ptr(
+                k + (boc * H + i_h) * K, (K, TC), (1, H * K), (0, i_c), (BK, BC), (0, 1)
+            )
+            # [BK, BC]
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+
+            # [G, BC]
+            b_s = tl.dot(b_q, b_k)
+            b_s = tl.where((o_c < NC)[None, :], b_s, float("-inf"))
+
+            # [G]
+            b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
+            b_r = exp(b_mp - b_m)
+            # [G, BC]
+            b_p = exp(b_s - b_m[:, None])
+            # [G]
+            b_acc = b_acc * b_r + tl.sum(b_p, 1)
+
+            b_mp = b_m
+        if NC == 0:
+            b_lse = tl.zeros([G], dtype=tl.float32)
+        else:
+            b_lse = b_m + log(b_acc)
+
+    ################################
+    # 2. topk selection
+    ################################
+    # [BC]
+    b_i = tl.full([BC], -1, dtype=tl.float32)
+    o_i = tl.zeros([BC], dtype=tl.int32)
+    m_i = tl.arange(0, BC) < BC // 2
+
+    IC = i_t // BS
+    for i_c in range(0, tl.cdiv(i_t + 1, BS), BC):
+        o_c = i_c + tl.arange(0, BC)
+
+        p_k = tl.make_block_ptr(
+            k + (boc * H + i_h) * K, (K, TC), (1, H * K), (0, i_c), (BK, BC), (0, 1)
+        )
+        # [BK, BC]
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        # [G, BC]
+        b_s = tl.dot(b_q, b_k)
+        b_s = tl.where(o_c < IC, b_s, float("-inf"))
+        # [G, BC]
+        # the 1st and the last 2 blocks are always selected
+        b_p = tl.where(
+            (o_c == 0) | ((o_c == IC - 1) | (o_c == IC)), 1.0, exp(b_s - b_lse[:, None])
+        )
+        # the importance scores of the current block
+        # [BC]
+        b_i, b_ip = tl.sum(b_p, 0), b_i
+        # blocks with index < 0 will be skipped
+        o_i, o_ip = tl.where(o_c <= IC, o_c, -1), o_i
+
+        n_dims: tl.constexpr = tl.standard._log2(b_i.shape[0])
+        for i in tl.static_range(1, n_dims):
+            b_i, o_i = _bitonic_merge(b_i, o_i.to(tl.int32), i, 2, n_dims)
+
+        if i_c != 0:
+            b_i, o_i = _bitonic_merge(b_i, o_i.to(tl.int32), n_dims, False, n_dims)
+            b_i_new = b_ip * m_i + b_i * (1 - m_i)
+            o_i_new = o_ip * m_i + o_i * (1 - m_i)
+            b_i, o_i = _bitonic_merge(
+                b_i_new, o_i_new.to(tl.int32), n_dims, True, n_dims
+            )
+        else:
+            b_i, o_i = _bitonic_merge(b_i, o_i.to(tl.int32), n_dims, True, n_dims)
+
+    m_top = tl.arange(0, BC // S) == 0
+    b_top = tl.sum(m_top[:, None] * tl.reshape(o_i, [BC // S, S]), 0)
+
+    p_b = tl.make_block_ptr(
+        block_indices + (bos + i_t) * H * S, (H * S,), (1,), (i_h * S,), (S,), (0,)
+    )
+    tl.store(p_b, b_top.to(p_b.dtype.element_ty))
+
+
+# ===========================================================================
+# Forward kernel
+# ===========================================================================
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "USE_BLOCK_COUNTS": lambda args: isinstance(args["block_counts"], torch.Tensor),
+    }
+)
+@triton.autotune(
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4]],
+    key=["BS", "BK", "BV"],
+    **autotune_cache_kwargs,
+)
+@triton.jit
+def parallel_nsa_fwd_kernel(
+    q,
+    k,
+    v,
+    o,
+    lse,
+    scale,
+    block_indices,
+    block_counts,
+    cu_seqlens,
+    token_indices,
+    T,
+    H: tl.constexpr,
+    HQ: tl.constexpr,
+    G: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    S: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_BLOCK_COUNTS: tl.constexpr,
+):
+    i_t, i_v, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(
+            token_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    k += (bos * H + i_h) * K
+    v += (bos * H + i_h) * V
+    block_indices += (bos + i_t) * H * S + i_h * S
+
+    if USE_BLOCK_COUNTS:
+        NS = tl.load(block_counts + (bos + i_t) * H + i_h)
+    else:
+        NS = S
+
+    p_q = tl.make_block_ptr(
+        q + (bos + i_t) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0)
+    )
+    # the Q block is kept in the shared memory throughout the whole kernel
+    # [G, BK]
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = (b_q * scale).to(b_q.dtype)
+
+    p_o = tl.make_block_ptr(
+        o + (bos + i_t) * HQ * V, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0)
+    )
+    p_lse = lse + (bos + i_t) * HQ + i_h * G + tl.arange(0, G)
+    # [G, BV]
+    b_o = tl.zeros([G, BV], dtype=tl.float32)
+
+    b_m = tl.full([G], float("-inf"), dtype=tl.float32)
+    b_acc = tl.zeros([G], dtype=tl.float32)
+    for i in range(NS):
+        i_s = tl.load(block_indices + i).to(tl.int32) * BS
+        if i_s <= i_t and i_s >= 0:
+            p_k = tl.make_block_ptr(k, (K, T), (1, H * K), (0, i_s), (BK, BS), (0, 1))
+            p_v = tl.make_block_ptr(
+                v, (T, V), (H * V, 1), (i_s, i_v * BV), (BS, BV), (1, 0)
+            )
+            # [BK, BS]
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            # [G, BS] — compute QK^T scores
+            b_s = tl.dot(b_q, b_k)
+            # b_k registers are now free — will be reused for later loads
+            b_s = tl.where(
+                (i_t >= (i_s + tl.arange(0, BS)))[None, :], b_s, float("-inf")
+            )
+
+            # [G]
+            b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
+            b_r = exp(b_mp - b_m)
+            # [G, BS] — b_s registers reused for softmax output b_p
+            b_p = exp(b_s - b_m[:, None])
+            # [G]
+            b_acc = b_acc * b_r + tl.sum(b_p, 1)
+
+            # [BS, BV] — load V tile AFTER score computation
+            # so b_k registers are freed and peak register usage is reduced
+            b_v = tl.load(p_v, boundary_check=(0, 1))
+            # [G, BV]
+            b_o = b_o * b_r[:, None] + tl.dot(b_p.to(b_q.dtype), b_v)
+
+            b_mp = b_m
+    b_o = b_o / b_acc[:, None]
+    b_m += log(b_acc)
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_lse, b_m.to(p_lse.dtype.element_ty))
+
+
+# ===========================================================================
+# TLE-optimized forward kernel (Triton Language Extensions)
+# ===========================================================================
+
+if HAS_TLE:
+
+    @triton.heuristics(
+        {
+            "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+            "USE_BLOCK_COUNTS": lambda args: isinstance(
+                args["block_counts"], torch.Tensor
+            ),
+        }
+    )
+    @triton.autotune(
+        configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4]],
+        key=["BS", "BK", "BV"],
+        **autotune_cache_kwargs,
+    )
+    @triton.jit
+    def parallel_nsa_fwd_kernel_tle(
+        q,
+        k,
+        v,
+        o,
+        lse,
+        scale,
+        block_indices,
+        block_counts,
+        cu_seqlens,
+        token_indices,
+        T,
+        H: tl.constexpr,
+        HQ: tl.constexpr,
+        G: tl.constexpr,
+        K: tl.constexpr,
+        V: tl.constexpr,
+        S: tl.constexpr,
+        BS: tl.constexpr,
+        BK: tl.constexpr,
+        BV: tl.constexpr,
+        IS_VARLEN: tl.constexpr,
+        USE_BLOCK_COUNTS: tl.constexpr,
+    ):
+        i_t, i_v, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+        i_b, i_h = i_bh // H, i_bh % H
+
+        if IS_VARLEN:
+            i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(
+                token_indices + i_t * 2 + 1
+            ).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+                cu_seqlens + i_n + 1
+            ).to(tl.int32)
+            T = eos - bos
+        else:
+            bos, eos = i_b * T, i_b * T + T
+
+        k += (bos * H + i_h) * K
+        v += (bos * H + i_h) * V
+        block_indices += (bos + i_t) * H * S + i_h * S
+
+        if USE_BLOCK_COUNTS:
+            NS = tl.load(block_counts + (bos + i_t) * H + i_h)
+        else:
+            NS = S
+
+        p_q = tl.make_block_ptr(
+            q + (bos + i_t) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0)
+        )
+        # [G, BK]
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = (b_q * scale).to(b_q.dtype)
+
+        p_o = tl.make_block_ptr(
+            o + (bos + i_t) * HQ * V,
+            (HQ, V),
+            (V, 1),
+            (i_h * G, i_v * BV),
+            (G, BV),
+            (1, 0),
+        )
+        p_lse = lse + (bos + i_t) * HQ + i_h * G + tl.arange(0, G)
+        # [G, BV]
+        b_o = tl.zeros([G, BV], dtype=tl.float32)
+
+        b_m = tl.full([G], float("-inf"), dtype=tl.float32)
+        b_acc = tl.zeros([G], dtype=tl.float32)
+
+        # Precompute indices for async K/V loads via tle.load(is_async=True).
+        offs_k = tl.arange(0, BK)
+        offs_s = tl.arange(0, BS)
+        offs_v = tl.arange(0, BV)
+        k_base = k  # already offset to (bos*H + i_h)*K
+        v_base = v  # already offset to (bos*H + i_h)*V
+        v_start = i_v * BV
+
+        for i in range(NS):
+            i_s = tl.load(block_indices + i).to(tl.int32) * BS
+            if i_s <= i_t and i_s >= 0:
+                # Async K load via regular pointer arithmetic
+                k_ptrs = k_base + offs_k[:, None] + (i_s + offs_s[None, :]) * H * K
+                k_mask = (offs_k[:, None] < K) & ((i_s + offs_s[None, :]) < T)
+                b_k = tle.load(k_ptrs, mask=k_mask, other=0.0, is_async=True)
+
+                # Compute QK^T scores
+                b_s = tl.dot(b_q, b_k.to(b_q.dtype))
+                b_s = tl.where(
+                    (i_t >= (i_s + tl.arange(0, BS)))[None, :], b_s, float("-inf")
+                )
+
+                # [G]
+                b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
+                b_r = exp(b_mp - b_m)
+                # [G, BS] — b_s registers reused for softmax output b_p
+                b_p = exp(b_s - b_m[:, None])
+                # [G]
+                b_acc = b_acc * b_r + tl.sum(b_p, 1)
+
+                # Async V load AFTER score computation
+                v_ptrs = (
+                    v_base
+                    + (i_s + offs_s[:, None]) * H * V
+                    + (v_start + offs_v[None, :])
+                )
+                v_mask = ((i_s + offs_s[:, None]) < T) & (
+                    (v_start + offs_v[None, :]) < V
+                )
+                b_v = tle.load(v_ptrs, mask=v_mask, other=0.0, is_async=True)
+
+                # [G, BV]
+                b_o = b_o * b_r[:, None] + tl.dot(b_p.to(b_q.dtype), b_v)
+
+                b_mp = b_m
+        b_o = b_o / b_acc[:, None]
+        b_m += log(b_acc)
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_lse, b_m.to(p_lse.dtype.element_ty))
+
+
+# ===========================================================================
+# Block mask kernel
+# ===========================================================================
+
+
+@triton.heuristics(
+    {
+        "USE_BLOCK_COUNTS": lambda args: isinstance(args["block_counts"], torch.Tensor),
+    }
+)
+@triton.jit(do_not_specialize=["T"])
+def parallel_nsa_kernel_mask(
+    block_indices,
+    block_counts,
+    block_mask,
+    T,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    BS: tl.constexpr,
+    NS: tl.constexpr,
+    USE_BLOCK_COUNTS: tl.constexpr,
+):
+    i_t, i_b, i_hs = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_h, i_s = i_hs // S, i_hs % S
+
+    b_i = tl.load(block_indices + i_b * T * H * S + i_t * H * S + i_h * S + i_s)
+    if USE_BLOCK_COUNTS:
+        b_m = b_i * BS <= i_t and i_s < tl.load(
+            block_counts + i_b * T * H + i_t * H + i_h
+        )
+    else:
+        b_m = b_i * BS <= i_t
+
+    if b_i < NS and b_i >= 0:
+        tl.store(
+            block_mask + i_b * T * H * NS + i_t * H * NS + i_h * NS + b_i,
+            b_m.to(block_mask.dtype.element_ty),
+        )
+
+
+# ===========================================================================
+# Backward kernel: dQ
+# ===========================================================================
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "USE_BLOCK_COUNTS": lambda args: isinstance(args["block_counts"], torch.Tensor),
+    }
+)
+@triton.autotune(
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4]],
+    key=["BS", "BK", "BV"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def parallel_nsa_bwd_kernel_dq(
+    q,
+    k,
+    v,
+    lse,
+    delta,
+    do,
+    dq,
+    scale,
+    block_indices,
+    block_counts,
+    cu_seqlens,
+    token_indices,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    HQ: tl.constexpr,
+    G: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    S: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_BLOCK_COUNTS: tl.constexpr,
+):
+    i_t, i_v, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    all = B * T
+    if IS_VARLEN:
+        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(
+            token_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    q += (bos + i_t) * HQ * K
+    do += (bos + i_t) * HQ * V
+    lse += (bos + i_t) * HQ
+    delta += (bos + i_t) * HQ
+    dq += (i_v * all + bos + i_t) * HQ * K
+    block_indices += (bos + i_t) * H * S + i_h * S
+
+    if USE_BLOCK_COUNTS:
+        NS = tl.load(block_counts + (bos + i_t) * H + i_h)
+    else:
+        NS = S
+
+    k += (bos * H + i_h) * K
+    v += (bos * H + i_h) * V
+
+    p_q = tl.make_block_ptr(q, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+    p_dq = tl.make_block_ptr(dq, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+
+    # [G, BK]
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = (b_q * scale).to(b_q.dtype)
+
+    p_do = tl.make_block_ptr(do, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0))
+    p_lse = lse + i_h * G + tl.arange(0, G)
+    p_delta = delta + i_h * G + tl.arange(0, G)
+
+    # [G, BV]
+    b_do = tl.load(p_do, boundary_check=(0, 1))
+    # [G]
+    b_lse = tl.load(p_lse)
+    b_delta = tl.load(p_delta)
+
+    # [G, BK]
+    b_dq = tl.zeros([G, BK], dtype=tl.float32)
+    for i in range(NS):
+        i_s = tl.load(block_indices + i).to(tl.int32) * BS
+        if i_s <= i_t and i_s >= 0:
+            p_k = tl.make_block_ptr(k, (K, T), (1, H * K), (0, i_s), (BK, BS), (0, 1))
+            p_v = tl.make_block_ptr(
+                v, (V, T), (1, H * V), (i_v * BV, i_s), (BV, BS), (0, 1)
+            )
+            # [BK, BS]
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            # [BV, BS]
+            b_v = tl.load(p_v, boundary_check=(0, 1))
+
+            # [G, BS]
+            b_s = tl.dot(b_q, b_k)
+            b_p = exp(b_s - b_lse[:, None])
+            b_p = tl.where((i_t >= (i_s + tl.arange(0, BS)))[None, :], b_p, 0)
+
+            # [G, BV] @ [BV, BS] -> [G, BS]
+            b_dp = tl.dot(b_do, b_v)
+            b_ds = b_p * (b_dp.to(tl.float32) - b_delta[:, None])
+            # [G, BS] @ [BS, BK] -> [G, BK]
+            b_dq += tl.dot(b_ds.to(b_k.dtype), tl.trans(b_k))
+    b_dq *= scale
+
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+
+
+# ===========================================================================
+# Backward kernel: dK / dV
+# ===========================================================================
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4]],
+    key=["BS", "BK", "BV"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def parallel_nsa_bwd_kernel_dkv(
+    q,
+    k,
+    v,
+    lse,
+    delta,
+    do,
+    dk,
+    dv,
+    block_mask,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    HQ: tl.constexpr,
+    G: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    M: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_s, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    all = B * T
+    if IS_VARLEN:
+        i_n, i_s = tl.load(chunk_indices + i_s * 2).to(tl.int32), tl.load(
+            chunk_indices + i_s * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    p_k = tl.make_block_ptr(
+        k + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_s * BS, 0), (BS, BK), (1, 0)
+    )
+    p_v = tl.make_block_ptr(
+        v + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_s * BS, i_v * BV),
+        (BS, BV),
+        (1, 0),
+    )
+    p_dk = tl.make_block_ptr(
+        dk + (i_v * all * H + bos * H + i_h) * K,
+        (T, K),
+        (H * K, 1),
+        (i_s * BS, 0),
+        (BS, BK),
+        (1, 0),
+    )
+    p_dv = tl.make_block_ptr(
+        dv + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_s * BS, i_v * BV),
+        (BS, BV),
+        (1, 0),
+    )
+
+    # [BS, BK]
+    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_dk = tl.zeros([BS, BK], dtype=tl.float32)
+    # [BS, BV]
+    b_v = tl.load(p_v, boundary_check=(0, 1))
+    b_dv = tl.zeros([BS, BV], dtype=tl.float32)
+
+    for i in range(i_s * BS, T):
+        b_m = tl.load(block_mask + (bos + i) * H * M + i_h * M + i_s)
+        if b_m:
+            p_q = tl.make_block_ptr(
+                q + (bos + i) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0)
+            )
+            # [G, BK]
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_q = (b_q * scale).to(b_q.dtype)
+
+            p_do = tl.make_block_ptr(
+                do + (bos + i) * HQ * V,
+                (HQ, V),
+                (V, 1),
+                (i_h * G, i_v * BV),
+                (G, BV),
+                (1, 0),
+            )
+            p_lse = lse + (bos + i) * HQ + i_h * G + tl.arange(0, G)
+            p_delta = delta + (bos + i) * HQ + i_h * G + tl.arange(0, G)
+            # [G, BV]
+            b_do = tl.load(p_do, boundary_check=(0, 1))
+            # [G]
+            b_lse = tl.load(p_lse)
+            b_delta = tl.load(p_delta)
+            # [BS, G]
+            b_s = tl.dot(b_k, tl.trans(b_q))
+            b_p = exp(b_s - b_lse[None, :])
+            b_p = tl.where((i >= (i_s * BS + tl.arange(0, BS)))[:, None], b_p, 0)
+            # [BS, G] @ [G, BV] -> [BS, BV]
+            b_dv += tl.dot(b_p.to(b_do.dtype), b_do)
+            # [BS, BV] @ [BV, G] -> [BS, G]
+            b_dp = tl.dot(b_v, tl.trans(b_do))
+            # [BS, G]
+            b_ds = b_p * (b_dp - b_delta[None, :])
+            # [BS, G] @ [G, BK] -> [BS, BK]
+            b_dk += tl.dot(b_ds.to(b_q.dtype), b_q)
+
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+
+
+# ===========================================================================
+# Python-level wrapper functions
+# ===========================================================================
+
+
+def parallel_nsa_topk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    lse: torch.Tensor,
+    block_counts: torch.LongTensor | int,
+    block_size: int = 64,
+    scale: float = None,
+    cu_seqlens: torch.LongTensor | None = None,
+) -> torch.LongTensor:
+    B, T, HQ, K = q.shape
+    H = k.shape[2]
+    G = HQ // H
+    # the number of selected blocks for each token
+    S = block_counts if isinstance(block_counts, int) else block_counts.max().item()
+    S = triton.next_power_of_2(S)
+    # here we set BC = BS, but beware that they can be chosen separately if required
+    BC = BS = block_size
+    BK = max(triton.next_power_of_2(K), 16)
+    assert BC >= 2 * S, f"BC ({BC}) must be greater than or equal to 2 * S ({S})"
+
+    block_indices = torch.zeros(B, T, H, S, dtype=torch.int32, device=q.device)
+    token_indices = (
+        prepare_token_indices(cu_seqlens) if cu_seqlens is not None else None
+    )
+    chunk_offsets = (
+        prepare_chunk_offsets(cu_seqlens, BS) if cu_seqlens is not None else None
+    )
+    grid = (T, B * H)
+    # the 1st and the last 2 blocks are always selected
+    parallel_nsa_kernel_topk[grid](
+        q=q,
+        k=k,
+        lse=lse,
+        scale=scale,
+        block_indices=block_indices,
+        cu_seqlens=cu_seqlens,
+        token_indices=token_indices,
+        chunk_offsets=chunk_offsets,
+        T=T,
+        H=H,
+        HQ=HQ,
+        G=G,
+        K=K,
+        S=S,
+        BC=BC,
+        BS=BS,
+        BK=BK,
+    )
+    return block_indices
+
+
+def parallel_nsa_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    block_indices: torch.LongTensor,
+    block_counts: torch.LongTensor | int,
+    block_size: int,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    token_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K, V, S = *k.shape, v.shape[-1], block_indices.shape[-1]
+    HQ = q.shape[2]
+    G = HQ // H
+    BS = block_size
+    if check_shared_mem("hopper", q.device.index):
+        BK = min(256, triton.next_power_of_2(K))
+        BV = min(256, triton.next_power_of_2(V))
+    else:
+        BK = min(128, triton.next_power_of_2(K))
+        BV = min(128, triton.next_power_of_2(V))
+    # MetaX: cap the output tile to avoid severe D=128 register pressure.
+    BV = min(BV, 64)
+    NK = triton.cdiv(K, BK)
+    NV = triton.cdiv(V, BV)
+    assert NK == 1, "The key dimension can not be larger than 256"
+
+    grid = (T, NV, B * H)
+    o = torch.empty(B, T, HQ, V, dtype=v.dtype, device=q.device)
+    lse = torch.empty(B, T, HQ, dtype=torch.float, device=q.device)
+
+    # Dispatch to TLE-optimized kernel when available.
+    _use_tle = HAS_TLE and os.environ.get("FLA_NSA_TLE", "1") != "0"
+    if _use_tle:
+        kernel = parallel_nsa_fwd_kernel_tle
+    else:
+        kernel = parallel_nsa_fwd_kernel
+
+    kernel[grid](
+        q=q,
+        k=k,
+        v=v,
+        o=o,
+        lse=lse,
+        scale=scale,
+        block_indices=block_indices,
+        block_counts=block_counts,
+        cu_seqlens=cu_seqlens,
+        token_indices=token_indices,
+        T=T,
+        H=H,
+        HQ=HQ,
+        G=G,
+        K=K,
+        V=V,
+        S=S,
+        BS=BS,
+        BK=BK,
+        BV=BV,
+    )
+    return o, lse
+
+
+def parallel_nsa_block_mask(
+    block_indices: torch.LongTensor,
+    block_counts: torch.LongTensor | int,
+    cu_seqlens: torch.LongTensor,
+    block_size: int,
+):
+    B, T, H, S = block_indices.shape
+    BS = block_size
+    if cu_seqlens is not None:
+        NS = triton.cdiv(prepare_lens(cu_seqlens).max().item(), BS)
+    else:
+        NS = triton.cdiv(T, BS)
+    block_mask = torch.zeros(B, T, H, NS, dtype=torch.bool, device=block_indices.device)
+
+    parallel_nsa_kernel_mask[(T, B, H * S)](
+        block_indices=block_indices,
+        block_counts=block_counts,
+        block_mask=block_mask,
+        T=T,
+        H=H,
+        S=S,
+        BS=BS,
+        NS=NS,
+    )
+    return block_mask
+
+
+def parallel_nsa_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    o: torch.Tensor,
+    lse: torch.Tensor,
+    do: torch.Tensor,
+    block_indices: torch.Tensor,
+    block_counts: torch.LongTensor | int,
+    block_size: int = 64,
+    scale: float = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    token_indices: torch.LongTensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K, V, S = *k.shape, v.shape[-1], block_indices.shape[-1]
+    HQ = q.shape[2]
+    G = HQ // H
+    BS = block_size
+    BK = max(triton.next_power_of_2(K), 16)
+    BV = min(128, max(triton.next_power_of_2(v.shape[-1]), 16))
+    NV = triton.cdiv(V, BV)
+
+    delta = parallel_attn_bwd_preprocess(o, do)
+
+    dq = torch.empty(
+        NV, *q.shape, dtype=q.dtype if NV == 1 else torch.float, device=q.device
+    )
+    grid = (T, NV, B * H)
+    parallel_nsa_bwd_kernel_dq[grid](
+        q=q,
+        k=k,
+        v=v,
+        lse=lse,
+        delta=delta,
+        do=do,
+        dq=dq,
+        block_indices=block_indices,
+        block_counts=block_counts,
+        cu_seqlens=cu_seqlens,
+        token_indices=token_indices,
+        scale=scale,
+        T=T,
+        B=B,
+        H=H,
+        HQ=HQ,
+        G=G,
+        K=K,
+        V=V,
+        S=S,
+        BS=BS,
+        BK=BK,
+        BV=BV,
+    )
+    dq = dq.sum(0)
+
+    if cu_seqlens is not None:
+        if chunk_indices is None:
+            chunk_indices = prepare_chunk_indices(cu_seqlens, BS)
+        NS = len(chunk_indices)
+    else:
+        NS = triton.cdiv(T, BS)
+
+    block_mask = parallel_nsa_block_mask(
+        block_indices, block_counts, cu_seqlens, block_size
+    )
+    dk = torch.empty(
+        NV, *k.shape, dtype=k.dtype if NV == 1 else torch.float, device=q.device
+    )
+    dv = torch.empty(v.shape, dtype=v.dtype, device=q.device)
+
+    grid = (NV, NS, B * H)
+    parallel_nsa_bwd_kernel_dkv[grid](
+        q=q,
+        k=k,
+        v=v,
+        lse=lse,
+        delta=delta,
+        do=do,
+        dk=dk,
+        dv=dv,
+        block_mask=block_mask,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        B=B,
+        H=H,
+        HQ=HQ,
+        G=G,
+        K=K,
+        V=V,
+        M=block_mask.shape[-1],
+        BS=BS,
+        BK=BK,
+        BV=BV,
+    )
+    dk = dk.sum(0)
+    return dq, dk, dv
+
+
+# ===========================================================================
+# Autograd Function
+# ===========================================================================
+
+
+class ParallelNSAFunction(torch.autograd.Function):
+
+    @staticmethod
+    @input_guard
+    def forward(
+        ctx, q, k, v, block_indices, block_counts, block_size, scale, cu_seqlens
+    ):
+        ctx.dtype = q.dtype
+
+        token_indices = (
+            prepare_token_indices(cu_seqlens) if cu_seqlens is not None else None
+        )
+
+        o, lse = parallel_nsa_fwd(
+            q=q,
+            k=k,
+            v=v,
+            block_indices=block_indices,
+            block_counts=block_counts,
+            block_size=block_size,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            token_indices=token_indices,
+        )
+        ctx.save_for_backward(q, k, v, o, lse)
+        ctx.block_indices = block_indices
+        ctx.block_counts = block_counts
+        ctx.cu_seqlens = cu_seqlens
+        ctx.token_indices = token_indices
+        ctx.block_size = block_size
+        ctx.scale = scale
+        return o.to(q.dtype)
+
+    @staticmethod
+    @input_guard
+    def backward(ctx, do):
+        q, k, v, o, lse = ctx.saved_tensors
+        dq, dk, dv = parallel_nsa_bwd(
+            q=q,
+            k=k,
+            v=v,
+            o=o,
+            lse=lse,
+            do=do,
+            block_indices=ctx.block_indices,
+            block_counts=ctx.block_counts,
+            block_size=ctx.block_size,
+            scale=ctx.scale,
+            cu_seqlens=ctx.cu_seqlens,
+            token_indices=ctx.token_indices,
+        )
+        return dq.to(q), dk.to(k), dv.to(v), None, None, None, None, None
+
+
+def parallel_nsa(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g_cmp: torch.Tensor | None = None,
+    g_slc: torch.Tensor | None = None,
+    g_swa: torch.Tensor | None = None,
+    block_indices: torch.LongTensor | None = None,
+    block_counts: torch.LongTensor | int = 16,
+    block_size: int = 64,
+    window_size: int = 0,
+    scale: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+) -> torch.Tensor:
+    r"""
+    Native Sparse Attention (NSA) — parallel implementation.
+
+    Args:
+        q (torch.Tensor):
+            queries of shape ``[B, T, HQ, K]``.
+        k (torch.Tensor):
+            keys of shape ``[B, T, H, K]``.
+            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H)
+            must be a power of 2 and >= 16.
+        v (torch.Tensor):
+            values of shape ``[B, T, H, V]``.
+        g_cmp (torch.Tensor):
+            Gate score for compressed attention of shape ``[B, T, HQ]``. If provided,
+            ``block_indices`` will be computed automatically.
+        g_slc (torch.Tensor):
+            Gate score for selected attention of shape ``[B, T, HQ]``.
+        g_swa (torch.Tensor):
+            Gate score for sliding window attention of shape ``[B, T, HQ]``.
+        block_indices (torch.LongTensor):
+            Pre-computed block indices of shape ``[B, T, H, S]``.
+            If ``g_cmp`` is provided, this is computed automatically.
+        block_counts (int or torch.LongTensor):
+            Number of selected blocks for each query. If a tensor, shape ``[B, T, H]``.
+            Default: 16.
+        block_size (int):
+            Size of each selected block. Default: 64.
+        window_size (int):
+            Sliding window size. 0 means no sliding attention. Default: 0.
+        scale (float):
+            Scale factor. If ``None``, defaults to ``K ** -0.5``.
+        cu_seqlens (torch.LongTensor):
+            Cumulative sequence lengths for variable-length sequences.
+
+    Returns:
+        torch.Tensor of shape ``[B, T, HQ, V]``.
+    """
+    assert block_counts is not None, "block counts must be provided for selection"
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    if cu_seqlens is not None and q.shape[0] != 1:
+        raise ValueError(
+            f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`. "
+            f"Please flatten variable-length inputs before processing.",
+        )
+    assert (
+        q.shape[2] % (k.shape[2] * 16) == 0
+    ), "Group size must be a multiple of 16 in NSA"
+
+    k_cmp = mean_pooling(k, block_size, cu_seqlens)
+    v_cmp = mean_pooling(v, block_size, cu_seqlens)
+    o_cmp, lse_cmp = None, None
+    if g_cmp is not None:
+        o_cmp, lse_cmp = parallel_nsa_compression(
+            q=q,
+            k=k_cmp,
+            v=v_cmp,
+            block_size=block_size,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+        )
+        if block_indices is not None:
+            warnings.warn("`block_indices` will be ignored when `g_cmp` is provided")
+        block_indices = parallel_nsa_topk(
+            q=q,
+            k=k_cmp,
+            lse=lse_cmp,
+            block_counts=block_counts,
+            block_size=block_size,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+        )
+    o = o_slc = ParallelNSAFunction.apply(
+        q, k, v, block_indices, block_counts, block_size, scale, cu_seqlens
+    )
+    if g_slc is not None:
+        o = o_slc * g_slc.unsqueeze(-1)
+    if o_cmp is not None:
+        o = torch.addcmul(o, o_cmp, g_cmp.unsqueeze(-1))
+    if window_size > 0:
+        try:
+            from flash_attn import flash_attn_func, flash_attn_varlen_func
+        except ImportError:
+            raise ImportError(
+                "Flash Attention is required for sliding window attention. "
+                "Install it via `pip install flash-attn --no-build-isolation`"
+            )
+        if cu_seqlens is not None:
+            max_seqlen = q.shape[1]
+            o_swa = flash_attn_varlen_func(
+                q.squeeze(0),
+                k.squeeze(0),
+                v.squeeze(0),
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+                causal=True,
+                window_size=(window_size - 1, 0),
+            ).unsqueeze(0)
+        else:
+            o_swa = flash_attn_func(
+                q,
+                k,
+                v,
+                causal=True,
+                window_size=(window_size - 1, 0),
+            )
+        o = torch.addcmul(o, o_swa, g_swa.unsqueeze(-1))
+    return o

--- a/src/flaggems_vllm/runtime/backend/_metax/ops/parallel_nsa_compression.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/ops/parallel_nsa_compression.py
@@ -1,0 +1,927 @@
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import torch
+import triton
+import triton.language as tl
+
+from flaggems_vllm.ops.FLA.bwd_preprocess import parallel_attn_bwd_preprocess
+from flaggems_vllm.ops.FLA.index import (
+    prepare_chunk_indices,
+    prepare_chunk_offsets,
+    prepare_token_indices,
+)
+from flaggems_vllm.ops.FLA.triton_ops_helper import autotune_cache_kwargs, exp, log
+from flaggems_vllm.ops.FLA.utils import check_shared_mem, input_guard
+
+# ===========================================================================
+# Forward kernel
+# ===========================================================================
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BC": bc}, num_warps=num_warps, num_stages=num_stages)
+        for bc in [64, 32, 16]
+        for num_warps in [1, 2, 4]
+        for num_stages in [1, 2, 3]
+    ],
+    key=["BS", "BK", "BV"],
+    **autotune_cache_kwargs,
+)
+@triton.jit
+def parallel_nsa_compression_fwd_kernel(
+    q,
+    k,
+    v,
+    o,
+    lse,
+    scale,
+    cu_seqlens,
+    token_indices,
+    chunk_offsets,
+    T,
+    H: tl.constexpr,
+    HQ: tl.constexpr,
+    G: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BC: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_v, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(
+            token_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+        boc = tl.load(chunk_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_b * T, i_b * T + T
+        boc = i_b * tl.cdiv(T, BS)
+
+    p_q = tl.make_block_ptr(
+        q + (bos + i_t) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0)
+    )
+
+    # the Q block is kept in the shared memory throughout the whole kernel
+    # [G, BK]
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = (b_q * scale).to(b_q.dtype)
+
+    # the number of compression representations in total
+    TC = tl.cdiv(T, BS)
+    # the number of compression representations required to iterate over
+    # incomplete compression blocks are not included
+    NC = (i_t + 1) // BS
+
+    p_o = tl.make_block_ptr(
+        o + (bos + i_t) * HQ * V, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0)
+    )
+    # [G, BV]
+    b_o = tl.zeros([G, BV], dtype=tl.float32)
+    # max scores for the current block
+    b_m = tl.full([G], float("-inf"), dtype=tl.float32)
+    # lse = log(acc) + m
+    b_acc = tl.zeros([G], dtype=tl.float32)
+
+    for i_c in range(0, NC, BC):
+        o_c = i_c + tl.arange(0, BC)
+
+        p_k = tl.make_block_ptr(
+            k + (boc * H + i_h) * K, (K, TC), (1, H * K), (0, i_c), (BK, BC), (0, 1)
+        )
+        p_v = tl.make_block_ptr(
+            v + (boc * H + i_h) * V,
+            (TC, V),
+            (H * V, 1),
+            (i_c, i_v * BV),
+            (BC, BV),
+            (1, 0),
+        )
+        # [BK, BC]
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        # [BC, BV]
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        # [G, BC]
+        b_s = tl.dot(b_q, b_k)
+        b_s = tl.where((o_c < NC)[None, :], b_s, float("-inf"))
+
+        # [G]
+        b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
+        b_r = exp(b_mp - b_m)
+        # [G, BC]
+        b_p = exp(b_s - b_m[:, None])
+        # [G]
+        b_acc = tl.math.fma(b_acc, b_r, tl.sum(b_p, 1))
+
+        # [G, BV]
+        b_o = tl.math.fma(b_o, b_r[:, None], tl.dot(b_p.to(b_q.dtype), b_v))
+
+        b_mp = b_m
+    if NC == 0:
+        b_lse = tl.zeros([G], dtype=tl.float32)
+    else:
+        b_o = b_o / b_acc[:, None]
+        b_lse = b_m + log(b_acc)
+
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    if i_v == 0:
+        tl.store(
+            lse + (bos + i_t) * HQ + i_h * G + tl.arange(0, G),
+            b_lse.to(lse.dtype.element_ty),
+        )
+
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BC": bc}, num_warps=num_warps, num_stages=num_stages)
+        for bc in [64, 32, 16]
+        for num_warps in [1, 2, 4]
+        for num_stages in [1, 2, 3]
+    ],
+    key=["BS", "BK", "BV"],
+    **autotune_cache_kwargs,
+)
+@triton.jit
+def parallel_nsa_compression_fwd_kernel_g_lt_16(
+    q,
+    k,
+    v,
+    o,
+    lse,
+    scale,
+    cu_seqlens,
+    token_indices,
+    chunk_offsets,
+    T,
+    H: tl.constexpr,
+    HQ: tl.constexpr,
+    G: tl.constexpr,
+    BG: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BC: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_v, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(
+            token_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+        boc = tl.load(chunk_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_b * T, i_b * T + T
+        boc = i_b * tl.cdiv(T, BS)
+
+    if G < 16:
+        p_q = tl.make_block_ptr(
+            q + ((bos + i_t) * HQ + i_h * G) * K,
+            (G, K),
+            (K, 1),
+            (0, 0),
+            (BG, BK),
+            (1, 0),
+        )
+    else:
+        p_q = tl.make_block_ptr(
+            q + (bos + i_t) * HQ * K,
+            (HQ, K),
+            (K, 1),
+            (i_h * G, 0),
+            (G, BK),
+            (1, 0),
+        )
+
+    # the Q block is kept in the shared memory throughout the whole kernel
+    # [G, BK]
+    if G < 16:
+        b_q = tl.load(
+            p_q, boundary_check=(0, 1), padding_option="zero"
+        )
+    else:
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = (b_q * scale).to(b_q.dtype)
+
+    # the number of compression representations in total
+    TC = tl.cdiv(T, BS)
+    # the number of compression representations required to iterate over
+    # incomplete compression blocks are not included
+    NC = (i_t + 1) // BS
+
+    if G < 16:
+        p_o = tl.make_block_ptr(
+            o + ((bos + i_t) * HQ + i_h * G) * V,
+            (G, V),
+            (V, 1),
+            (0, i_v * BV),
+            (BG, BV),
+            (1, 0),
+        )
+    else:
+        p_o = tl.make_block_ptr(
+            o + (bos + i_t) * HQ * V,
+            (HQ, V),
+            (V, 1),
+            (i_h * G, i_v * BV),
+            (G, BV),
+            (1, 0),
+        )
+    # [G, BV]
+    b_o = tl.zeros([BG, BV], dtype=tl.float32)
+    # max scores for the current block
+    b_m = tl.full([BG], float("-inf"), dtype=tl.float32)
+    # lse = log(acc) + m
+    b_acc = tl.zeros([BG], dtype=tl.float32)
+
+    for i_c in range(0, NC, BC):
+        o_c = i_c + tl.arange(0, BC)
+
+        p_k = tl.make_block_ptr(
+            k + (boc * H + i_h) * K, (K, TC), (1, H * K), (0, i_c), (BK, BC), (0, 1)
+        )
+        p_v = tl.make_block_ptr(
+            v + (boc * H + i_h) * V,
+            (TC, V),
+            (H * V, 1),
+            (i_c, i_v * BV),
+            (BC, BV),
+            (1, 0),
+        )
+        # [BK, BC]
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        # [BC, BV]
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        # [G, BC]
+        b_s = tl.dot(b_q, b_k)
+        b_s = tl.where((o_c < NC)[None, :], b_s, float("-inf"))
+
+        # [G]
+        b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
+        b_r = exp(b_mp - b_m)
+        # [G, BC]
+        b_p = exp(b_s - b_m[:, None])
+        # [G]
+        b_acc = tl.math.fma(b_acc, b_r, tl.sum(b_p, 1))
+
+        # [G, BV]
+        b_o = tl.math.fma(b_o, b_r[:, None], tl.dot(b_p.to(b_q.dtype), b_v))
+
+        b_mp = b_m
+    if NC == 0:
+        b_lse = tl.zeros([BG], dtype=tl.float32)
+    else:
+        b_o = b_o / b_acc[:, None]
+        b_lse = b_m + log(b_acc)
+
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    if i_v == 0:
+        if G < 16:
+            o_g = tl.arange(0, BG)
+            tl.store(
+                lse + (bos + i_t) * HQ + i_h * G + o_g,
+                b_lse.to(lse.dtype.element_ty),
+                mask=o_g < G,
+            )
+        else:
+            tl.store(
+                lse + (bos + i_t) * HQ + i_h * G + tl.arange(0, G),
+                b_lse.to(lse.dtype.element_ty),
+            )
+
+
+# ===========================================================================
+# Backward kernel: dQ
+# ===========================================================================
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [1, 2, 4]
+        for num_stages in [1, 2, 3]
+    ],
+    key=["BS", "BK", "BV"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def parallel_nsa_compression_bwd_kernel_dq(
+    q,
+    k,
+    v,
+    lse,
+    delta,
+    do,
+    dq,
+    scale,
+    cu_seqlens,
+    token_indices,
+    chunk_offsets,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    HQ: tl.constexpr,
+    G: tl.constexpr,
+    BG: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BC: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_v, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    all = B * T
+    if IS_VARLEN:
+        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(
+            token_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+        boc = tl.load(chunk_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_b * T, i_b * T + T
+        boc = i_b * tl.cdiv(T, BS)
+
+    q += (bos + i_t) * HQ * K
+    do += (bos + i_t) * HQ * V
+    lse += (bos + i_t) * HQ
+    delta += (bos + i_t) * HQ
+    dq += (i_v * all + bos + i_t) * HQ * K
+
+    o_g = tl.arange(0, BG)
+    m_g = o_g < G
+    p_q = tl.make_block_ptr(
+        q + i_h * G * K,
+        (G, K),
+        (K, 1),
+        (0, 0),
+        (BG, BK),
+        (1, 0),
+    )
+    p_dq = tl.make_block_ptr(
+        dq + i_h * G * K,
+        (G, K),
+        (K, 1),
+        (0, 0),
+        (BG, BK),
+        (1, 0),
+    )
+
+    # [G, BK]
+    b_q = tl.load(
+        p_q, boundary_check=(0, 1), padding_option="zero"
+    )
+    b_q = (b_q * scale).to(b_q.dtype)
+
+    p_do = tl.make_block_ptr(
+        do + i_h * G * V,
+        (G, V),
+        (V, 1),
+        (0, i_v * BV),
+        (BG, BV),
+        (1, 0),
+    )
+    p_lse = lse + i_h * G + o_g
+    p_delta = delta + i_h * G + o_g
+
+    # the number of compression representations in total
+    TC = tl.cdiv(T, BS)
+    # the number of compression representations required to iterate over
+    # incomplete compression blocks are not included
+    NC = (i_t + 1) // BS
+
+    # [G, BV]
+    b_do = tl.load(
+        p_do, boundary_check=(0, 1), padding_option="zero"
+    )
+    # [G]
+    b_lse = tl.load(p_lse, mask=m_g, other=0.0)
+    b_delta = tl.load(p_delta, mask=m_g, other=0.0)
+
+    # [G, BK]
+    b_dq = tl.zeros([BG, BK], dtype=tl.float32)
+    for i_c in range(0, NC, BC):
+        o_c = i_c + tl.arange(0, BC)
+        p_k = tl.make_block_ptr(
+            k + (boc * H + i_h) * K, (K, TC), (1, H * K), (0, i_c), (BK, BC), (0, 1)
+        )
+        p_v = tl.make_block_ptr(
+            v + (boc * H + i_h) * V,
+            (V, TC),
+            (1, H * V),
+            (i_v * BV, i_c),
+            (BV, BC),
+            (0, 1),
+        )
+        # [BK, BC]
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        # [BV, BC]
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+
+        # [G, BC]
+        b_s = tl.dot(b_q, b_k)
+        b_p = exp(b_s - b_lse[:, None])
+        b_p = tl.where(
+            (o_c < NC)[None, :] & m_g[:, None], b_p, 0
+        )
+
+        # [G, BV] @ [BV, BC] -> [G, BC]
+        b_dp = tl.dot(b_do, b_v)
+        b_ds = b_p * (b_dp.to(tl.float32) - b_delta[:, None])
+        # [G, BC] @ [BC, BK] -> [G, BK]
+        b_dq += tl.dot(b_ds.to(b_k.dtype), tl.trans(b_k))
+    b_dq *= scale
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+
+
+# ===========================================================================
+# Backward kernel: dK / dV
+# ===========================================================================
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [1, 2, 4]
+        for num_stages in [1, 2, 3]
+    ],
+    key=["BS", "BK", "BV"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T", "TC"])
+def parallel_nsa_compression_bwd_kernel_dkv(
+    q,
+    k,
+    v,
+    lse,
+    delta,
+    do,
+    dk,
+    dv,
+    cu_seqlens,
+    chunk_indices,
+    chunk_offsets,
+    scale,
+    T,
+    TC,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    HQ: tl.constexpr,
+    G: tl.constexpr,
+    BG: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BC: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    all = B * TC
+
+    if IS_VARLEN:
+        i_n, i_c = tl.load(chunk_indices + i_c * 2).to(tl.int32), tl.load(
+            chunk_indices + i_c * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+        # the number of compression representations in total
+        TC = tl.cdiv(T, BS)
+        boc = tl.load(chunk_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_b * T, i_b * T + T
+        boc = i_b * tl.cdiv(T, BS)
+
+    p_k = tl.make_block_ptr(
+        k + (boc * H + i_h) * K, (TC, K), (H * K, 1), (i_c * BC, 0), (BC, BK), (1, 0)
+    )
+    p_v = tl.make_block_ptr(
+        v + (boc * H + i_h) * V,
+        (TC, V),
+        (H * V, 1),
+        (i_c * BC, i_v * BV),
+        (BC, BV),
+        (1, 0),
+    )
+    p_dk = tl.make_block_ptr(
+        dk + (i_v * all * H + boc * H + i_h) * K,
+        (TC, K),
+        (H * K, 1),
+        (i_c * BC, 0),
+        (BC, BK),
+        (1, 0),
+    )
+    p_dv = tl.make_block_ptr(
+        dv + (boc * H + i_h) * V,
+        (TC, V),
+        (H * V, 1),
+        (i_c * BC, i_v * BV),
+        (BC, BV),
+        (1, 0),
+    )
+
+    # [BC, BK]
+    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_dk = tl.zeros([BC, BK], dtype=tl.float32)
+    # [BC, BV]
+    b_v = tl.load(p_v, boundary_check=(0, 1))
+    b_dv = tl.zeros([BC, BV], dtype=tl.float32)
+    o_g = tl.arange(0, BG)
+    m_g = o_g < G
+
+    for i in range(i_c * BC * BS, T):
+        o_c = i_c * BC + tl.arange(0, BC)
+
+        p_q = tl.make_block_ptr(
+            q + ((bos + i) * HQ + i_h * G) * K,
+            (G, K),
+            (K, 1),
+            (0, 0),
+            (BG, BK),
+            (1, 0),
+        )
+        # [G, BK]
+        b_q = tl.load(
+            p_q, boundary_check=(0, 1), padding_option="zero"
+        )
+        b_q = (b_q * scale).to(b_q.dtype)
+
+        p_do = tl.make_block_ptr(
+            do + ((bos + i) * HQ + i_h * G) * V,
+            (G, V),
+            (V, 1),
+            (0, i_v * BV),
+            (BG, BV),
+            (1, 0),
+        )
+        p_lse = lse + (bos + i) * HQ + i_h * G + o_g
+        p_delta = delta + (bos + i) * HQ + i_h * G + o_g
+        # [G, BV]
+        b_do = tl.load(
+            p_do, boundary_check=(0, 1), padding_option="zero"
+        )
+        # [G]
+        b_lse = tl.load(p_lse, mask=m_g, other=0.0)
+        b_delta = tl.load(p_delta, mask=m_g, other=0.0)
+        # [BC, G]
+        b_s = tl.dot(b_k, tl.trans(b_q))
+        b_p = exp(b_s - b_lse[None, :])
+        b_p = tl.where(
+            (i >= max(0, (o_c + 1) * BS - 1))[:, None]
+            & m_g[None, :],
+            b_p,
+            0,
+        )
+        # [BC, G] @ [G, BV] -> [BC, BV]
+        b_dv += tl.dot(b_p.to(b_do.dtype), b_do)
+        # [BC, BV] @ [BV, G] -> [BC, G]
+        b_dp = tl.dot(b_v, tl.trans(b_do))
+        # [BC, G]
+        b_ds = b_p * (b_dp - b_delta[None, :])
+        # [BC, G] @ [G, BK] -> [BC, BK]
+        b_dk += tl.dot(b_ds.to(b_q.dtype), b_q)
+
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+
+
+# ===========================================================================
+# Python-level wrapper functions (forward / backward)
+# ===========================================================================
+
+
+def parallel_nsa_compression_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    block_size: int,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    token_indices: torch.LongTensor | None = None,
+):
+    B, T, HQ, K, V = *q.shape, v.shape[-1]
+    H = k.shape[2]
+    G = HQ // H
+    BS = block_size
+    if check_shared_mem("hopper", q.device.index):
+        BK = min(256, triton.next_power_of_2(K))
+        BV = min(256, triton.next_power_of_2(V))
+    else:
+        BK = min(128, triton.next_power_of_2(K))
+        BV = min(128, triton.next_power_of_2(V))
+    NK = triton.cdiv(K, BK)
+    NV = triton.cdiv(V, BV)
+    assert NK == 1, "The key dimension can not be larger than 256"
+
+    chunk_offsets = (
+        prepare_chunk_offsets(cu_seqlens, BS) if cu_seqlens is not None else None
+    )
+
+    grid = (T, NV, B * H)
+    o = torch.empty(B, T, HQ, V, dtype=v.dtype, device=q.device)
+    lse = torch.empty(B, T, HQ, dtype=torch.float, device=q.device)
+
+    if G < 16:
+        parallel_nsa_compression_fwd_kernel_g_lt_16[grid](
+            q=q,
+            k=k,
+            v=v,
+            o=o,
+            lse=lse,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            token_indices=token_indices,
+            chunk_offsets=chunk_offsets,
+            T=T,
+            H=H,
+            HQ=HQ,
+            G=G,
+            BG=max(G, 16),
+            K=K,
+            V=V,
+            BS=BS,
+            BK=BK,
+            BV=BV,
+        )
+    else:
+        parallel_nsa_compression_fwd_kernel[grid](
+            q=q,
+            k=k,
+            v=v,
+            o=o,
+            lse=lse,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            token_indices=token_indices,
+            chunk_offsets=chunk_offsets,
+            T=T,
+            H=H,
+            HQ=HQ,
+            G=G,
+            K=K,
+            V=V,
+            BS=BS,
+            BK=BK,
+            BV=BV,
+        )
+    return o, lse
+
+
+def parallel_nsa_compression_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    o: torch.Tensor,
+    lse: torch.Tensor,
+    do: torch.Tensor,
+    block_size: int = 64,
+    scale: float = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    token_indices: torch.LongTensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, HQ, K, V = *q.shape, v.shape[-1]
+    TC = k.shape[1]
+    H = k.shape[2]
+    G = HQ // H
+    # MetaX tl.dot requires group tiles of at least 16 lanes.
+    BG = max(G, 16)
+    BC = BS = block_size
+    BK = max(triton.next_power_of_2(K), 16)
+    BV = min(128, max(triton.next_power_of_2(v.shape[-1]), 16))
+    NV = triton.cdiv(V, BV)
+    if cu_seqlens is not None:
+        chunk_offsets = prepare_chunk_offsets(cu_seqlens, BS)
+        if chunk_indices is None:
+            chunk_indices = prepare_chunk_indices(chunk_offsets, BC)
+        NC = len(chunk_indices)
+    else:
+        chunk_indices, chunk_offsets = None, None
+        NC = triton.cdiv(triton.cdiv(T, BS), BC)
+
+    delta = parallel_attn_bwd_preprocess(o, do)
+
+    dq = torch.empty(
+        NV, *q.shape, dtype=q.dtype if NV == 1 else torch.float, device=q.device
+    )
+    grid = (T, NV, B * H)
+    parallel_nsa_compression_bwd_kernel_dq[grid](
+        q=q,
+        k=k,
+        v=v,
+        lse=lse,
+        delta=delta,
+        do=do,
+        dq=dq,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        token_indices=token_indices,
+        chunk_offsets=chunk_offsets,
+        T=T,
+        B=B,
+        H=H,
+        HQ=HQ,
+        G=G,
+        BG=BG,
+        K=K,
+        V=V,
+        BC=BC,
+        BS=BS,
+        BK=BK,
+        BV=BV,
+    )
+    dq = dq.sum(0)
+
+    dk = torch.empty(
+        NV, *k.shape, dtype=k.dtype if NV == 1 else torch.float, device=q.device
+    )
+    dv = torch.empty(v.shape, dtype=v.dtype, device=q.device)
+
+    grid = (NV, NC, B * H)
+    parallel_nsa_compression_bwd_kernel_dkv[grid](
+        q=q,
+        k=k,
+        v=v,
+        lse=lse,
+        delta=delta,
+        do=do,
+        dk=dk,
+        dv=dv,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
+        scale=scale,
+        T=T,
+        TC=TC,
+        B=B,
+        H=H,
+        HQ=HQ,
+        G=G,
+        BG=BG,
+        K=K,
+        V=V,
+        BC=BC,
+        BS=BS,
+        BK=BK,
+        BV=BV,
+    )
+    dk = dk.sum(0)
+    return dq, dk, dv
+
+
+# ===========================================================================
+# Autograd Function
+# ===========================================================================
+
+
+class ParallelNSACompressionFunction(torch.autograd.Function):
+
+    @staticmethod
+    @input_guard
+    @torch.amp.custom_fwd(device_type="cuda")
+    def forward(
+        ctx,
+        q,
+        k,
+        v,
+        block_size,
+        scale,
+        cu_seqlens,
+    ):
+        ctx.dtype = q.dtype
+
+        # 2-d sequence indices denoting the cu_seqlens of tokens in each sequence
+        # for example, if the passed `cu_seqlens` is [0, 2, 6],
+        # then there are 2 and 4 tokens in the 1st and 2nd sequences respectively, and `token_indices` will be
+        # [[0, 0], [0, 1], [1, 0], [1, 1], [1, 2], [1, 3]]
+        token_indices = (
+            prepare_token_indices(cu_seqlens) if cu_seqlens is not None else None
+        )
+
+        o, lse = parallel_nsa_compression_fwd(
+            q=q,
+            k=k,
+            v=v,
+            block_size=block_size,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            token_indices=token_indices,
+        )
+        ctx.save_for_backward(q, k, v, o, lse)
+        ctx.cu_seqlens = cu_seqlens
+        ctx.token_indices = token_indices
+        ctx.block_size = block_size
+        ctx.scale = scale
+        return o.to(q.dtype), lse
+
+    @staticmethod
+    @input_guard
+    @torch.amp.custom_bwd(device_type="cuda")
+    def backward(ctx, do, *args):
+        q, k, v, o, lse = ctx.saved_tensors
+        dq, dk, dv = parallel_nsa_compression_bwd(
+            q=q,
+            k=k,
+            v=v,
+            o=o,
+            lse=lse,
+            do=do,
+            block_size=ctx.block_size,
+            scale=ctx.scale,
+            cu_seqlens=ctx.cu_seqlens,
+            token_indices=ctx.token_indices,
+        )
+        return dq.to(q), dk.to(k), dv.to(v), None, None, None
+
+
+# ===========================================================================
+# Public API
+# ===========================================================================
+
+
+def parallel_nsa_compression(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    block_size: int = 64,
+    scale: float = None,
+    cu_seqlens: torch.LongTensor | None = None,
+):
+    """NSA-style parallel compression forward with backward support.
+
+    Args:
+        q: Query tensor of shape ``[B, T, HQ, K]``.
+        k: Key tensor of shape ``[B, T, H, K]`` (compressed representation).
+        v: Value tensor of shape ``[B, T, H, V]`` (compressed representation).
+        block_size: Compression block size (default 64).
+        scale: Attention scale. If ``None``, defaults to ``K ** -0.5``.
+        cu_seqlens: Optional CUDA-style cumulative sequence lengths for
+            variable-length sequences.
+
+    Returns:
+        Output tensor ``o`` of shape ``[B, T, HQ, V]`` and log-sum-exp
+        tensor ``lse`` of shape ``[B, T, HQ]``.
+    """
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    return ParallelNSACompressionFunction.apply(
+        q,
+        k,
+        v,
+        block_size,
+        scale,
+        cu_seqlens,
+    )


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

New Feature

### Description

Add MetaX C550 implementations of Native Sparse Attention:

- Add `parallel_nsa`, including forward, backward, Top-K selection, block mask, GQA, causal and variable-length support.
- Add `parallel_nsa_compression`, including forward and backward support.
- Add a MetaX-compatible `G < 16` path while preserving the existing `G >= 16` fast path.
- Export both operators from the MetaX backend package.
- Support FP16/BF16 inputs with FP32 accumulation and optional TLE dispatch.

The PR contains only three files:

- `runtime/backend/_metax/ops/__init__.py`
- `runtime/backend/_metax/ops/parallel_nsa.py`
- `runtime/backend/_metax/ops/parallel_nsa_compression.py`

### Issue

N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

Validation on MetaX C550:

- `tests/test_parallel_nsa.py -k parallel_varlen`: 3 passed
- `tests/test_parallel_nsa_compression.py`: 8 passed
- MetaX backend public imports and dispatch: passed

### Performance

Environment:

- Device: MetaX C550
- PyTorch: 2.8.0+metax3.7.2.0
- Triton: 3.6.0
- Python: 3.12.11
- `FLA_NSA_TLE=1`
- Benchmark mode: kernel / comprehensive

Official benchmark latency for `parallel_nsa`
(`block_size=64`, `selected_blocks=16`):

| B | T | HQ | Hkv | D | BF16 (ms) | FP16 (ms) |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 16384 | 64 | 4 | 64 | 9.587200 | 8.423680 |
| 1 | 8192 | 256 | 16 | 64 | 17.444351 | 14.721152 |
| 1 | 16384 | 256 | 16 | 64 | 38.516609 | 31.980288 |
| 1 | 65536 | 256 | 16 | 64 | 200.021759 | 165.646851 |
| 1 | 16384 | 512 | 32 | 64 | 77.890045 | 68.959488 |
| 1 | 16384 | 256 | 16 | 128 | 133.148926 | 130.905853 |
| 4 | 8192 | 256 | 16 | 64 | 69.590019 | 58.683392 |

Official benchmark latency for `parallel_nsa_compression`
(`block_size=64`):

| B | T | HQ | Hkv | D | BF16 (ms) | FP16 (ms) |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 16384 | 64 | 4 | 64 | 3.150720 | 3.090944 |
| 1 | 8192 | 256 | 16 | 64 | 3.773440 | 3.628032 |
| 1 | 16384 | 256 | 16 | 64 | 12.510720 | 12.268672 |
| 1 | 65536 | 256 | 16 | 64 | 171.211777 | 170.951935 |
| 1 | 16384 | 512 | 32 | 64 | 24.982271 | 24.503679 |
| 1 | 16384 | 256 | 16 | 128 | 16.612352 | 15.856000 |
| 4 | 8192 | 256 | 16 | 64 | 15.029120 | 14.433408 |

Both official benchmark suites completed successfully.