### PR TITLE
[MetaX] Add FlashMLA specialization for C550

### DIFF
--- a/src/flaggems_vllm/runtime/backend/_metax/ops/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/ops/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from flaggems_vllm.runtime.backend._metax.ops.flash_mla import flash_mla
 from flaggems_vllm.runtime.backend._metax.ops.per_token_group_quant_fp8 import (
     SUPPORTED_FP8_DTYPE,
     per_token_group_quant_fp8,
@@ -20,6 +21,7 @@ from flaggems_vllm.runtime.backend._metax.ops.scaled_int8_quant import scaled_in
 
 __all__ = [
     "SUPPORTED_FP8_DTYPE",
+    "flash_mla",
     "per_token_group_quant_fp8",
     "scaled_int8_quant",
 ]

--- a/src/flaggems_vllm/runtime/backend/_metax/ops/flash_mla.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/ops/flash_mla.py
@@ -1,0 +1,99 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import math
+
+import torch
+import triton
+
+from flaggems_vllm.ops.flash_mla import flash_mla_attn_kernel
+from flaggems_vllm.runtime import device, torch_device_fn
+
+device = device.name
+logger = logging.getLogger(__name__)
+
+
+def _require_contiguous(name: str, tensor: torch.Tensor) -> None:
+    if not tensor.is_contiguous():
+        raise NotImplementedError(f"MetaX flash_mla requires contiguous {name}")
+
+
+def flash_mla(
+    q,
+    block_table,
+    blocked_k,
+    max_seqlen_pad,
+    block_size,
+    b,
+    s_q,
+    cache_seqlens,
+    h_q,
+    h_kv,
+    d,
+    dv,
+    causal,
+):
+    """Run the C550-compatible Triton FlashMLA decode path."""
+    logger.debug("GEMS FLASH MLA")
+    assert causal, "causal False not supported"
+    assert d > dv, "mla with rope dim should be larger than no rope dim"
+
+    _ = max_seqlen_pad
+    _ = h_kv
+
+    _require_contiguous("q", q)
+    _require_contiguous("blocked_k", blocked_k)
+    _require_contiguous("block_table", block_table)
+    _require_contiguous("cache_seqlens", cache_seqlens)
+
+    batch_size, query_length, head_num, head_dim = q.shape
+    q = q.view(-1, head_num, head_dim)
+    blocked_k = blocked_k.view(-1, head_dim)
+
+    sm_scale = 1 / math.sqrt(d)
+    output = torch.empty((b * s_q, h_q, dv), dtype=q.dtype, device=device)
+
+    # C550 exposes 64 KiB shared memory per block. The generic major-8 launch
+    # (BLOCK_H=32, BLOCK_N=64, num_stages=2) exceeds that limit.
+    block_h = 16
+    block_n = 16
+    grid = (triton.cdiv(head_num, block_h), batch_size)
+
+    with torch_device_fn.device(device):
+        flash_mla_attn_kernel[grid](
+            q,
+            blocked_k,
+            block_table,
+            cache_seqlens,
+            output,
+            sm_scale,
+            head_num,
+            q.stride(0),
+            q.stride(1),
+            blocked_k.stride(-2),
+            block_table.stride(0),
+            output.stride(0),
+            output.stride(1),
+            output.stride(2),
+            BLOCK_H=block_h,
+            BLOCK_N=block_n,
+            PAGE_SIZE=block_size,
+            HEAD_DIM_V=dv,
+            HEAD_DIM=d,
+            num_warps=4,
+            num_stages=1,
+        )
+
+    return output.view(b, query_length, h_q, dv)


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

New Feature, Performance Optimization

### Description

- Add a MetaX backend specialization for `flash_mla`.
- Reuse the existing `flash_mla_attn_kernel` with a C550-compatible launch configuration: `BLOCK_H=16`, `BLOCK_N=16`, `num_warps=4`, and `num_stages=1`.
- Keep the per-block shared-memory requirement within the C550 64 KiB limit.
- Export `flash_mla` through the MetaX backend package.
- Use no-copy tensor views and the Triton kernel for computation; no PyTorch compute fallback is introduced.

### Issue

N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Correctness

Validated on MetaX C550 with the existing unit test:

```bash
PYTHONPATH=src python -m pytest -q tests/test_flash_mla.py
```

```text
4 passed in 16.26s
```

The test covers BF16 decode workloads with `seqlen` values of 1024, 2048, 4096, and 8192 and compares the output against the existing reference implementation.

### Performance

Environment:

- Device: MetaX C550
- dtype: `bfloat16`
- `S_Q=1`, `H_Q=128`, `H_KV=1`
- `D=576`, `D_V=512`
- `block_size=64`, `causal=True`
- Unit: milliseconds; lower is better

Across the 30 measured workloads, the C550 Triton path is **61.11x to 75.59x faster** than the serial TLE reference, with a **72.88x geometric-mean speedup**.

| batch | S_KV | C550 Triton (ms) | C550 Serial TLE (ms) | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 32 | 1024 | 0.1792 | 10.9509 | 61.11x |
| 32 | 2048 | 0.2862 | 19.2873 | 67.39x |
| 32 | 4096 | 0.5000 | 35.8072 | 71.61x |
| 32 | 8192 | 0.9293 | 68.1167 | 73.30x |
| 32 | 16384 | 1.7833 | 132.9385 | 74.55x |
| 32 | 32768 | 3.4934 | 262.4128 | 75.12x |
| 64 | 1024 | 0.2959 | 19.0630 | 64.42x |
| 64 | 2048 | 0.5112 | 35.1675 | 68.79x |
| 64 | 4096 | 0.9408 | 67.2210 | 71.45x |
| 64 | 8192 | 1.7956 | 132.3715 | 73.72x |
| 64 | 16384 | 3.5052 | 262.0641 | 74.76x |
| 64 | 32768 | 6.9228 | 519.9058 | 75.10x |
| 128 | 1024 | 0.5169 | 36.2783 | 70.18x |
| 128 | 2048 | 0.9542 | 69.1871 | 72.51x |
| 128 | 4096 | 1.8104 | 133.5368 | 73.76x |
| 128 | 8192 | 3.5194 | 263.5266 | 74.88x |
| 128 | 16384 | 6.9396 | 521.3481 | 75.13x |
| 128 | 32768 | 13.7724 | 1037.9044 | 75.36x |
| 256 | 1024 | 0.9731 | 69.4738 | 71.39x |
| 256 | 2048 | 1.8413 | 135.1350 | 73.39x |
| 256 | 4096 | 3.5501 | 266.7023 | 75.13x |
| 256 | 8192 | 6.9719 | 523.7194 | 75.12x |
| 256 | 16384 | 13.7946 | 1039.1324 | 75.33x |
| 256 | 32768 | 27.4440 | 2074.1707 | 75.58x |
| 512 | 1024 | 1.8995 | 139.4808 | 73.43x |
| 512 | 2048 | 3.6116 | 270.8907 | 75.01x |
| 512 | 4096 | 7.0330 | 528.4393 | 75.14x |
| 512 | 8192 | 13.8784 | 1045.2812 | 75.32x |
| 512 | 16384 | 27.5412 | 2078.1292 | 75.46x |
| 512 | 32768 | 54.7909 | 4141.5396 | 75.59x |

### Files Changed

- `src/flaggems_vllm/runtime/backend/_metax/ops/flash_mla.py`
- `src/flaggems_vllm/runtime/backend/_metax/ops/__init__.py`