### PR TITLE
[MetaX] Add MiniMax M3 sparse attention for C550

### DIFF
--- a/benchmark/test_minimax_m3_sparse_attention.py
+++ b/benchmark/test_minimax_m3_sparse_attention.py
@@ -1,0 +1,181 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import pytest
+import torch
+
+import flaggems_vllm
+from benchmark.base import Benchmark
+from flaggems_vllm.runtime.backend._metax.ops.minimax_sparse_attention import (
+    SPARSE_BLOCK_SIZE,
+    minimax_m3_sparse_attn_decode,
+)
+
+
+def _torch_sparse_decode(
+    q,
+    kv_cache,
+    topk_idx,
+    block_table,
+    seq_lens,
+    num_kv_heads,
+    sm_scale,
+    output,
+    decode_query_len,
+):
+    del output
+    assert decode_query_len == 1
+    batch, num_heads, head_dim = q.shape
+    group_size = num_heads // num_kv_heads
+    topk = topk_idx.shape[-1]
+    offsets = torch.arange(SPARSE_BLOCK_SIZE, device=q.device)
+    result = torch.empty_like(q)
+
+    for kv_head in range(num_kv_heads):
+        logical_blocks = topk_idx[kv_head].long()
+        physical_pages = torch.gather(block_table.long(), 1, logical_blocks)
+        pages = kv_cache[physical_pages, kv_head]
+        k = pages[..., :head_dim].reshape(batch, topk * SPARSE_BLOCK_SIZE, head_dim)
+        v = pages[..., head_dim:].reshape(
+            batch, topk * SPARSE_BLOCK_SIZE, head_dim
+        )
+        positions = (
+            logical_blocks[..., None] * SPARSE_BLOCK_SIZE + offsets[None, None, :]
+        ).reshape(batch, topk * SPARSE_BLOCK_SIZE)
+        valid = positions < seq_lens[:, None]
+
+        head_start = kv_head * group_size
+        head_end = head_start + group_size
+        query = q[:, head_start:head_end].float()
+        scores = torch.einsum("bhd,bkd->bhk", query, k.float()) * sm_scale
+        scores.masked_fill_(~valid[:, None, :], -float("inf"))
+        probs = torch.softmax(scores, dim=-1)
+        result[:, head_start:head_end] = torch.einsum(
+            "bhk,bkd->bhd", probs, v.float()
+        ).to(q.dtype)
+    return result
+
+
+def _metax_sparse_decode(
+    q,
+    kv_cache,
+    topk_idx,
+    block_table,
+    seq_lens,
+    num_kv_heads,
+    sm_scale,
+    output,
+    decode_query_len,
+):
+    minimax_m3_sparse_attn_decode(
+        q,
+        kv_cache,
+        topk_idx,
+        block_table,
+        seq_lens,
+        num_kv_heads,
+        sm_scale,
+        output,
+        decode_query_len,
+    )
+    return output
+
+
+class MiniMaxM3SparseAttentionBenchmark(Benchmark):
+    DEFAULT_DTYPES = [torch.float16, torch.bfloat16]
+    DEFAULT_METRICS = ["latency_base", "latency", "speedup"]
+    DEFAULT_SHAPES = [
+        (1, 4096, 16, 32, 128),
+        (4, 4096, 16, 32, 128),
+        (8, 8192, 32, 32, 128),
+        (16, 16384, 64, 32, 128),
+        (32, 32768, 64, 32, 128),
+    ]
+    DEFAULT_SHAPE_DESC = "B, SEQ_LEN, TOPK, H, D"
+
+    def init_user_config(self):
+        super().init_user_config()
+        if any(len(shape) != 5 for shape in self.shapes):
+            self.shapes = self.DEFAULT_SHAPES
+
+    def get_input_iter(self, dtype):
+        for batch, seq_len, topk, num_heads, head_dim in self.shapes:
+            if seq_len < topk * SPARSE_BLOCK_SIZE:
+                continue
+            yield self._build_inputs(
+                batch, seq_len, topk, num_heads, head_dim, dtype
+            )
+
+    def _build_inputs(self, batch, seq_len, topk, num_heads, head_dim, dtype):
+        torch.manual_seed(batch + seq_len + topk)
+        num_kv_heads = 2
+        num_blocks = math.ceil(seq_len / SPARSE_BLOCK_SIZE)
+        num_pages = batch * num_blocks
+        q = torch.randn(
+            batch,
+            num_heads,
+            head_dim,
+            device=self.device,
+            dtype=dtype,
+        ) * 0.1
+        kv_cache = torch.randn(
+            num_pages,
+            num_kv_heads,
+            SPARSE_BLOCK_SIZE,
+            2 * head_dim,
+            device=self.device,
+            dtype=dtype,
+        ) * 0.1
+        block_table = torch.randperm(
+            num_pages, device=self.device, dtype=torch.int32
+        ).reshape(batch, num_blocks)
+        selected = torch.arange(
+            num_blocks - topk,
+            num_blocks,
+            device=self.device,
+            dtype=torch.int32,
+        )
+        topk_idx = selected[None, None, :].expand(
+            num_kv_heads, batch, topk
+        ).contiguous()
+        seq_lens = torch.full(
+            (batch,), seq_len, device=self.device, dtype=torch.int32
+        )
+        output = torch.empty_like(q)
+        return (
+            q,
+            kv_cache,
+            topk_idx,
+            block_table,
+            seq_lens,
+            num_kv_heads,
+            head_dim**-0.5,
+            output,
+            1,
+        )
+
+
+@pytest.mark.skipif(
+    flaggems_vllm.vendor_name != "metax",
+    reason="MiniMax M3 specialization requires MetaX",
+)
+def test_minimax_m3_sparse_attention():
+    bench = MiniMaxM3SparseAttentionBenchmark(
+        op_name="minimax_m3_sparse_attention",
+        torch_op=_torch_sparse_decode,
+    )
+    bench.set_gems(_metax_sparse_decode)
+    bench.run()

--- a/src/flaggems_vllm/runtime/backend/_metax/ops/minimax_sparse_attention/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/ops/minimax_sparse_attention/__init__.py
@@ -1,4 +1,5 @@
 # Copyright 2026 FlagOS Contributors
+# Copyright contributors to the vLLM project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,36 +13,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from flaggems_vllm.runtime.backend._metax.ops.compress_norm_mrope import (
-    qwen4_compress_norm_mrope_store_groups,
-)
-from flaggems_vllm.runtime.backend._metax.ops.minimax_sparse_attention import (
+"""MiniMax M3 Sparse Attention with a paged KV cache.
+
+The cache layout is compatible with vLLM:
+  kv_cache: [num_blocks, num_kv_heads, 128, 2*head_dim]  K=[..., :head_dim] V=[..., head_dim:]
+  index_kv_cache: [num_blocks, 128, head_dim]
+  block_table: [batch, max_blocks]
+"""
+
+from .index_topk import (
+    SPARSE_BLOCK_SIZE,
     minimax_m3_index_decode,
     minimax_m3_index_decode_score,
     minimax_m3_index_score,
     minimax_m3_index_topk,
-    minimax_m3_sparse_attn,
-    minimax_m3_sparse_attn_decode,
 )
-from flaggems_vllm.runtime.backend._metax.ops.per_token_group_quant_fp8 import (
-    SUPPORTED_FP8_DTYPE,
-    per_token_group_quant_fp8,
-)
-from flaggems_vllm.runtime.backend._metax.ops.ple_state import ple_state_scatter_
-from flaggems_vllm.runtime.backend._metax.ops.qsa_mqa import qwen4_qsa_mqa_paged_dot
-from flaggems_vllm.runtime.backend._metax.ops.scaled_int8_quant import scaled_int8_quant
+from .sparse_attn import minimax_m3_sparse_attn, minimax_m3_sparse_attn_decode
 
 __all__ = [
-    "SUPPORTED_FP8_DTYPE",
+    "SPARSE_BLOCK_SIZE",
     "minimax_m3_index_decode",
     "minimax_m3_index_decode_score",
     "minimax_m3_index_score",
     "minimax_m3_index_topk",
     "minimax_m3_sparse_attn",
     "minimax_m3_sparse_attn_decode",
-    "per_token_group_quant_fp8",
-    "ple_state_scatter_",
-    "qwen4_qsa_mqa_paged_dot",
-    "qwen4_compress_norm_mrope_store_groups",
-    "scaled_int8_quant",
 ]

--- a/src/flaggems_vllm/runtime/backend/_metax/ops/minimax_sparse_attention/index_topk.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/ops/minimax_sparse_attention/index_topk.py
@@ -1,0 +1,1634 @@
+# Copyright 2026 FlagOS Contributors
+# Copyright contributors to the vLLM project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton kernels for MiniMax M3 lightning-indexer block scoring + top-k.
+
+Index queries score each 128-token block of index keys (max over the block),
+then the top-k blocks (plus forced init/local blocks) are selected per query
+token. Adapted to vLLM's paged KV cache: the KV page size is forced to equal the
+sparse block size (128), so one sparse block maps to exactly one page.
+
+Index-K cache layout (vLLM): ``(num_blocks, 128, idx_head_dim)`` (single head).
+
+Only the paths MiniMax M3 uses are implemented: score_type="max", index value
+disabled (score-only indexer), single shared index head. The selected block ids
+feed the block-sparse attention kernels in ``sparse_attn``.
+"""
+
+import torch
+import triton
+import triton.language as tl
+from triton.errors import TritonError
+
+from .utils import current_platform, has_triton_tle, round_up, triton_jit
+
+if has_triton_tle(3, 6, 0):
+    try:
+        import triton.experimental.tle.language as tle
+
+        _HAS_TLE = True
+    except ImportError:
+        tle = None
+        _HAS_TLE = False
+else:
+    tle = None
+    _HAS_TLE = False
+
+
+# MetaX TLE cannot lower the radix histogram/scan kernel.
+# Keep TLE enabled elsewhere and use streaming top-k on MetaX.
+_HAS_TLE_RADIX = _HAS_TLE and not current_platform.is_metax()
+
+# One sparse block == one KV page.
+SPARSE_BLOCK_SIZE = 128
+
+
+# ---------------------------------------------------------------------------
+# Bitonic top-k helpers (layout-agnostic).
+# ---------------------------------------------------------------------------
+@triton.jit
+def _compare_and_swap(x, ids, flip, i: tl.constexpr, n_dims: tl.constexpr):
+    n_outer: tl.constexpr = x.numel >> n_dims
+    shape: tl.constexpr = [n_outer * 2**i, 2, 2 ** (n_dims - i - 1)]
+    y = tl.reshape(x, shape)
+    mask = tl.arange(0, 2)[None, :, None]
+    left = tl.broadcast_to(tl.sum(y * (1 - mask), 1)[:, None, :], shape).to(y.dtype)
+    right = tl.broadcast_to(tl.sum(y * mask, 1)[:, None, :], shape).to(y.dtype)
+    left = tl.reshape(left, x.shape)
+    right = tl.reshape(right, x.shape)
+    y_idx = tl.reshape(ids, shape)
+    left_idx = tl.broadcast_to(tl.sum(y_idx * (1 - mask), 1)[:, None, :], shape)
+    right_idx = tl.broadcast_to(tl.sum(y_idx * mask, 1)[:, None, :], shape)
+    left_idx = tl.reshape(left_idx, x.shape).to(y_idx.dtype)
+    right_idx = tl.reshape(right_idx, x.shape).to(y_idx.dtype)
+    idtype = tl.core.get_int_dtype(bitwidth=x.dtype.primitive_bitwidth, signed=True)
+    ileft = left.to(idtype, bitcast=True)
+    iright = right.to(idtype, bitcast=True)
+    ix = x.to(idtype, bitcast=True)
+    cond = (left > right) != flip
+    ret = ix ^ tl.where(cond, ileft ^ iright, tl.zeros_like(ix))
+    new_ids = ids ^ tl.where(cond, left_idx ^ right_idx, tl.zeros_like(ids))
+    return ret.to(x.dtype, bitcast=True), new_ids
+
+
+@triton.jit
+def _bitonic_merge(
+    x, ids, stage: tl.constexpr, order: tl.constexpr, n_dims: tl.constexpr
+):
+    n_outer: tl.constexpr = x.numel >> n_dims
+    tl.static_assert(stage <= n_dims)
+    if order == 2:
+        shape: tl.constexpr = [n_outer * 2 ** (n_dims - 1 - stage), 2, 2**stage]
+        flip = tl.reshape(
+            tl.broadcast_to(tl.arange(0, 2)[None, :, None], shape), x.shape
+        )
+    else:
+        flip = order
+    for i in tl.static_range(stage):
+        x, ids = _compare_and_swap(x, ids, flip, i + (n_dims - stage), n_dims)
+    return x, ids
+
+
+# ---------------------------------------------------------------------------
+# Index block-score kernel (paged). score[h, token, block] = max over the
+# 128-token block of (idx_q . index_k), causal-masked. BLOCK_SIZE_K == 128 so
+# each K-tile is exactly one page (BLOCKS_PER_K_BLOCK == 1).
+# ---------------------------------------------------------------------------
+# since prefill metadata is sliced from mixed batch metadata, seq_lens and prefix_lens
+# might lose pointer alignment, which trigger Triton recompiles. we don't actually
+# need pointer alignment for those tensors anyway because we do scalar load.
+@triton_jit(do_not_specialize_on_alignment=["seq_lens", "prefix_lens"])
+def _index_block_score_kernel(
+    q_ptr,  # idx_q: [total_q, num_idx_heads, head_dim]
+    ik_cache_ptr,  # index-K cache: [num_blocks, 128, head_dim]
+    score_ptr,  # [num_idx_heads, total_q, max_block]
+    block_table_ptr,  # [num_reqs, max_blocks]
+    cu_seqlens,  # [batch+1] query start offsets
+    seq_lens,  # [batch] total K length
+    prefix_lens,  # [batch] context length before this chunk's queries
+    num_idx_heads,
+    head_dim: tl.constexpr,
+    stride_q_n,
+    stride_q_h,
+    stride_q_d,
+    stride_ik_blk,
+    stride_ik_pos,
+    stride_ik_d,
+    stride_s_h,
+    stride_s_n,
+    stride_s_k,
+    stride_bt_b,
+    BLOCK_SIZE_Q: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,  # == SPARSE_BLOCK_SIZE (128)
+):
+    pid_q = tl.program_id(0)
+    pid_bh = tl.program_id(1)
+    pid_b = pid_bh // num_idx_heads
+    pid_h = pid_bh % num_idx_heads
+
+    seq_start = tl.load(cu_seqlens + pid_b)
+    q_len = tl.load(cu_seqlens + pid_b + 1) - seq_start
+    seq_len = tl.load(seq_lens + pid_b)
+    prefix_len = tl.load(prefix_lens + pid_b)
+    if BLOCK_SIZE_Q * pid_q >= q_len:
+        return
+
+    q_ptrs = tl.make_block_ptr(
+        base=q_ptr + seq_start * stride_q_n + pid_h * stride_q_h,
+        shape=(q_len, head_dim),
+        strides=(stride_q_n, stride_q_d),
+        offsets=(pid_q * BLOCK_SIZE_Q, 0),
+        block_shape=(BLOCK_SIZE_Q, head_dim),
+        order=(1, 0),
+    )
+    q = tl.load(q_ptrs, boundary_check=(0,), padding_option="zero")
+    q_start = prefix_len + pid_q * BLOCK_SIZE_Q
+
+    off_q = tl.arange(0, BLOCK_SIZE_Q) + pid_q * BLOCK_SIZE_Q + prefix_len
+    off_k = tl.arange(0, BLOCK_SIZE_K)
+    off_d = tl.arange(0, head_dim)
+    # Block table row for this request.
+    bt_row = block_table_ptr + pid_b * stride_bt_b
+    # Causal window: only blocks up to the last query token's position.
+    hi = min(seq_len, prefix_len + (pid_q + 1) * BLOCK_SIZE_Q)
+    for i in tl.range(0, hi, BLOCK_SIZE_K):
+        blk = i // BLOCK_SIZE_K
+        page = tl.load(bt_row + blk).to(tl.int64)
+        pos = i + off_k
+        # index-K for this page: [BLOCK_SIZE_D, BLOCK_SIZE_K] (transposed)
+        # we don't need masked load for K, because KV cache ensures
+        # allocation is multiple of BLOCK_SIZE_K.
+        # for tokens beyond seqlen, they will be masked in qk later.
+        k = tl.load(
+            ik_cache_ptr
+            + page * stride_ik_blk
+            + off_k[None, :] * stride_ik_pos
+            + off_d[:, None] * stride_ik_d,
+        )
+        qk = tl.dot(q, k)
+        # apply causal mask as needed
+        if q_start < i + BLOCK_SIZE_K:
+            qk = tl.where(off_q[:, None] >= pos[None, :], qk, float("-inf"))
+        # one sparse block per K-tile -> max over the 128 positions
+        score = tl.max(qk, axis=1)  # [BLOCK_SIZE_Q]
+        s_ptrs = (
+            score_ptr
+            + pid_h * stride_s_h
+            + (seq_start + pid_q * BLOCK_SIZE_Q + tl.arange(0, BLOCK_SIZE_Q))
+            * stride_s_n
+            + blk * stride_s_k
+        )
+        q_store_mask = (pid_q * BLOCK_SIZE_Q + tl.arange(0, BLOCK_SIZE_Q)) < q_len
+        tl.store(s_ptrs, score, mask=q_store_mask)
+
+
+# ---------------------------------------------------------------------------
+# Top-k selection over per-token block scores (layout-agnostic). block_size_q
+# is 1 for M3, so top-k is computed per query token.
+# ---------------------------------------------------------------------------
+# since prefill metadata is sliced from mixed batch metadata, prefix_lens
+# might lose pointer alignment, which trigger Triton recompiles. we don't actually
+# need pointer alignment for those tensors anyway because we do scalar load.
+@triton.heuristics({"BLOCK_SIZE_T": lambda args: triton.next_power_of_2(args["topk"])})
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE_K": 2048}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 1024}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 512}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 256}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 64}, num_warps=2, num_stages=2),
+    ],
+    key=["BLOCK_SIZE_T"],
+)
+@triton_jit(do_not_specialize_on_alignment=["prefix_lens"])
+def _topk_index_kernel_fallback(
+    s_ptr,  # [num_heads, total_q, max_block]
+    ti_ptr,  # [num_heads, total_q, topk]
+    sample_interval: tl.constexpr,  # block_size_q (1 for M3)
+    block_size: tl.constexpr,  # sparse block size (128)
+    cu_seqlens,
+    cu_seqblocks_q,
+    prefix_lens,
+    topk,
+    init_blocks: tl.constexpr,
+    local_blocks: tl.constexpr,
+    stride_s_h,
+    stride_s_n,
+    stride_s_k,
+    stride_ti_h,
+    stride_ti_n,
+    stride_ti_t,
+    BLOCK_SIZE_K: tl.constexpr,
+    BLOCK_SIZE_T: tl.constexpr,
+    MASK_INIT: tl.constexpr,
+    MASK_LOCAL: tl.constexpr,
+):
+    tl.static_assert(BLOCK_SIZE_K > BLOCK_SIZE_T)
+    pid_q = tl.program_id(0)
+    pid_b = tl.program_id(1)
+    pid_h = tl.program_id(2)
+    seq_start = tl.load(cu_seqlens + pid_b)
+    block_start = tl.load(cu_seqblocks_q + pid_b)
+    block_num = tl.load(cu_seqblocks_q + pid_b + 1) - block_start
+    prefix_len = tl.load(prefix_lens + pid_b)
+    if pid_q >= block_num:
+        return
+    off_k = tl.arange(0, BLOCK_SIZE_K)
+    off_t = tl.arange(0, BLOCK_SIZE_T)
+    s_ptrs = (
+        s_ptr
+        + (seq_start + pid_q * sample_interval) * stride_s_n
+        + pid_h * stride_s_h
+        + off_k * stride_s_k
+    )
+    topk_score = tl.full((BLOCK_SIZE_K,), -1e30, dtype=tl.float32)
+    topk_idx = tl.full((BLOCK_SIZE_K,), 0, dtype=tl.int32)
+    left_half_mask = tl.arange(0, BLOCK_SIZE_K) < BLOCK_SIZE_K // 2
+    valid_blocks = (prefix_len + pid_q * sample_interval + block_size) // block_size
+    for i in tl.range(0, valid_blocks, BLOCK_SIZE_K):
+        causal_mask = i + off_k < valid_blocks
+        local_mask = i + off_k >= max(0, valid_blocks - local_blocks)
+        init_mask = i + off_k < init_blocks
+        score = tl.load(s_ptrs, mask=causal_mask, other=-1e30).to(tl.float32)
+        score = tl.where(score != score, -1e30, score)
+        s_ptrs = s_ptrs + stride_s_k * BLOCK_SIZE_K
+        if MASK_INIT:
+            score = tl.where(causal_mask & init_mask, score - 1e29, score)
+        else:
+            score = tl.where(causal_mask & init_mask, 1e30, score)
+        if MASK_LOCAL:
+            score = tl.where(causal_mask & local_mask, score - 1e28, score)
+        else:
+            score = tl.where(causal_mask & local_mask, 1e29, score)
+        topk_score, last_topk_score = score, topk_score
+        topk_idx, last_topk_idx = (tl.where(causal_mask, i + off_k + 1, 0), topk_idx)
+        n_dims: tl.constexpr = tl.standard._log2(BLOCK_SIZE_K)
+        for j in tl.static_range(1, n_dims):
+            topk_score, topk_idx = _bitonic_merge(
+                topk_score, topk_idx.to(tl.int32), j, 2, n_dims
+            )
+        if i != 0:
+            topk_score, topk_idx = _bitonic_merge(
+                topk_score, topk_idx.to(tl.int32), n_dims, False, n_dims
+            )
+            topk_score_new = last_topk_score * left_half_mask + topk_score * (
+                1 - left_half_mask
+            )
+            topk_idx_new = last_topk_idx * left_half_mask + topk_idx * (
+                1 - left_half_mask
+            )
+            topk_score, topk_idx = _bitonic_merge(
+                topk_score_new, topk_idx_new.to(tl.int32), n_dims, True, n_dims
+            )
+        else:
+            topk_score, topk_idx = _bitonic_merge(
+                topk_score, topk_idx.to(tl.int32), n_dims, True, n_dims
+            )
+    topk_mask = tl.arange(0, BLOCK_SIZE_K // BLOCK_SIZE_T) == 0
+    topk_idx = tl.sum(
+        topk_mask[:, None]
+        * tl.reshape(topk_idx - 1, [BLOCK_SIZE_K // BLOCK_SIZE_T, BLOCK_SIZE_T]),
+        axis=0,
+    )
+    ti_ptrs = (
+        ti_ptr
+        + (block_start + pid_q) * stride_ti_n
+        + pid_h * stride_ti_h
+        + off_t * stride_ti_t
+    )
+    store_mask = off_t < topk
+    valid_mask = off_t < valid_blocks
+    topk_idx = tl.where(store_mask & valid_mask, topk_idx, -1)
+    tl.store(ti_ptrs, topk_idx.to(ti_ptrs.dtype.element_ty), mask=store_mask)
+
+
+# ---------------------------------------------------------------------------
+# Streaming Top-K adapted to MSA prefill semantics.
+#
+# The reference implementation is ``FlagTree/python/tutorials/tle/03-topk.py``
+# and operates on a uniform 2-D [M, N] tensor.  This adapted kernel keeps the
+# MSA row mapping, per-query causal length, forced init/local blocks, NaN
+# handling, output layout, and -1 padding.  Only the row-local selection engine
+# is replaced by the packed-key ``tl.topk`` + ``tl.bitonic_merge`` algorithm.
+#
+# This path intentionally remains separate from ``_topk_index_kernel_fallback``
+# so unsupported shapes preserve the previous behavior.  The streaming
+# implementation uses only standard Triton APIs; it does not depend on TLE.
+# ---------------------------------------------------------------------------
+@triton.jit
+def _streaming_topk_fpval_to_key(x_bits):
+    sign_bit = tl.full(x_bits.shape, 0x80000000, dtype=tl.uint32)
+    full_mask = tl.full(x_bits.shape, 0xFFFFFFFF, dtype=tl.uint32)
+    mask = tl.where((x_bits & sign_bit) != 0, full_mask, sign_bit)
+    return x_bits ^ mask
+
+
+@triton.jit
+def _streaming_topk_index_to_key(index):
+    max_u16 = tl.full(index.shape, 0xFFFF, dtype=tl.uint32)
+    return max_u16 - index.to(tl.uint32)
+
+
+@triton.jit
+def _streaming_topk_key_to_index(index_key):
+    max_u16 = tl.full(index_key.shape, 0xFFFF, dtype=tl.uint32)
+    return (max_u16 - index_key.to(tl.uint32)).to(tl.int32)
+
+
+_MAX_STREAMING_TILE_SIZE = 2048
+_RADIX_BITS = 4
+_RADIX_MIN_PADDED_BLOCKS = 1024
+_RADIX_MAX_TOPK = 64
+_RADIX_MIN_BLOCKS_PER_TOPK = 16
+_FAILED_RADIX_CONFIGS: set[tuple[int, int]] = set()
+
+
+@triton.heuristics({"BLOCK_SIZE_T": lambda args: triton.next_power_of_2(args["topk"])})
+@triton_jit(do_not_specialize_on_alignment=["prefix_lens"])
+def _topk_index_kernel_streaming(
+    s_ptr,  # [num_heads, total_q, max_block]
+    ti_ptr,  # [num_heads, total_q, topk]
+    sample_interval: tl.constexpr,  # block_size_q (1 for M3)
+    block_size: tl.constexpr,  # sparse block size (128)
+    cu_seqlens,
+    cu_seqblocks_q,
+    prefix_lens,
+    topk: tl.constexpr,
+    init_blocks: tl.constexpr,
+    local_blocks: tl.constexpr,
+    stride_s_h,
+    stride_s_n,
+    stride_s_k,
+    stride_ti_h,
+    stride_ti_n,
+    stride_ti_t,
+    BLOCK_SIZE_K: tl.constexpr,
+    BLOCK_SIZE_T: tl.constexpr,
+    MASK_INIT: tl.constexpr,
+    MASK_LOCAL: tl.constexpr,
+):
+    tl.static_assert(BLOCK_SIZE_T == topk)
+    tl.static_assert(BLOCK_SIZE_K >= BLOCK_SIZE_T)
+
+    pid_q = tl.program_id(0)
+    pid_b = tl.program_id(1)
+    pid_h = tl.program_id(2)
+    seq_start = tl.load(cu_seqlens + pid_b)
+    block_start = tl.load(cu_seqblocks_q + pid_b)
+    block_num = tl.load(cu_seqblocks_q + pid_b + 1) - block_start
+    prefix_len = tl.load(prefix_lens + pid_b)
+    if pid_q >= block_num:
+        return
+
+    valid_blocks = (prefix_len + pid_q * sample_interval + block_size) // block_size
+    off_t = tl.arange(0, BLOCK_SIZE_T)
+    ti_ptrs = (
+        ti_ptr
+        + (block_start + pid_q) * stride_ti_n
+        + pid_h * stride_ti_h
+        + off_t * stride_ti_t
+    )
+
+    # When N <= K every visible block must be selected.  The normal streaming
+    # path also returns these ids in ascending order, so this is exactly the
+    # same output without loading or sorting scores.
+    if valid_blocks <= topk:
+        topk_idx = tl.where(off_t < valid_blocks, off_t, -1)
+        tl.store(ti_ptrs, topk_idx.to(ti_ptrs.dtype.element_ty))
+        return
+
+    off_k = tl.arange(0, BLOCK_SIZE_K)
+
+    # Start from the last (possibly partial) tile.  All preceding tiles are
+    # full, matching the order used by the source streaming kernel.
+    num_tiles = tl.cdiv(valid_blocks, BLOCK_SIZE_K)
+    tile_start = (num_tiles - 1) * BLOCK_SIZE_K
+    block_idx = tile_start + off_k
+    causal_mask = block_idx < valid_blocks
+    local_mask = block_idx >= max(0, valid_blocks - local_blocks)
+    init_mask = block_idx < init_blocks
+
+    score_row = (
+        s_ptr + (seq_start + pid_q * sample_interval) * stride_s_n + pid_h * stride_s_h
+    )
+    score = tl.load(
+        score_row + block_idx * stride_s_k,
+        mask=causal_mask,
+        other=-1e30,
+    ).to(tl.float32)
+    score = tl.where(score != score, -1e30, score)
+    if MASK_INIT:
+        score = tl.where(causal_mask & init_mask, score - 1e29, score)
+    else:
+        score = tl.where(causal_mask & init_mask, 1e30, score)
+    if MASK_LOCAL:
+        score = tl.where(causal_mask & local_mask, score - 1e28, score)
+    else:
+        score = tl.where(causal_mask & local_mask, 1e29, score)
+
+    score_key = _streaming_topk_fpval_to_key(score.to(tl.uint32, bitcast=True))
+    index_key = _streaming_topk_index_to_key(block_idx)
+    packed = (score_key.to(tl.uint64) << 16) | index_key.to(tl.uint64)
+    # A finite sentinel such as -1e30 is not below every valid FP32 value.
+    # Force lanes outside this row's causal range below the key for -inf so a
+    # partial tile can never return an out-of-range logical block id.
+    packed = tl.where(causal_mask, packed, tl.zeros_like(packed))
+    acc = tl.topk(packed, BLOCK_SIZE_T)
+
+    for _ in tl.range(0, num_tiles - 1):
+        acc = tl.bitonic_merge(acc)
+        tile_start -= BLOCK_SIZE_K
+        block_idx = tile_start + off_k
+        local_mask = block_idx >= max(0, valid_blocks - local_blocks)
+        init_mask = block_idx < init_blocks
+
+        score = tl.load(score_row + block_idx * stride_s_k).to(tl.float32)
+        score = tl.where(score != score, -1e30, score)
+        if MASK_INIT:
+            score = tl.where(init_mask, score - 1e29, score)
+        else:
+            score = tl.where(init_mask, 1e30, score)
+        if MASK_LOCAL:
+            score = tl.where(local_mask, score - 1e28, score)
+        else:
+            score = tl.where(local_mask, 1e29, score)
+
+        score_key = _streaming_topk_fpval_to_key(score.to(tl.uint32, bitcast=True))
+        index_key = _streaming_topk_index_to_key(block_idx)
+        packed = (score_key.to(tl.uint64) << 16) | index_key.to(tl.uint64)
+        acc = tl.maximum(acc, tl.topk(packed, BLOCK_SIZE_T))
+
+    # Match the source streaming implementation's output convention: rotate
+    # the index key into the high bits, then sort selected blocks by ascending
+    # logical block id.
+    acc = (acc << 48) | (acc >> 16)
+    acc = tl.sort(acc, descending=True)
+    selected_index_key = (acc >> 48).to(tl.uint32)
+    topk_idx = _streaming_topk_key_to_index(selected_index_key)
+
+    valid_result = (off_t < valid_blocks) & (topk_idx < valid_blocks)
+    topk_idx = tl.where(valid_result, topk_idx, -1)
+    tl.store(ti_ptrs, topk_idx.to(ti_ptrs.dtype.element_ty))
+
+
+# ---------------------------------------------------------------------------
+# TLE shared-memory Radix Select for wide Prefill rows.
+#
+# This adapts ``FlagTree/python/tutorials/tle/03-topk.py`` to MSA metadata.
+# Unlike the tutorial's atomic output compaction, the final pass scans block ids
+# in ascending order and uses prefix sums.  Equal scores therefore use the same
+# smaller-block-id tie-break as the packed-key streaming path.
+# ---------------------------------------------------------------------------
+@triton.jit
+def _load_prefill_topk_score(
+    score_row,
+    block_idx,
+    valid_blocks,
+    init_blocks: tl.constexpr,
+    local_blocks: tl.constexpr,
+    stride_s_k,
+    MASK_INIT: tl.constexpr,
+    MASK_LOCAL: tl.constexpr,
+):
+    valid = block_idx < valid_blocks
+    score = tl.load(
+        score_row + block_idx * stride_s_k,
+        mask=valid,
+        other=-1e30,
+    ).to(tl.float32)
+    score = tl.where(score != score, -1e30, score)
+    init_mask = block_idx < init_blocks
+    local_mask = block_idx >= max(0, valid_blocks - local_blocks)
+    if MASK_INIT:
+        score = tl.where(valid & init_mask, score - 1e29, score)
+    else:
+        score = tl.where(valid & init_mask, 1e30, score)
+    if MASK_LOCAL:
+        score = tl.where(valid & local_mask, score - 1e28, score)
+    else:
+        score = tl.where(valid & local_mask, 1e29, score)
+    return score, valid
+
+
+if _HAS_TLE:
+
+    @triton_jit(do_not_specialize_on_alignment=["prefix_lens"])
+    def _topk_index_kernel_radix_tle(
+        s_ptr,  # [num_heads, total_q, max_block]
+        ti_ptr,  # [num_heads, total_q, topk]
+        sample_interval: tl.constexpr,
+        block_size: tl.constexpr,
+        cu_seqlens,
+        cu_seqblocks_q,
+        prefix_lens,
+        topk: tl.constexpr,
+        init_blocks: tl.constexpr,
+        local_blocks: tl.constexpr,
+        stride_s_h,
+        stride_s_n,
+        stride_s_k,
+        stride_ti_h,
+        stride_ti_n,
+        stride_ti_t,
+        BLOCK_SIZE_K: tl.constexpr,
+        BLOCK_SIZE_T: tl.constexpr,
+        RADIX_BITS: tl.constexpr,
+        MASK_INIT: tl.constexpr,
+        MASK_LOCAL: tl.constexpr,
+    ):
+        tl.static_assert(RADIX_BITS == 4)
+        tl.static_assert(BLOCK_SIZE_T >= topk)
+        RADIX_SIZE: tl.constexpr = 1 << RADIX_BITS
+        RADIX_MASK: tl.constexpr = RADIX_SIZE - 1
+
+        pid_q = tl.program_id(0)
+        pid_b = tl.program_id(1)
+        pid_h = tl.program_id(2)
+        seq_start = tl.load(cu_seqlens + pid_b)
+        block_start = tl.load(cu_seqblocks_q + pid_b)
+        block_num = tl.load(cu_seqblocks_q + pid_b + 1) - block_start
+        prefix_len = tl.load(prefix_lens + pid_b)
+        if pid_q >= block_num:
+            return
+
+        valid_blocks = (prefix_len + pid_q * sample_interval + block_size) // block_size
+        off_t = tl.arange(0, BLOCK_SIZE_T)
+        output_row = ti_ptr + (block_start + pid_q) * stride_ti_n + pid_h * stride_ti_h
+
+        # Per-row Identity path.  It is particularly important for early
+        # Prefill queries, whose causal range has not yet grown beyond K.
+        if valid_blocks <= topk:
+            topk_idx = tl.where(off_t < valid_blocks, off_t, -1)
+            tl.store(
+                output_row + off_t * stride_ti_t,
+                topk_idx.to(ti_ptr.dtype.element_ty),
+                mask=off_t < topk,
+            )
+            return
+
+        score_row = (
+            s_ptr
+            + (seq_start + pid_q * sample_interval) * stride_s_n
+            + pid_h * stride_s_h
+        )
+        lane = tl.arange(0, BLOCK_SIZE_K)
+        bins = tl.arange(0, RADIX_SIZE)
+        n_tiles = tl.cdiv(valid_blocks, BLOCK_SIZE_K)
+
+        # The histogram is CTA-local, exactly as in the TLE tutorial.
+        smem_counts = tle.gpu.alloc(
+            [1, RADIX_SIZE],
+            dtype=tl.int32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        smem_count_ptrs = tl.reshape(
+            tle.gpu.local_ptr(smem_counts), (RADIX_SIZE,)
+        )
+
+        desired = tl.full((), 0, dtype=tl.uint32)
+        desired_mask = tl.full((), 0, dtype=tl.uint32)
+        k_to_find = tl.full((), topk, dtype=tl.int32)
+        radix_mask_u32 = tl.full((), RADIX_MASK, dtype=tl.uint32)
+
+        # Eight 4-bit MSD passes locate the exact FP32 key at the K boundary.
+        for digit_pos in tl.static_range(32 - RADIX_BITS, -1, -RADIX_BITS):
+            counts = tl.zeros([RADIX_SIZE], dtype=tl.int32)
+            for tile in tl.range(0, n_tiles):
+                block_idx = tile * BLOCK_SIZE_K + lane
+                score, valid = _load_prefill_topk_score(
+                    score_row,
+                    block_idx,
+                    valid_blocks,
+                    init_blocks,
+                    local_blocks,
+                    stride_s_k,
+                    MASK_INIT,
+                    MASK_LOCAL,
+                )
+                score_key = _streaming_topk_fpval_to_key(
+                    score.to(tl.uint32, bitcast=True)
+                )
+                matches = (score_key & desired_mask) == desired
+                digit = ((score_key >> digit_pos) & RADIX_MASK).to(tl.int32)
+                counts += tl.sum(
+                    (
+                        (digit[:, None] == bins[None, :])
+                        & valid[:, None]
+                        & matches[:, None]
+                    ).to(tl.int32),
+                    axis=0,
+                )
+            tl.store(smem_count_ptrs, counts)
+            tl.debug_barrier()
+
+            counts = tl.load(smem_count_ptrs)
+            cumsum_desc = tl.cumsum(counts, axis=0, reverse=True)
+            selected_mask = cumsum_desc >= k_to_find
+            selected = tl.max(tl.where(selected_mask, bins, 0), axis=0).to(tl.int32)
+            counts_gt = tl.max(tl.where(bins == selected + 1, cumsum_desc, 0), axis=0)
+            selected_u32 = selected.to(tl.uint32)
+            desired = desired | (selected_u32 << digit_pos)
+            desired_mask = desired_mask | (radix_mask_u32 << digit_pos)
+            k_to_find = k_to_find - counts_gt
+
+        # At this point ``desired`` is the exact threshold key and
+        # ``k_to_find`` is how many threshold-equal elements are still needed.
+        # Scan once in ascending block-id order, emitting all greater keys and
+        # the first equal keys.  This combines the tutorial's two collection
+        # passes and makes ties deterministic.
+        written = tl.full((), 0, dtype=tl.int32)
+        equal_seen = tl.full((), 0, dtype=tl.int32)
+        for tile in tl.range(0, n_tiles):
+            block_idx = tile * BLOCK_SIZE_K + lane
+            score, valid = _load_prefill_topk_score(
+                score_row,
+                block_idx,
+                valid_blocks,
+                init_blocks,
+                local_blocks,
+                stride_s_k,
+                MASK_INIT,
+                MASK_LOCAL,
+            )
+            score_key = _streaming_topk_fpval_to_key(score.to(tl.uint32, bitcast=True))
+            take_gt = valid & (score_key > desired)
+            take_equal = valid & (score_key == desired)
+            equal_rank = tl.cumsum(take_equal.to(tl.int32), axis=0)
+            take_equal = take_equal & (equal_seen + equal_rank <= k_to_find)
+            take = take_gt | take_equal
+            take_rank = tl.cumsum(take.to(tl.int32), axis=0)
+            out_pos = written + take_rank - 1
+            tl.store(
+                output_row + out_pos * stride_ti_t,
+                block_idx.to(ti_ptr.dtype.element_ty),
+                mask=take,
+            )
+            written = written + tl.sum(take.to(tl.int32), axis=0)
+            equal_seen = equal_seen + tl.sum(
+                (valid & (score_key == desired)).to(tl.int32), axis=0
+            )
+
+else:
+    _topk_index_kernel_radix_tle = None
+
+
+# ---------------------------------------------------------------------------
+# Decode index-score kernel (split-K over seq blocks). Decode batches are
+# flattened request-major, with a runtime query length used to map each query
+# token back to its request metadata. Chunk counts depend only on shape
+# constants so the grid is fixed within a cuda graph. The score scale is omitted
+# because decode only consumes block ordering.
+# ---------------------------------------------------------------------------
+@triton.jit(do_not_specialize=["num_kv_chunks", "decode_query_len"])
+def _decode_index_score_kernel(
+    q_ptr,  # idx_q: [total_q, num_idx_heads, head_dim]
+    ik_cache_ptr,  # index-K cache: [num_blocks, 128, head_dim]
+    score_ptr,  # [num_idx_heads, total_q, max_block]
+    block_table_ptr,  # [num_reqs, max_blocks]
+    seq_lens,  # [num_reqs]
+    num_idx_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    init_blocks,
+    local_blocks,
+    decode_query_len,
+    stride_q_n,
+    stride_q_h,
+    stride_q_d,
+    stride_ik_blk,
+    stride_ik_pos,
+    stride_ik_d,
+    stride_s_h,
+    stride_s_n,
+    stride_s_k,
+    stride_bt_b,
+    BLOCK_SIZE_K: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_SIZE_Q: tl.constexpr,
+    BLOCK_SIZE_HQ: tl.constexpr,
+    num_kv_chunks,
+    USE_PDL: tl.constexpr,
+):
+    tl.static_assert(PAGE_SIZE % BLOCK_SIZE_K == 0)
+    pid_r = tl.program_id(0)
+    pid_c = tl.program_id(1)
+    hq_offsets = tl.arange(0, BLOCK_SIZE_HQ)
+    h_offsets = hq_offsets // BLOCK_SIZE_Q
+    q_offsets = hq_offsets % BLOCK_SIZE_Q
+    q_mask = (h_offsets < num_idx_heads) & (q_offsets < decode_query_len)
+    q_ids = pid_r * decode_query_len + q_offsets
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    seq_len = tl.load(seq_lens + pid_r)
+    query_pos = seq_len - decode_query_len + q_offsets
+    # Full-CG padding uses zero-length request rows. Clamp to an empty
+    # attention range instead of letting padded rows produce negative lengths.
+    kv_len = tl.maximum(query_pos + 1, 0)
+    num_blocks_q = (kv_len + PAGE_SIZE - 1) // PAGE_SIZE
+    kv_len_max = tl.max(tl.where(q_mask, kv_len, 0), axis=0)
+    num_blocks = (kv_len_max + PAGE_SIZE - 1) // PAGE_SIZE
+
+    # block-aligned fixed-count split: grid independent of seq_len (cuda graph).
+    chunk_size_blocks = (num_blocks + num_kv_chunks - 1) // num_kv_chunks
+    chunk_start_block = pid_c * chunk_size_blocks
+    chunk_end_block = tl.minimum(chunk_start_block + chunk_size_blocks, num_blocks)
+    if chunk_start_block >= chunk_end_block:
+        return
+    off_k = tl.arange(0, BLOCK_SIZE_K)  # positions within a 128-block
+    off_d = tl.arange(0, head_dim)
+    bt_row = block_table_ptr + pid_r * stride_bt_b
+    # Force-select init (1e30) and local (1e29, higher priority) blocks.
+    local_start = tl.maximum(0, num_blocks_q - local_blocks)
+    # Query vectors for all index heads in a small spec-decode block.
+    q = tl.load(
+        q_ptr
+        + q_ids[None, :] * stride_q_n
+        + h_offsets[None, :] * stride_q_h
+        + off_d[:, None] * stride_q_d,
+        mask=q_mask[None, :],
+        other=0.0,
+    )  # [D,HQ]
+    for blk in tl.range(chunk_start_block, chunk_end_block):
+        page = tl.load(bt_row + blk).to(tl.int64)
+        score = tl.full((BLOCK_SIZE_HQ,), float("-inf"), tl.float32)
+        # Keep score/top-k at 128-token page granularity while using smaller
+        # dot tiles on 64 KiB shared-memory devices such as C550.
+        for page_offset in tl.static_range(0, PAGE_SIZE, BLOCK_SIZE_K):
+            pos = blk * PAGE_SIZE + page_offset + off_k
+            pos_mask = pos[:, None] < kv_len[None, :]
+            k = tl.load(
+                ik_cache_ptr
+                + page * stride_ik_blk
+                + (page_offset + off_k[:, None]) * stride_ik_pos
+                + off_d * stride_ik_d,
+            )
+            kq = tl.dot(k, q, out_dtype=tl.float32)
+            kq = tl.where(pos_mask & q_mask[None, :], kq, float("-inf"))
+            score = tl.maximum(score, tl.max(kq, axis=0))
+        is_visible_block = blk < num_blocks_q
+        is_init = (blk < init_blocks) & is_visible_block
+        is_local = (blk >= local_start) & is_visible_block
+        score = tl.where(is_local, 1e29, tl.where(is_init, 1e30, score))
+        tl.store(
+            score_ptr + h_offsets * stride_s_h + q_ids * stride_s_n + blk * stride_s_k,
+            score,
+            mask=q_mask,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Decode top-k: identity for N <= K, otherwise per-chunk partial top-k plus a
+# merge. Forced init/local blocks are already encoded in the scores.
+# ---------------------------------------------------------------------------
+@triton.jit(do_not_specialize=["decode_query_len"])
+def _decode_topk_identity_kernel(
+    ti_final_ptr,  # [num_idx_heads, total_q, topk]
+    seq_lens,  # [num_reqs]
+    block_size: tl.constexpr,
+    topk: tl.constexpr,
+    decode_query_len,
+    stride_tif_h,
+    stride_tif_b,
+    stride_tif_t,
+    BLOCK_SIZE_T: tl.constexpr,
+    USE_PDL: tl.constexpr,
+):
+    """Emit every visible block when the padded maximum cannot exceed K."""
+    pid_b = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    req_id = pid_b // decode_query_len
+    q_offset = pid_b - req_id * decode_query_len
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    seq_len = tl.load(seq_lens + req_id)
+    query_pos = seq_len - decode_query_len + q_offset
+    kv_len = tl.maximum(query_pos + 1, 0)
+    num_blocks = (kv_len + block_size - 1) // block_size
+
+    off_t = tl.arange(0, BLOCK_SIZE_T)
+    topk_idx = tl.where(off_t < num_blocks, off_t, -1)
+    tl.store(
+        ti_final_ptr
+        + pid_h * stride_tif_h
+        + pid_b * stride_tif_b
+        + off_t * stride_tif_t,
+        topk_idx.to(ti_final_ptr.dtype.element_ty),
+        mask=off_t < topk,
+    )
+
+
+@triton.heuristics({"BLOCK_SIZE_T": lambda args: triton.next_power_of_2(args["topk"])})
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE_K": 256}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 256}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 128}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_SIZE_K": 64}, num_warps=2, num_stages=2),
+    ],
+    key=["topk"],
+)
+@triton.jit(do_not_specialize=["chunk_blocks", "decode_query_len"])
+def _topk_index_partial_kernel(
+    s_ptr,  # score: [num_idx_heads, total_q, max_block]
+    ts_partial_ptr,  # partial scores out: [NUM_TOPK_CHUNKS, num_idx_heads, total_q, T]
+    ti_partial_ptr,  # partial idx out (1-indexed global, 0=invalid): same shape
+    seq_lens,  # [num_reqs]
+    block_size: tl.constexpr,  # sparse block size (128)
+    topk: tl.constexpr,
+    chunk_blocks,  # how many score-blocks each chunk owns
+    decode_query_len,
+    stride_s_h,
+    stride_s_b,
+    stride_s_k,
+    stride_ts_c,
+    stride_ts_h,
+    stride_ts_b,
+    stride_ts_t,
+    stride_ti_c,
+    stride_ti_h,
+    stride_ti_b,
+    stride_ti_t,
+    BLOCK_SIZE_K: tl.constexpr,
+    BLOCK_SIZE_T: tl.constexpr,
+    USE_PDL: tl.constexpr,
+):
+    tl.static_assert(topk < BLOCK_SIZE_K)
+    pid_b = tl.program_id(0)  # flattened query-token id
+    pid_h = tl.program_id(1)
+    pid_chunk = tl.program_id(2)
+    req_id = pid_b // decode_query_len
+    q_offset = pid_b - req_id * decode_query_len
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
+
+    seq_len = tl.load(seq_lens + req_id)
+    query_pos = seq_len - decode_query_len + q_offset
+    # Full-CG padding uses zero-length request rows. Clamp to an empty
+    # attention range instead of letting padded rows produce negative lengths.
+    kv_len = tl.maximum(query_pos + 1, 0)
+    num_blocks = (kv_len + block_size - 1) // block_size
+
+    # Slice this chunk owns within [0, num_blocks).
+    chunk_start = pid_chunk * chunk_blocks
+    chunk_end = tl.minimum(chunk_start + chunk_blocks, num_blocks)
+    chunk_actual = tl.maximum(chunk_end - chunk_start, 0)
+
+    off_k = tl.arange(0, BLOCK_SIZE_K)
+    off_t = tl.arange(0, BLOCK_SIZE_T)
+
+    s_ptrs = (
+        s_ptr
+        + pid_b * stride_s_b
+        + pid_h * stride_s_h
+        + (chunk_start + off_k) * stride_s_k
+    )
+
+    topk_score = tl.full((BLOCK_SIZE_K,), -1e30, dtype=tl.float32)
+    topk_idx = tl.full((BLOCK_SIZE_K,), 0, dtype=tl.int32)
+    left_half_mask = tl.arange(0, BLOCK_SIZE_K) < BLOCK_SIZE_K // 2
+
+    # Streaming top-K within this chunk. tl.range(0, 0) is a no-op so empty
+    # chunks (chunk_actual == 0) skip the body and store sentinel -1e30 / 0.
+    for i in tl.range(0, chunk_actual, BLOCK_SIZE_K):
+        mask = off_k < chunk_actual - i
+        score = tl.load(s_ptrs, mask=mask, other=-1e30).to(tl.float32)
+        score = tl.where(score != score, -1e30, score)
+        s_ptrs = s_ptrs + stride_s_k * BLOCK_SIZE_K
+        topk_score, last_topk_score = score, topk_score
+        topk_idx, last_topk_idx = (
+            tl.where(mask, chunk_start + i + off_k + 1, 0),  # 1-indexed global
+            topk_idx,
+        )
+        n_dims: tl.constexpr = tl.standard._log2(BLOCK_SIZE_K)
+        for j in tl.static_range(1, n_dims):
+            topk_score, topk_idx = _bitonic_merge(
+                topk_score, topk_idx.to(tl.int32), j, 2, n_dims
+            )
+        if i != 0:
+            topk_score, topk_idx = _bitonic_merge(
+                topk_score, topk_idx.to(tl.int32), n_dims, False, n_dims
+            )
+            topk_score_new = last_topk_score * left_half_mask + topk_score * (
+                1 - left_half_mask
+            )
+            topk_idx_new = last_topk_idx * left_half_mask + topk_idx * (
+                1 - left_half_mask
+            )
+            topk_score, topk_idx = _bitonic_merge(
+                topk_score_new, topk_idx_new.to(tl.int32), n_dims, True, n_dims
+            )
+        else:
+            topk_score, topk_idx = _bitonic_merge(
+                topk_score, topk_idx.to(tl.int32), n_dims, True, n_dims
+            )
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
+    # Extract first BLOCK_SIZE_T entries (top-K of this chunk after the sort).
+    topk_mask_extract = tl.arange(0, BLOCK_SIZE_K // BLOCK_SIZE_T) == 0
+    final_score = tl.sum(
+        topk_mask_extract[:, None]
+        * tl.reshape(topk_score, [BLOCK_SIZE_K // BLOCK_SIZE_T, BLOCK_SIZE_T]),
+        axis=0,
+    )
+    final_idx = tl.sum(
+        topk_mask_extract[:, None]
+        * tl.reshape(topk_idx, [BLOCK_SIZE_K // BLOCK_SIZE_T, BLOCK_SIZE_T]),
+        axis=0,
+    )
+
+    # Always write all BLOCK_SIZE_T slots — invalid slots carry -1e30 / 0
+    # sentinels and lose to real scores in the merge stage.
+    ts_ptrs = (
+        ts_partial_ptr
+        + pid_chunk * stride_ts_c
+        + pid_b * stride_ts_b
+        + pid_h * stride_ts_h
+        + off_t * stride_ts_t
+    )
+    ti_ptrs = (
+        ti_partial_ptr
+        + pid_chunk * stride_ti_c
+        + pid_b * stride_ti_b
+        + pid_h * stride_ti_h
+        + off_t * stride_ti_t
+    )
+    tl.store(ts_ptrs, final_score)
+    tl.store(ti_ptrs, final_idx)
+
+
+@triton.heuristics(
+    {
+        "BLOCK_SIZE_T": lambda args: triton.next_power_of_2(args["topk"]),
+        "BLOCK_SIZE_K": lambda args: triton.next_power_of_2(
+            args["num_topk_chunks"] * triton.next_power_of_2(args["topk"])
+        ),
+    }
+)
+@triton.jit(do_not_specialize=["num_topk_chunks", "decode_query_len"])
+def _topk_index_merge_kernel(
+    ts_partial_ptr,  # partial scores: [NUM_TOPK_CHUNKS, num_idx_heads, total_q, T]
+    ti_partial_ptr,  # partial idx (1-indexed global, 0=invalid): same shape
+    ti_final_ptr,  # final idx (0-indexed, -1=invalid): [num_idx_heads, total_q, topk]
+    seq_lens,  # [num_reqs]
+    block_size: tl.constexpr,  # sparse block size (128)
+    topk: tl.constexpr,
+    decode_query_len,
+    stride_ts_c,
+    stride_ts_h,
+    stride_ts_b,
+    stride_ts_t,
+    stride_ti_c,
+    stride_ti_h,
+    stride_ti_b,
+    stride_ti_t,
+    stride_tif_h,
+    stride_tif_b,
+    stride_tif_t,
+    num_topk_chunks,
+    BLOCK_SIZE_K: tl.constexpr,
+    BLOCK_SIZE_T: tl.constexpr,
+    USE_PDL: tl.constexpr,
+):
+    pid_b = tl.program_id(0)  # flattened query-token id
+    pid_h = tl.program_id(1)
+    req_id = pid_b // decode_query_len
+    q_offset = pid_b - req_id * decode_query_len
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    seq_len = tl.load(seq_lens + req_id)
+    query_pos = seq_len - decode_query_len + q_offset
+    # Full-CG padding uses zero-length request rows. Clamp to an empty
+    # attention range instead of letting padded rows produce negative lengths.
+    kv_len = tl.maximum(query_pos + 1, 0)
+    num_blocks = (kv_len + block_size - 1) // block_size
+
+    # Load NUM_TOPK_CHUNKS * BLOCK_SIZE_T candidates, padded to BLOCK_SIZE_K.
+    # Candidate at flat position p comes from chunk = p // BLOCK_SIZE_T,
+    # in_chunk = p % BLOCK_SIZE_T.
+    off = tl.arange(0, BLOCK_SIZE_K)
+    chunk_idx = off // BLOCK_SIZE_T
+    in_chunk_idx = off % BLOCK_SIZE_T
+    valid = chunk_idx < num_topk_chunks
+
+    score_offset = (
+        chunk_idx * stride_ts_c
+        + pid_h * stride_ts_h
+        + pid_b * stride_ts_b
+        + in_chunk_idx * stride_ts_t
+    )
+    idx_offset = (
+        chunk_idx * stride_ti_c
+        + pid_h * stride_ti_h
+        + pid_b * stride_ti_b
+        + in_chunk_idx * stride_ti_t
+    )
+
+    score = tl.load(ts_partial_ptr + score_offset, mask=valid, other=-1e30).to(
+        tl.float32
+    )
+    score = tl.where(score != score, -1e30, score)
+    idx = tl.load(ti_partial_ptr + idx_offset, mask=valid, other=0).to(tl.int32)
+
+    # Full bitonic descending sort of BLOCK_SIZE_K items.
+    n_dims: tl.constexpr = tl.standard._log2(BLOCK_SIZE_K)
+    for j in tl.static_range(1, n_dims):
+        score, idx = _bitonic_merge(score, idx.to(tl.int32), j, 2, n_dims)
+    score, idx = _bitonic_merge(score, idx.to(tl.int32), n_dims, True, n_dims)
+
+    # Extract first BLOCK_SIZE_T positions — these are the global top-K.
+    extract_mask = tl.arange(0, BLOCK_SIZE_K // BLOCK_SIZE_T) == 0
+    topk_idx_final = tl.sum(
+        extract_mask[:, None]
+        * tl.reshape(idx - 1, [BLOCK_SIZE_K // BLOCK_SIZE_T, BLOCK_SIZE_T]),
+        axis=0,
+    )
+
+    off_t = tl.arange(0, BLOCK_SIZE_T)
+    tif_ptrs = (
+        ti_final_ptr
+        + pid_h * stride_tif_h
+        + pid_b * stride_tif_b
+        + off_t * stride_tif_t
+    )
+    store_mask = off_t < topk
+    topk_idx_final = tl.where(off_t < tl.minimum(topk, num_blocks), topk_idx_final, -1)
+    tl.store(
+        tif_ptrs, topk_idx_final.to(ti_final_ptr.dtype.element_ty), mask=store_mask
+    )
+
+
+# ---------------------------------------------------------------------------
+# Python wrappers
+# ---------------------------------------------------------------------------
+@torch.no_grad()
+def minimax_m3_index_score(
+    idx_q: torch.Tensor,  # [total_q, num_idx_heads, head_dim]
+    index_kv_cache: torch.Tensor,  # [num_blocks, 128, head_dim]
+    block_table: torch.Tensor,  # [batch, max_blocks]
+    cu_seqlens_q: torch.Tensor,  # [batch+1] int32
+    seq_lens: torch.Tensor,  # [batch] int32
+    prefix_lens: torch.Tensor,  # [batch] int32
+    max_query_len: int,
+    max_seq_len: int,
+    num_kv_heads: int,
+) -> torch.Tensor:
+    """Compute per-token index scores for each visible sparse block.
+
+    Returns score [num_kv_heads, total_q, max_block], where each score is the
+    max over a 128-token index-K block. M3 has num_idx_heads == num_kv_heads.
+    """
+    total_q, num_idx_heads, head_dim = idx_q.shape
+    assert (
+        num_idx_heads == num_kv_heads
+    ), "M3 expects num_idx_heads == num_kv_heads (no topk index reduce)"
+    batch = cu_seqlens_q.shape[0] - 1
+    max_block = triton.cdiv(max_seq_len, SPARSE_BLOCK_SIZE)
+
+    # Keep score strides 16-divisible to avoid Triton recompiles.
+    score_block_stride = round_up(max_block, 16)
+    score = torch.empty(
+        (num_idx_heads, total_q, score_block_stride),
+        dtype=torch.float32,
+        device=idx_q.device,
+    )
+    BLOCK_SIZE_Q = 64
+    grid_score = (triton.cdiv(max_query_len, BLOCK_SIZE_Q), batch * num_idx_heads)
+    _index_block_score_kernel[grid_score](
+        idx_q,
+        index_kv_cache,
+        score,
+        block_table,
+        cu_seqlens_q,
+        seq_lens,
+        prefix_lens,
+        num_idx_heads,
+        head_dim,
+        idx_q.stride(0),
+        idx_q.stride(1),
+        idx_q.stride(2),
+        index_kv_cache.stride(0),
+        index_kv_cache.stride(1),
+        index_kv_cache.stride(2),
+        score.stride(0),
+        score.stride(1),
+        score.stride(2),
+        block_table.stride(0),
+        BLOCK_SIZE_Q=BLOCK_SIZE_Q,
+        BLOCK_SIZE_K=SPARSE_BLOCK_SIZE,
+        num_warps=4,
+        num_stages=1,
+        pipeline="basic",
+        scenario="flashattn-fwd;unprefetch",
+    )
+    return score
+
+
+def _supports_prefill_selector_input(score: torch.Tensor, topk: int) -> bool:
+    """Common correctness boundary for the optimized Prefill selectors."""
+    if score.device.type != "cuda":
+        return False
+    if score.dtype != torch.float32 or score.ndim != 3:
+        return False
+    if topk <= 0 or score.shape[2] <= 0:
+        return False
+    return True
+
+
+def _can_use_radix_prefill_topk(
+    score: torch.Tensor,
+    topk: int,
+    max_query_len: int,
+) -> bool:
+    """Use Radix for a short Prefill chunk over a wide existing context."""
+    if not _HAS_TLE_RADIX or _topk_index_kernel_radix_tle is None:
+        return False
+    if not _supports_prefill_selector_input(score, topk):
+        return False
+    max_score_blocks = score.shape[2]
+    block_size_k, _ = _radix_prefill_launch_config(max_score_blocks)
+    return (
+        # A chunk no longer than one sparse page keeps per-row valid_blocks
+        # nearly constant.  Full Prefill has N growing from 1 to max_block and
+        # is better served by the single-pass Streaming selector.
+        0 < max_query_len <= SPARSE_BLOCK_SIZE
+        and max_score_blocks >= _RADIX_MIN_PADDED_BLOCKS
+        and topk <= _RADIX_MAX_TOPK
+        and max_score_blocks >= _RADIX_MIN_BLOCKS_PER_TOPK * topk
+        and (block_size_k, topk) not in _FAILED_RADIX_CONFIGS
+    )
+
+
+def _can_use_streaming_prefill_topk(score: torch.Tensor, topk: int) -> bool:
+    """Return whether packed-key Streaming supports this call exactly."""
+    if not _supports_prefill_selector_input(score, topk):
+        return False
+    if topk > _MAX_STREAMING_TILE_SIZE:
+        return False
+    # The streaming selector packs the logical block id into 16 bits and uses
+    # an exact (not padded) compile-time K in ``tl.topk``.
+    if score.shape[2] > 0xFFFF:
+        return False
+    if (topk & (topk - 1)) != 0:
+        return False
+    return True
+
+
+def _select_prefill_topk_path(
+    score: torch.Tensor,
+    topk: int,
+    max_query_len: int,
+) -> str:
+    """Choose an algorithm; correctness support and performance policy differ."""
+    if _can_use_radix_prefill_topk(score, topk, max_query_len):
+        return "radix"
+    if _can_use_streaming_prefill_topk(score, topk):
+        return "streaming"
+    return "fallback"
+
+
+def _topk_tile_num_warps(block_size: int) -> int:
+    if block_size <= 64:
+        return 2
+    if block_size <= 128:
+        return 4
+    return 8
+
+
+def _streaming_prefill_launch_config(
+    max_score_blocks: int,
+    topk: int,
+) -> tuple[int, int]:
+    """Choose Streaming resources from MSA's padded max-block dimension."""
+    # MSA rows have different valid_blocks, but they share this padded upper
+    # bound.  Cap the normal tile at 1024 as in TLE, then enlarge only when K
+    # itself needs more lanes.  No synthetic kernel argument is required.
+    block_size = max(
+        64,
+        topk,
+        triton.next_power_of_2(min(max_score_blocks, 1024)),
+    )
+    return block_size, _topk_tile_num_warps(block_size)
+
+
+def _radix_prefill_launch_config(max_score_blocks: int) -> tuple[int, int]:
+    """Choose Radix resources from MSA's padded max-block dimension."""
+    tile_cap = 256 if current_platform.is_metax() else 1024
+    block_size = max(
+        32,
+        triton.next_power_of_2(min(max_score_blocks, tile_cap)),
+    )
+    num_warps = 4 if current_platform.is_metax() else _topk_tile_num_warps(block_size)
+    return block_size, num_warps
+
+
+@torch.no_grad()
+def minimax_m3_index_topk(
+    score: torch.Tensor,  # [num_idx_heads, total_q, max_block]
+    cu_seqlens_q: torch.Tensor,  # [batch+1] int32
+    prefix_lens: torch.Tensor,  # [batch] int32
+    max_query_len: int,
+    topk: int,
+    init_blocks: int,
+    local_blocks: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Select index top-k from a precomputed score tensor.
+
+    Dispatches short Prefill chunks over wide contexts to TLE Radix Select,
+    full/medium Prefill to packed-key Streaming Top-K, and unsupported inputs to
+    the original Bitonic fallback.  Optimized kernels contain a per-row N <= K
+    identity path.
+
+    When ``out`` is provided (a ``[num_idx_heads, >=total_q, topk]`` buffer), the
+    result is written into ``out[:, :total_q, :]`` instead of a fresh tensor --
+    used to keep the top-k output at a stable address for cudagraph capture.
+    """
+    num_idx_heads = score.shape[0]
+    batch = cu_seqlens_q.shape[0] - 1
+    total_q = score.shape[1]
+    if out is not None:
+        topk_idx = out[:, :total_q, :]
+    else:
+        topk_idx = torch.empty(
+            (num_idx_heads, total_q, topk),
+            dtype=torch.int32,
+            device=score.device,
+        )
+    # block_size_q == 1 -> query blocks coincide with query tokens.
+    grid_topk = (max_query_len, batch, num_idx_heads)
+    kernel_args = (
+        score,
+        topk_idx,
+        1,  # sample_interval (block_size_q)
+        SPARSE_BLOCK_SIZE,
+        cu_seqlens_q,
+        cu_seqlens_q,  # cu_seqblocks_q == cu_seqlens_q when block_size_q == 1
+        prefix_lens,
+        topk,
+        init_blocks,
+        local_blocks,
+        score.stride(0),
+        score.stride(1),
+        score.stride(2),
+        topk_idx.stride(0),
+        topk_idx.stride(1),
+        topk_idx.stride(2),
+    )
+    path = _select_prefill_topk_path(score, topk, max_query_len)
+    if path == "radix":
+        assert _topk_index_kernel_radix_tle is not None
+        block_size_k, num_warps = _radix_prefill_launch_config(score.shape[2])
+        radix_launch_kwargs = {"num_warps": num_warps, "num_stages": 1}
+        if current_platform.is_metax():
+            radix_launch_kwargs["pipeline"] = ""
+        try:
+            _topk_index_kernel_radix_tle[grid_topk](
+                *kernel_args,
+                BLOCK_SIZE_K=block_size_k,
+                BLOCK_SIZE_T=triton.next_power_of_2(topk),
+                RADIX_BITS=_RADIX_BITS,
+                MASK_INIT=False,
+                MASK_LOCAL=False,
+                **radix_launch_kwargs,
+            )
+            return topk_idx
+        except TritonError:
+            # Some CUDA/Triton combinations expose the TLE module but cannot
+            # lower this shared-memory kernel.  Remember the failed compile
+            # configuration so later calls do not repeatedly pay that cost.
+            _FAILED_RADIX_CONFIGS.add((block_size_k, topk))
+            path = (
+                "streaming"
+                if _can_use_streaming_prefill_topk(score, topk)
+                else "fallback"
+            )
+
+    if path == "streaming":
+        block_size_k, num_warps = _streaming_prefill_launch_config(score.shape[2], topk)
+        _topk_index_kernel_streaming[grid_topk](
+            *kernel_args,
+            BLOCK_SIZE_K=block_size_k,
+            MASK_INIT=False,
+            MASK_LOCAL=False,
+            num_warps=num_warps,
+            num_stages=2,
+        )
+    else:
+        _topk_index_kernel_fallback[grid_topk](
+            *kernel_args,
+            MASK_INIT=False,
+            MASK_LOCAL=False,
+        )
+    return topk_idx
+
+
+@torch.no_grad()
+def minimax_m3_index_decode_score(
+    idx_q: torch.Tensor,  # [total_q, num_idx_heads, head_dim]
+    index_kv_cache: torch.Tensor,  # [num_blocks, 128, head_dim]
+    block_table: torch.Tensor,  # [num_reqs, max_blocks]
+    seq_lens: torch.Tensor,  # [num_reqs] int32
+    max_seq_len: int,
+    init_blocks: int,
+    local_blocks: int,
+    num_kv_heads: int,
+    decode_query_len: int,
+    max_decode_query_len: int,
+    score_out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Decode index block-score (split-K, cudagraph-safe); no top-k.
+
+    Returns score [num_kv_heads, total_q, >=max_block] (fp32; init/local blocks
+    forced to 1e30/1e29). When ``score_out`` is given the scores are written into
+    it (read/written by strides, so a transposed view of a unified buffer is
+    accepted) instead of a fresh tensor -- used to share a unified score buffer
+    with the prefill side and run a single top-k over both.
+    """
+    total_q, num_idx_heads, head_dim = idx_q.shape
+    assert (
+        num_idx_heads == num_kv_heads
+    ), "M3 expects num_idx_heads == num_kv_heads (no topk index reduce)"
+    assert decode_query_len <= max_decode_query_len
+    assert total_q == seq_lens.shape[0] * decode_query_len
+    max_block = triton.cdiv(max_seq_len, SPARSE_BLOCK_SIZE)
+    use_pdl = current_platform.is_arch_support_pdl()
+    # `launch_pdl` is a Triton runtime kwarg only some backends accept (CUDA
+    # SM9+); this ROCm Triton rejects it even when False ("Keyword argument
+    # launch_pdl was specified but unrecognised"). Only pass it when PDL is
+    # actually supported -- on ROCm use_pdl is always False, so it's omitted.
+    pdl_kwargs: dict[str, bool | int] = {}
+    if use_pdl:
+        pdl_kwargs.update({"launch_pdl": True})
+    # TP=1 spec decode scores a wide 4-head x 4-position query tile per K block;
+    # reduce stages to ease memory/register pressure. Keep no-spec and TP=4
+    # single-head codegen unchanged.
+    score_kwargs = pdl_kwargs.copy()
+    if num_idx_heads > 1 and max_decode_query_len > 1:
+        score_kwargs.update({"num_warps": 4, "num_stages": 2})
+    score_kwargs.update(
+        current_platform.attention_launch_kwargs(
+            num_stages=1, scenario="flashattn-fwd;unprefetch"
+        )
+    )
+
+    if score_out is not None:
+        score = score_out
+    else:
+        # Keep score strides 16-divisible to avoid Triton recompiles.
+        score_block_stride = round_up(max_block, 16)
+        score = torch.empty(
+            (num_idx_heads, total_q, score_block_stride),
+            dtype=torch.float32,
+            device=idx_q.device,
+        )
+    # split-K over seq blocks; chunk count depends only on shape constants so
+    # the grid is fixed within a cuda graph.
+    TARGET_GRID = 512
+    MAX_NUM_KV_CHUNKS = 256
+    # Use the configured max decode length to avoid Triton recompiles when
+    # switching between qlen=1 and spec-decode verification batches.
+    BLOCK_SIZE_Q = triton.next_power_of_2(max_decode_query_len)
+    score_ctas_per_chunk = seq_lens.shape[0]
+    target = max(
+        1,
+        min(MAX_NUM_KV_CHUNKS, TARGET_GRID // max(1, score_ctas_per_chunk)),
+    )
+    num_kv_chunks = 1 << (target.bit_length() - 1)
+    grid_score = (seq_lens.shape[0], num_kv_chunks)
+    _decode_index_score_kernel[grid_score](
+        idx_q,
+        index_kv_cache,
+        score,
+        block_table,
+        seq_lens,
+        num_idx_heads,
+        head_dim,
+        init_blocks,
+        local_blocks,
+        decode_query_len,
+        idx_q.stride(0),
+        idx_q.stride(1),
+        idx_q.stride(2),
+        index_kv_cache.stride(0),
+        index_kv_cache.stride(1),
+        index_kv_cache.stride(2),
+        score.stride(0),
+        score.stride(1),
+        score.stride(2),
+        block_table.stride(0),
+        BLOCK_SIZE_K=64 if current_platform.is_metax() else SPARSE_BLOCK_SIZE,
+        PAGE_SIZE=SPARSE_BLOCK_SIZE,
+        BLOCK_SIZE_Q=BLOCK_SIZE_Q,
+        BLOCK_SIZE_HQ=max(16, num_idx_heads * BLOCK_SIZE_Q),
+        num_kv_chunks=num_kv_chunks,
+        USE_PDL=use_pdl,
+        **score_kwargs,
+    )
+    return score
+
+
+@torch.no_grad()
+def minimax_m3_index_decode(
+    idx_q: torch.Tensor,  # [total_q, num_idx_heads, head_dim]
+    index_kv_cache: torch.Tensor,  # [num_blocks, 128, head_dim]
+    block_table: torch.Tensor,  # [num_reqs, max_blocks]
+    seq_lens: torch.Tensor,  # [num_reqs] int32
+    max_seq_len: int,
+    topk: int,
+    init_blocks: int,
+    local_blocks: int,
+    num_kv_heads: int,
+    decode_query_len: int,
+    max_decode_query_len: int,
+    out: torch.Tensor | None = None,
+    score_out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Decode index block-score + dispatched top-k (cudagraph-safe).
+
+    Returns topk_idx [num_kv_heads, total_q, topk] (0-indexed block ids, -1 pad).
+    When ``out`` ([num_kv_heads, >=total_q, topk]) is given, writes into
+    ``out[:, :total_q, :]`` (stable address for cudagraph) instead of allocating.
+    When ``score_out`` ([num_kv_heads, total_q, >=max_block]) is given, the block
+    scores are written into it (read back by the top-k) instead of a fresh
+    tensor -- used to share a unified score buffer with the prefill side. Reads
+    via strides, so a transposed view of a block-major buffer is accepted.
+    """
+    total_q, num_idx_heads, _ = idx_q.shape
+    assert (
+        num_idx_heads == num_kv_heads
+    ), "M3 expects num_idx_heads == num_kv_heads (no topk index reduce)"
+    assert decode_query_len <= max_decode_query_len
+    assert total_q == seq_lens.shape[0] * decode_query_len
+    batch = total_q
+    max_block = triton.cdiv(max_seq_len, SPARSE_BLOCK_SIZE)
+    use_pdl = current_platform.is_arch_support_pdl()
+    pdl_kwargs: dict[str, bool | int] = {}
+    if use_pdl:
+        pdl_kwargs.update({"launch_pdl": True})
+
+    block_size_t = triton.next_power_of_2(topk)
+    if max_block <= topk:
+        # Every visible block is selected, so scores cannot affect the result.
+        # Preserve the documented score_out mutation when the caller supplies
+        # that buffer; otherwise skip both score generation and Top-K sorting.
+        if out is not None:
+            topk_idx = out[:, :total_q, :]
+        else:
+            topk_idx = torch.empty(
+                (num_idx_heads, total_q, topk),
+                dtype=torch.int32,
+                device=idx_q.device,
+            )
+        if score_out is not None:
+            minimax_m3_index_decode_score(
+                idx_q,
+                index_kv_cache,
+                block_table,
+                seq_lens,
+                max_seq_len,
+                init_blocks,
+                local_blocks,
+                num_kv_heads,
+                decode_query_len,
+                max_decode_query_len,
+                score_out=score_out,
+            )
+        identity_use_pdl = use_pdl and score_out is not None
+        identity_pdl_kwargs = pdl_kwargs if identity_use_pdl else {}
+        _decode_topk_identity_kernel[(batch, num_idx_heads)](
+            topk_idx,
+            seq_lens,
+            SPARSE_BLOCK_SIZE,
+            topk,
+            decode_query_len,
+            topk_idx.stride(0),
+            topk_idx.stride(1),
+            topk_idx.stride(2),
+            BLOCK_SIZE_T=block_size_t,
+            USE_PDL=identity_use_pdl,
+            **identity_pdl_kwargs,
+        )
+        return topk_idx
+
+    score = minimax_m3_index_decode_score(
+        idx_q,
+        index_kv_cache,
+        block_table,
+        seq_lens,
+        max_seq_len,
+        init_blocks,
+        local_blocks,
+        num_kv_heads,
+        decode_query_len,
+        max_decode_query_len,
+        score_out=score_out,
+    )
+
+    if out is not None:
+        topk_idx = out[:, :total_q, :]
+    else:
+        topk_idx = torch.empty(
+            (num_idx_heads, total_q, topk),
+            dtype=torch.int32,
+            device=idx_q.device,
+        )
+
+    # Chunk count is shape-constant (cudagraph-safe), capped so the merge sorts
+    # pow2(num_topk_chunks * pow2(topk)) candidates.
+    TOPK_TARGET_GRID = 64
+    MAX_NUM_TOPK_CHUNKS = 16
+    topk_target = max(
+        1, min(MAX_NUM_TOPK_CHUNKS, TOPK_TARGET_GRID // max(1, batch * num_idx_heads))
+    )
+    num_topk_chunks = 1 << (topk_target.bit_length() - 1)
+    chunk_blocks = (max_block + num_topk_chunks - 1) // num_topk_chunks
+    topk_score_partial = torch.empty(
+        num_topk_chunks,
+        num_idx_heads,
+        batch,
+        block_size_t,
+        dtype=torch.float32,
+        device=idx_q.device,
+    )
+    topk_idx_partial = torch.empty(
+        num_topk_chunks,
+        num_idx_heads,
+        batch,
+        block_size_t,
+        dtype=torch.int32,
+        device=idx_q.device,
+    )
+    _topk_index_partial_kernel[(batch, num_idx_heads, num_topk_chunks)](
+        score,
+        topk_score_partial,
+        topk_idx_partial,
+        seq_lens,
+        SPARSE_BLOCK_SIZE,
+        topk,
+        chunk_blocks,
+        decode_query_len,
+        score.stride(0),
+        score.stride(1),
+        score.stride(2),
+        topk_score_partial.stride(0),
+        topk_score_partial.stride(1),
+        topk_score_partial.stride(2),
+        topk_score_partial.stride(3),
+        topk_idx_partial.stride(0),
+        topk_idx_partial.stride(1),
+        topk_idx_partial.stride(2),
+        topk_idx_partial.stride(3),
+        USE_PDL=use_pdl,
+        **pdl_kwargs,
+    )
+    _topk_index_merge_kernel[(batch, num_idx_heads)](
+        topk_score_partial,
+        topk_idx_partial,
+        topk_idx,
+        seq_lens,
+        SPARSE_BLOCK_SIZE,
+        topk,
+        decode_query_len,
+        topk_score_partial.stride(0),
+        topk_score_partial.stride(1),
+        topk_score_partial.stride(2),
+        topk_score_partial.stride(3),
+        topk_idx_partial.stride(0),
+        topk_idx_partial.stride(1),
+        topk_idx_partial.stride(2),
+        topk_idx_partial.stride(3),
+        topk_idx.stride(0),
+        topk_idx.stride(1),
+        topk_idx.stride(2),
+        num_topk_chunks=num_topk_chunks,
+        USE_PDL=use_pdl,
+        **pdl_kwargs,
+    )
+    return topk_idx

--- a/src/flaggems_vllm/runtime/backend/_metax/ops/minimax_sparse_attention/sparse_attn.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/ops/minimax_sparse_attention/sparse_attn.py
@@ -1,0 +1,1573 @@
+# Copyright 2026 FlagOS Contributors
+# Copyright contributors to the vLLM project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton kernels for MiniMax M3 block-sparse GQA attention.
+
+The main heads attend only to the blocks selected by the lightning indexer (see
+``index_topk``). Adapted to vLLM's paged KV cache: the KV page size is forced to
+equal the sparse block size (128), so one selected block maps to exactly one
+page.
+
+Main K/V cache layout (vLLM):
+  ``(num_blocks, num_kv_heads, 128, 2 * head_dim)``
+  K=[..., :head_dim] V=[..., head_dim:]
+
+Only the paths MiniMax M3 uses are implemented: no attention sink, base-2
+(exp2/log2) softmax. The decode kernels use split-K (flash-decoding) over the
+selected blocks with a separate merge step, since one query token per request
+leaves the prefill kernels (which parallelize over the query dim) idle.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from .utils import current_platform, has_triton_tle, triton_jit
+
+if has_triton_tle():
+    try:
+        import triton.experimental.tle.language as tle
+
+        _HAS_TLE = True
+    except Exception:
+        tle = None
+        _HAS_TLE = False
+else:
+    tle = None
+    _HAS_TLE = False
+
+
+def _has_tle_gpu_apis(*names: str) -> bool:
+    return _HAS_TLE and all(hasattr(tle.gpu, name) for name in names)
+
+
+_HAS_TLE_SYNC = _has_tle_gpu_apis("alloc", "local_ptr")
+_HAS_TLE_ASYNC_MMA = _has_tle_gpu_apis(
+    "alloc_barriers",
+    "barrier_wait",
+    "barrier_arrive",
+    "wgmma",
+    "wgmma_wait",
+    "READY",
+)
+
+# One sparse block == one KV page.
+SPARSE_BLOCK_SIZE = 128
+
+# A 64-token double buffer amortizes its extra softmax/barrier work only for
+# the smallest benchmark GQA tile. Larger tiles reuse one full-page KV stage.
+_PREFILL_HALF_KV_MAX_BLOCK_SIZE_QH = 8
+
+_PREFILL_SYNC_BLOCK_SIZE_K = 32
+_PREFILL_SYNC_NUM_WARPS = 4
+
+_FP8_DTYPES = tuple(
+    dtype
+    for name in (
+        "float8_e4m3fn",
+        "float8_e4m3fnuz",
+        "float8_e5m2",
+        "float8_e5m2fnuz",
+    )
+    if (dtype := getattr(torch, name, None)) is not None
+)
+
+
+# ---------------------------------------------------------------------------
+# GQA block-sparse attention (paged). Main heads attend only to the selected
+# blocks. BLOCK_SIZE_K == 128 so each selected block is one page.
+# ---------------------------------------------------------------------------
+# since prefill metadata is sliced from mixed batch metadata, seq_lens and prefix_lens
+# might lose pointer alignment, which trigger Triton recompiles. we don't actually
+# need pointer alignment for those tensors anyway because we do scalar load.
+@triton_jit(do_not_specialize_on_alignment=["seq_lens", "prefix_lens"])
+def _gqa_sparse_fwd_direct(
+    q_ptr,  # [total_q, num_heads, head_dim]
+    kv_cache_ptr,  # main cache: [num_blocks, num_kv_heads, 128, 2*head_dim]
+    k_scale_ptr,
+    v_scale_ptr,
+    t_ptr,  # topk_idx: [num_kv_heads, total_q, topk]
+    o_ptr,  # [total_q, num_heads, head_dim]
+    block_table_ptr,  # [num_reqs, max_blocks]
+    cu_seqlens_q,
+    cu_seqblocks_q,
+    seq_lens,
+    prefix_lens,
+    num_kv_heads,
+    gqa_group_size,
+    head_dim,
+    max_topk,
+    num_q_loop,
+    sm_scale,
+    stride_qn,
+    stride_qh,
+    stride_qd,
+    stride_kv_blk,
+    stride_kv_h,
+    stride_kv_pos,
+    stride_kv_d,
+    stride_ks_h,
+    stride_ks_t,
+    stride_vs_h,
+    stride_vs_t,
+    stride_th,
+    stride_tn,
+    stride_tk,
+    stride_on,
+    stride_oh,
+    stride_od,
+    stride_bt_b,
+    BLOCK_SIZE_Q: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,  # == SPARSE_BLOCK_SIZE (128)
+    BLOCK_SIZE_D: tl.constexpr,
+    BLOCK_SIZE_H: tl.constexpr,
+    BLOCK_SIZE_QH: tl.constexpr,
+    USE_FP8: tl.constexpr,  # fp8 KV cache: dequantize K/V to q.dtype on load
+    KV_SCALE_MODE: tl.constexpr,  # 0: none, 1: scalar, 2: [kv_head, token]
+):
+    sm_scale_log2e = sm_scale * 1.4426950409
+    pid_q = tl.program_id(0)
+    pid_kh = tl.program_id(1)
+    pid_b = tl.program_id(2)
+    q_start = tl.load(cu_seqlens_q + pid_b)
+    q_len = tl.load(cu_seqlens_q + pid_b + 1) - q_start
+    q_block_start = tl.load(cu_seqblocks_q + pid_b)
+    q_block_len = tl.load(cu_seqblocks_q + pid_b + 1) - q_block_start
+    seq_len = tl.load(seq_lens + pid_b)
+    prefix_len = tl.load(prefix_lens + pid_b)
+    if pid_q * num_q_loop >= q_block_len:
+        return
+    real_q_loop = min(num_q_loop, q_block_len - pid_q * num_q_loop)
+    bt_row = block_table_ptr + pid_b * stride_bt_b
+    off_n = tl.arange(0, BLOCK_SIZE_K)
+    if USE_FP8 and KV_SCALE_MODE == 1:
+        # Scalar scales are invariant across every selected page. Fold K into
+        # the logits scale and delay V until the normalized output.
+        qk_scale = sm_scale_log2e * tl.load(k_scale_ptr)
+        v_scale_scalar = tl.load(v_scale_ptr)
+    for j in range(real_q_loop):
+        pid_q_j = pid_q * num_q_loop + j
+        t_ptr_j = t_ptr + (q_block_start + pid_q_j) * stride_tn + pid_kh * stride_th
+        # Valid block count from seq position (no sentinel): block_size_q == 1.
+        q_abs = prefix_len + pid_q_j * BLOCK_SIZE_Q
+        valid_blocks = (q_abs + BLOCK_SIZE_K) // BLOCK_SIZE_K
+        real_topk = tl.minimum(max_topk, valid_blocks)
+        q_ptrs = tl.make_block_ptr(
+            base=q_ptr + q_start * stride_qn + pid_kh * gqa_group_size * stride_qh,
+            shape=(q_len, gqa_group_size, head_dim),
+            strides=(stride_qn, stride_qh, stride_qd),
+            offsets=(pid_q_j * BLOCK_SIZE_Q, 0, 0),
+            block_shape=(BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D),
+            order=(2, 1, 0),
+        )
+        q = tl.load(q_ptrs, boundary_check=(0, 1, 2), padding_option="zero")
+        off_q = (
+            tl.arange(0, BLOCK_SIZE_Q)[:, None]
+            + pid_q_j * BLOCK_SIZE_Q
+            + prefix_len
+            - tl.arange(0, BLOCK_SIZE_K)[None, :]
+        )
+        m_i = tl.full((BLOCK_SIZE_QH,), float("-inf"), dtype=tl.float32)
+
+        l_i = tl.zeros((BLOCK_SIZE_QH,), dtype=tl.float32)
+        # Keep the direct kernel's PV accumulator in [QH, D] order.  The
+        # transposed [D, QH] form spills heavily for the FP8 QH=32 tile.
+        acc_o = tl.zeros((BLOCK_SIZE_QH, BLOCK_SIZE_D), dtype=tl.float32)
+        q = tl.reshape(q, BLOCK_SIZE_QH, BLOCK_SIZE_D)
+        if USE_FP8:
+            # Keep QK in FP8 Tensor Core form.  Q is per-head dynamically
+            # scaled once, then its scale is restored on the FP32 logits.
+            # This keeps the existing K cache in FP8 through tl.dot instead
+            # of materializing a BF16 K tile for every selected page.
+            qk_q_scale = tl.maximum(
+                tl.max(tl.abs(q), axis=1) * (1.0 / 448.0), 1.0e-8
+            )
+            q_qk = (q / qk_q_scale[:, None]).to(tl.float8e4nv)
+        else:
+            q_qk = q
+        for _ in range(real_topk):
+            blk = tl.load(t_ptr_j).to(tl.int32)
+            t_ptr_j = t_ptr_j + stride_tk
+            c = blk * BLOCK_SIZE_K
+            page = tl.load(bt_row + blk).to(tl.int64)
+
+            pos = c + off_n
+            pos_mask = pos < seq_len
+
+            k_base_ptr = kv_cache_ptr + page * stride_kv_blk + pid_kh * stride_kv_h
+            k_ptrs = tl.make_block_ptr(
+                base=k_base_ptr,
+                shape=(BLOCK_SIZE_K, head_dim),
+                strides=(stride_kv_pos, stride_kv_d),
+                offsets=(0, 0),
+                block_shape=(BLOCK_SIZE_K, BLOCK_SIZE_D),
+                order=(1, 0),
+            )
+            k = tl.load(
+                k_ptrs,
+                boundary_check=(0, 1),
+                padding_option="zero",
+            )
+            if USE_FP8:
+                if KV_SCALE_MODE == 2:
+                    k_scale = tl.load(
+                        k_scale_ptr
+                        + pid_kh * stride_ks_h
+                        + (page * BLOCK_SIZE_K + off_n) * stride_ks_t,
+                        mask=pos_mask,
+                        other=1.0,
+                    )
+            qk_dot = tl.dot(q_qk, tl.trans(k))
+            if USE_FP8:
+                qk_dot *= qk_q_scale[:, None]
+
+            is_full_causal = (c + BLOCK_SIZE_K) <= q_abs
+            is_full_seq    = (c + BLOCK_SIZE_K) <= seq_len
+
+            qk = tl.zeros((BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_K), dtype=tl.float32)
+            if not is_full_causal:
+                qk += tl.where(off_q[:, None, :] >= c, 0, float("-inf"))
+
+            qk = tl.reshape(qk, BLOCK_SIZE_QH, BLOCK_SIZE_K)
+            if USE_FP8:
+                if KV_SCALE_MODE == 1:
+                    qk += qk_dot * qk_scale
+                elif KV_SCALE_MODE == 2:
+                    # Q @ (K * scale[token]) is equivalent to scaling the
+                    # smaller [QH, K] logits instead of the [K, D] K tile.
+                    qk += qk_dot * (sm_scale_log2e * k_scale[None, :])
+                else:
+                    qk += qk_dot * sm_scale_log2e
+            else:
+                qk += qk_dot * sm_scale_log2e
+
+            if not is_full_seq:
+                qk += tl.where(pos_mask[None, :], 0, float("-inf"))
+
+            m_ij = tl.maximum(m_i, tl.max(qk, axis=1))
+            p = tl.exp2(qk - m_ij[:, None])
+            l_ij = tl.sum(p, axis=1)
+
+            alpha = tl.exp2(m_i - m_ij)
+            acc_o = acc_o * alpha[:, None]
+            l_i = l_i * alpha + l_ij
+
+            v_base_ptr = k_base_ptr + head_dim * stride_kv_d
+            v_ptrs = tl.make_block_ptr(
+                base=v_base_ptr,
+                shape=(BLOCK_SIZE_K, head_dim),
+                strides=(stride_kv_pos, stride_kv_d),
+                offsets=(0, 0),
+                block_shape=(BLOCK_SIZE_K, BLOCK_SIZE_D),
+                order=(1, 0),
+            )
+            v = tl.load(
+                v_ptrs,
+                boundary_check=(0, 1),
+                padding_option="zero",
+            )
+
+            if USE_FP8:
+                if KV_SCALE_MODE == 2:
+                    v_scale = tl.load(
+                        v_scale_ptr
+                        + pid_kh * stride_vs_h
+                        + (page * BLOCK_SIZE_K + off_n) * stride_vs_t,
+                        mask=pos_mask,
+                        other=1.0,
+                    )
+
+            if USE_FP8 and BLOCK_SIZE_H < 32:
+                # The 8/16-head tiles lower efficiently as FP8 PV MMAs.
+                # Fold a per-token V scale into P before quantizing P
+                # row-wise, and keep V in its FP8 cache format.
+                pv_p = p
+                if KV_SCALE_MODE == 2:
+                    pv_p *= v_scale[None, :]
+                pv_p_scale = tl.maximum(
+                    tl.max(tl.abs(pv_p), axis=1) * (1.0 / 448.0), 1.0e-8
+                )
+                p_dot = (pv_p / pv_p_scale[:, None]).to(tl.float8e4nv)
+                acc_o += tl.dot(p_dot, v) * pv_p_scale[:, None]
+            else:
+                # QH=32 uses the native PV accumulator layout above, but its
+                # FP8 PV lowering spills heavily; retain BF16 operands there.
+                if USE_FP8:
+                    v = v.to(q.dtype)
+                p_dot = p.to(v.dtype)
+                if USE_FP8 and KV_SCALE_MODE == 2:
+                    p_dot = (p * v_scale[None, :]).to(v.dtype)
+                acc_o += tl.dot(p_dot, v)
+            m_i = m_ij
+
+        inv_l = tl.where(l_i > 0, 1.0 / l_i, 0.0)
+        if USE_FP8 and KV_SCALE_MODE == 1:
+            inv_l *= v_scale_scalar
+        acc_o = acc_o * inv_l[:, None]
+        acc_o = tl.reshape(acc_o, BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D)
+        o_ptrs = tl.make_block_ptr(
+            base=o_ptr + q_start * stride_on + pid_kh * gqa_group_size * stride_oh,
+            shape=(q_len, gqa_group_size, head_dim),
+            strides=(stride_on, stride_oh, stride_od),
+            offsets=(pid_q_j * BLOCK_SIZE_Q, 0, 0),
+            block_shape=(BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D),
+            order=(2, 1, 0),
+        )
+        tl.store(o_ptrs, acc_o.to(o_ptr.dtype.element_ty), boundary_check=(0, 1, 2))
+
+
+@triton_jit(do_not_specialize_on_alignment=["seq_lens", "prefix_lens"])
+def _gqa_sparse_fwd_tle_sync(
+    q_ptr,
+    kv_cache_ptr,
+    t_ptr,
+    o_ptr,
+    block_table_ptr,
+    cu_seqlens_q,
+    cu_seqblocks_q,
+    seq_lens,
+    prefix_lens,
+    num_kv_heads,
+    gqa_group_size,
+    head_dim,
+    max_topk,
+    sm_scale,
+    stride_qn,
+    stride_qh,
+    stride_qd,
+    stride_kv_blk,
+    stride_kv_h,
+    stride_kv_pos,
+    stride_kv_d,
+    stride_th,
+    stride_tn,
+    stride_tk,
+    stride_on,
+    stride_oh,
+    stride_od,
+    stride_bt_b,
+    BLOCK_SIZE_Q: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+    BLOCK_SIZE_H: tl.constexpr,
+    BLOCK_SIZE_QH: tl.constexpr,
+):
+    """Synchronous MetaX TLE path using TLE shared buffers and ``tl.dot``."""
+    tl.static_assert(PAGE_SIZE % BLOCK_SIZE_K == 0)
+    sm_scale_log2e = sm_scale * 1.4426950409
+    pid_q = tl.program_id(0)
+    pid_kh = tl.program_id(1)
+    pid_b = tl.program_id(2)
+    pid_h = pid_kh * gqa_group_size
+
+    q_start = tl.load(cu_seqlens_q + pid_b)
+    q_len = tl.load(cu_seqlens_q + pid_b + 1) - q_start
+    q_block_start = tl.load(cu_seqblocks_q + pid_b)
+    q_block_len = tl.load(cu_seqblocks_q + pid_b + 1) - q_block_start
+    seq_len = tl.load(seq_lens + pid_b)
+    prefix_len = tl.load(prefix_lens + pid_b)
+
+    q_tile_start = pid_q * BLOCK_SIZE_Q
+    if q_tile_start >= q_block_len:
+        return
+
+    off_q = tl.arange(0, BLOCK_SIZE_Q)
+    off_n = tl.arange(0, BLOCK_SIZE_K)
+    off_d = tl.arange(0, BLOCK_SIZE_D)
+    q_abs = prefix_len + q_tile_start + off_q
+    real_topk = tl.minimum(max_topk, (q_abs + PAGE_SIZE) // PAGE_SIZE)
+    loop_blocks = tl.max(real_topk, axis=0)
+
+    bt_row = block_table_ptr + pid_b * stride_bt_b
+    topk_ptr = (
+        t_ptr
+        + pid_kh * stride_th
+        + (q_block_start + q_tile_start) * stride_tn
+    )
+    q_ptrs = tl.make_block_ptr(
+        base=q_ptr + q_start * stride_qn + pid_h * stride_qh,
+        shape=(q_len, gqa_group_size, head_dim),
+        strides=(stride_qn, stride_qh, stride_qd),
+        offsets=(q_tile_start, 0, 0),
+        block_shape=(BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D),
+        order=(2, 1, 0),
+    )
+    q = tl.load(q_ptrs, boundary_check=(0, 1, 2), padding_option="zero")
+    q = tl.reshape(q, BLOCK_SIZE_QH, BLOCK_SIZE_D)
+
+    # MCTLE provides alloc/copy/local_ptr but not Hopper barriers or WGMMA.
+    # Keep its shared-memory abstraction and execute each stage synchronously.
+    kv_smem = tle.gpu.alloc(
+        [BLOCK_SIZE_K, BLOCK_SIZE_D],
+        dtype=kv_cache_ptr.dtype.element_ty,
+        layout=None,
+        scope=tle.gpu.smem,
+    )
+    kv_local_ptrs = tle.gpu.local_ptr(kv_smem)
+
+    causal_offsets = q_abs[:, None] - off_n[None, :]
+    m_i = tl.full((BLOCK_SIZE_QH,), float("-inf"), dtype=tl.float32)
+    l_i = tl.zeros((BLOCK_SIZE_QH,), dtype=tl.float32)
+    acc_o = tl.zeros((BLOCK_SIZE_QH, BLOCK_SIZE_D), dtype=tl.float32)
+
+    for block_iter in tl.range(loop_blocks, disable_licm=True, num_stages=1):
+        blk = tl.load(topk_ptr + block_iter * stride_tk).to(tl.int32)
+        page = tl.load(bt_row + blk).to(tl.int64)
+        kv_base = kv_cache_ptr + page * stride_kv_blk + pid_kh * stride_kv_h
+        for page_offset in tl.static_range(0, PAGE_SIZE, BLOCK_SIZE_K):
+            c = blk * PAGE_SIZE + page_offset
+            pos = c + off_n
+            pos_mask = pos < seq_len
+            k_ptrs = (
+                kv_base
+                + (page_offset + off_n[:, None]) * stride_kv_pos
+                + off_d[None, :] * stride_kv_d
+            )
+            tl.store(kv_local_ptrs, tl.load(k_ptrs))
+            tl.debug_barrier()
+            k = tl.load(kv_local_ptrs)
+            qk = tl.dot(q, tl.trans(k)) * sm_scale_log2e
+            qk = tl.reshape(qk, (BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_K))
+
+            if (c + BLOCK_SIZE_K) > (prefix_len + q_tile_start):
+                qk += tl.where(causal_offsets[:, None, :] >= c, 0, float("-inf"))
+            qk = tl.reshape(qk, BLOCK_SIZE_QH, BLOCK_SIZE_K)
+            if (c + BLOCK_SIZE_K) > seq_len:
+                qk += tl.where(pos_mask[None, :], 0, float("-inf"))
+
+            m_ij = tl.maximum(m_i, tl.max(qk, axis=1))
+            p = tl.exp2(qk - m_ij[:, None])
+            alpha = tl.exp2(m_i - m_ij)
+            l_ij = tl.sum(p, axis=1)
+            acc_o *= alpha[:, None]
+
+            # Finish consuming K before reusing the same TLE buffer for V.
+            tl.debug_barrier()
+            v_ptrs = k_ptrs + head_dim * stride_kv_d
+            tl.store(kv_local_ptrs, tl.load(v_ptrs))
+            tl.debug_barrier()
+            v = tl.load(kv_local_ptrs)
+            p_dot = p.to(v.dtype)
+            acc_o += tl.dot(p_dot, v)
+
+            l_i = tl.math.fma(l_i, alpha, l_ij)
+            m_i = m_ij
+
+    inv_l = tl.where(l_i > 0, 1.0 / l_i, 0.0)
+    acc_o *= inv_l[:, None]
+    acc_o = tl.reshape(acc_o, BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D)
+    o_ptrs = tl.make_block_ptr(
+        base=o_ptr + q_start * stride_on + pid_h * stride_oh,
+        shape=(q_len, gqa_group_size, head_dim),
+        strides=(stride_on, stride_oh, stride_od),
+        offsets=(q_tile_start, 0, 0),
+        block_shape=(BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D),
+        order=(2, 1, 0),
+    )
+    tl.store(o_ptrs, acc_o.to(o_ptr.dtype.element_ty), boundary_check=(0, 1, 2))
+
+
+@triton.heuristics(
+    {
+        "BLOCK_SIZE_D": lambda args: triton.next_power_of_2(args["head_dim"]),
+        "BLOCK_SIZE_H": lambda args: triton.next_power_of_2(args["gqa_group_size"]),
+        "BLOCK_SIZE_QH": lambda args: args["BLOCK_SIZE_Q"]
+        * triton.next_power_of_2(args["gqa_group_size"]),
+    }
+)
+@triton_jit(do_not_specialize_on_alignment=["seq_lens", "prefix_lens"])
+def _gqa_sparse_fwd_kernel(
+    q_ptr,  # [total_q, num_heads, head_dim]
+    kv_cache_ptr,  # [num_blocks, num_kv_heads, 128, 2*head_dim]
+    kv_cache_desc,  # flattened [num_blocks*num_kv_heads*128, 2*head_dim]
+    k_scale_ptr,
+    v_scale_ptr,
+    t_ptr,  # topk_idx: [num_kv_heads, total_q, topk]
+    o_ptr,  # [total_q, num_heads, head_dim]
+    block_table_ptr,  # [num_reqs, max_blocks]
+    cu_seqlens_q,
+    cu_seqblocks_q,
+    seq_lens,
+    prefix_lens,
+    num_kv_heads,
+    gqa_group_size,
+    head_dim,
+    max_topk,
+    num_q_loop,
+    sm_scale,
+    stride_qn,
+    stride_qh,
+    stride_qd,
+    stride_kv_blk,
+    stride_kv_h,
+    stride_kv_pos,
+    stride_kv_d,
+    stride_ks_h,
+    stride_ks_t,
+    stride_vs_h,
+    stride_vs_t,
+    stride_th,
+    stride_tn,
+    stride_tk,
+    stride_on,
+    stride_oh,
+    stride_od,
+    stride_bt_b,
+    BLOCK_SIZE_Q: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+    BLOCK_SIZE_H: tl.constexpr,
+    BLOCK_SIZE_QH: tl.constexpr,
+    USE_DIRECT: tl.constexpr,
+    USE_FP8: tl.constexpr,
+    KV_SCALE_MODE: tl.constexpr,
+    USE_HALF_KV_PIPE: tl.constexpr,
+):
+    if USE_DIRECT:
+        _gqa_sparse_fwd_direct(
+            q_ptr,
+            kv_cache_ptr,
+            k_scale_ptr,
+            v_scale_ptr,
+            t_ptr,
+            o_ptr,
+            block_table_ptr,
+            cu_seqlens_q,
+            cu_seqblocks_q,
+            seq_lens,
+            prefix_lens,
+            num_kv_heads,
+            gqa_group_size,
+            head_dim,
+            max_topk,
+            num_q_loop,
+            sm_scale,
+            stride_qn,
+            stride_qh,
+            stride_qd,
+            stride_kv_blk,
+            stride_kv_h,
+            stride_kv_pos,
+            stride_kv_d,
+            stride_ks_h,
+            stride_ks_t,
+            stride_vs_h,
+            stride_vs_t,
+            stride_th,
+            stride_tn,
+            stride_tk,
+            stride_on,
+            stride_oh,
+            stride_od,
+            stride_bt_b,
+            BLOCK_SIZE_Q,
+            BLOCK_SIZE_K,
+            BLOCK_SIZE_D,
+            BLOCK_SIZE_H,
+            BLOCK_SIZE_QH,
+            USE_FP8,
+            KV_SCALE_MODE,
+        )
+        return
+
+    sm_scale_log2e = sm_scale * 1.4426950409
+    pid_q = tl.program_id(0)
+    pid_kh = tl.program_id(1)
+    pid_b = tl.program_id(2)
+    pid_h = pid_kh * gqa_group_size
+    q_start = tl.load(cu_seqlens_q + pid_b)
+    q_len = tl.load(cu_seqlens_q + pid_b + 1) - q_start
+    q_block_start = tl.load(cu_seqblocks_q + pid_b)
+    q_block_len = tl.load(cu_seqblocks_q + pid_b + 1) - q_block_start
+    seq_len = tl.load(seq_lens + pid_b)
+    prefix_len = tl.load(prefix_lens + pid_b)
+
+    q_tile_start = pid_q * BLOCK_SIZE_Q
+    if q_tile_start >= q_block_len:
+        return
+
+    off_q = tl.arange(0, BLOCK_SIZE_Q)
+    off_n = tl.arange(0, BLOCK_SIZE_K)
+    q_abs = prefix_len + q_tile_start + off_q
+    real_topk = tl.minimum(max_topk, (q_abs + BLOCK_SIZE_K) // BLOCK_SIZE_K)
+
+    bt_row = block_table_ptr + pid_b * stride_bt_b
+    q_ptrs = tl.make_block_ptr(
+        base=q_ptr + q_start * stride_qn + pid_h * stride_qh,
+        shape=(q_len, gqa_group_size, head_dim),
+        strides=(stride_qn, stride_qh, stride_qd),
+        offsets=(q_tile_start, 0, 0),
+        block_shape=(BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D),
+        order=(2, 1, 0),
+    )
+    q = tl.load(q_ptrs, boundary_check=(0, 1, 2), padding_option="zero")
+    q = tl.reshape(q, BLOCK_SIZE_QH, BLOCK_SIZE_D)
+
+    # Four warps form one Hopper warpgroup. Q is staged once and reused by all
+    # selected pages as the transposed WGMMA B operand.
+    q_smem = tle.gpu.alloc(
+        [1, BLOCK_SIZE_QH, BLOCK_SIZE_D],
+        dtype=q_ptr.dtype.element_ty,
+        layout=None,
+        scope=tle.gpu.smem,
+    )
+    tl.store(tle.gpu.local_ptr(q_smem.slot(0)), q)
+    tl.debug_barrier()
+
+    m_i = tl.full((BLOCK_SIZE_QH,), float("-inf"), dtype=tl.float32)
+    l_i = tl.zeros((BLOCK_SIZE_QH,), dtype=tl.float32)
+    acc_o_t = tl.zeros((BLOCK_SIZE_D, BLOCK_SIZE_QH), dtype=tl.float32)
+
+    loop_blocks = tl.max(real_topk, axis=0)
+    topk_ptr = t_ptr + pid_kh * stride_th + (q_block_start + q_tile_start) * stride_tn
+
+    if USE_HALF_KV_PIPE:
+        HALF_K: tl.constexpr = BLOCK_SIZE_K // 2
+        off_half = tl.arange(0, HALF_K)
+        causal_offsets = q_abs[:, None] - off_half[None, :]
+        p_smem = tle.gpu.alloc(
+            [1, BLOCK_SIZE_QH, HALF_K],
+            dtype=kv_cache_ptr.dtype.element_ty,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+        kv_smem = tle.gpu.alloc(
+            [2, HALF_K, BLOCK_SIZE_D],
+            dtype=kv_cache_ptr.dtype.element_ty,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+        kv_stage_bytes: tl.constexpr = HALF_K * BLOCK_SIZE_D * 2
+        kv_empty = tle.gpu.alloc_barriers(
+            num_barriers=2,
+            arrive_count=1,
+            init=tle.gpu.READY,
+        )
+        kv_full = tle.gpu.alloc_barriers(
+            num_barriers=2,
+            arrive_count=1,
+            expect_bytes=kv_stage_bytes,
+        )
+        loop_tiles = loop_blocks * 2
+        # The K prefetch already resolves the next tile's logical block and
+        # physical page. Keep these two scalar addresses live across the loop
+        # so the V copy does not reload topk_idx and block_table for that tile.
+        cur_kv_row = tl.full((), 0, dtype=tl.int32)
+        cur_c = tl.full((), 0, dtype=tl.int32)
+
+        # Prologue: stage the first K half before entering the ping-pong loop.
+        if loop_tiles > 0:
+            first_blk = tl.load(topk_ptr).to(tl.int32)
+            first_page = tl.load(bt_row + first_blk).to(tl.int32)
+            first_row = (first_page * num_kv_heads + pid_kh) * BLOCK_SIZE_K
+            cur_kv_row = first_row
+            cur_c = first_blk * BLOCK_SIZE_K
+            tle.gpu.barrier_wait(kv_empty[0], phaseIdx=0)
+            tle.gpu.copy(
+                kv_cache_desc,
+                kv_smem.slot(0),
+                [HALF_K, BLOCK_SIZE_D],
+                [first_row, 0],
+                barrier=kv_full[0],
+            )
+
+        for tile_iter in tl.range(loop_tiles, disable_licm=True, num_stages=1):
+            block_iter = tile_iter // 2
+            # half_idx = tile_iter % 2
+            buf_idx = tile_iter % 2
+            reuse_iter = tile_iter // 2
+            k_phase = reuse_iter * 2
+            v_phase = k_phase + 1
+
+            kv_row = cur_kv_row
+            c = cur_c
+            pos = c + off_half
+            pos_mask = pos < seq_len
+
+            tle.gpu.barrier_wait(kv_full[buf_idx], phaseIdx=k_phase)
+            qk_t = tle.gpu.wgmma(
+                kv_smem.slot(buf_idx),
+                q_smem.slot(0),
+                out_dtype=tl.float32,
+                trans_b=True,
+            )
+            qk_t = tle.gpu.wgmma_wait(0, qk_t)
+            qk_t *= sm_scale_log2e
+            qk = tl.reshape(
+                tl.trans(qk_t),
+                (BLOCK_SIZE_Q, BLOCK_SIZE_H, HALF_K),
+            )
+
+            # Reuse this slot for V while the other slot receives the next K.
+            tle.gpu.barrier_arrive(kv_empty[buf_idx], phaseIdx=k_phase)
+            tle.gpu.barrier_wait(kv_empty[buf_idx], phaseIdx=v_phase)
+            tle.gpu.copy(
+                kv_cache_desc,
+                kv_smem.slot(buf_idx),
+                [HALF_K, BLOCK_SIZE_D],
+                [kv_row, BLOCK_SIZE_D],
+                barrier=kv_full[buf_idx],
+            )
+
+            if tile_iter + 1 < loop_tiles:
+                next_tile = tile_iter + 1
+                next_block_iter = next_tile // 2
+                next_half_idx = next_tile % 2
+                next_buf_idx = next_tile % 2
+                next_reuse_iter = next_tile // 2
+                next_k_phase = next_reuse_iter * 2
+                next_blk = tl.load(
+                    topk_ptr + next_block_iter * stride_tk
+                ).to(tl.int32)
+                next_page = tl.load(bt_row + next_blk).to(tl.int32)
+                next_kv_row = (
+                    next_page * num_kv_heads + pid_kh
+                ) * BLOCK_SIZE_K + next_half_idx * HALF_K
+                next_c = next_blk * BLOCK_SIZE_K + next_half_idx * HALF_K
+                tle.gpu.barrier_wait(
+                    kv_empty[next_buf_idx], phaseIdx=next_k_phase
+                )
+                tle.gpu.copy(
+                    kv_cache_desc,
+                    kv_smem.slot(next_buf_idx),
+                    [HALF_K, BLOCK_SIZE_D],
+                    [next_kv_row, 0],
+                    barrier=kv_full[next_buf_idx],
+                )
+                cur_kv_row = next_kv_row
+                cur_c = next_c
+
+            if (c + HALF_K) > (prefix_len + q_tile_start):
+                qk += tl.where(causal_offsets[:, None, :] >= c, 0, float("-inf"))
+            qk = tl.reshape(qk, BLOCK_SIZE_QH, HALF_K)
+            if (c + HALF_K) > seq_len:
+                qk += tl.where(pos_mask[None, :], 0, float("-inf"))
+
+            m_ij = tl.maximum(m_i, tl.max(qk, axis=1))
+            p = tl.exp2(qk - m_ij[:, None])
+            alpha = tl.exp2(m_i - m_ij)
+            l_ij = tl.sum(p, axis=1)
+            acc_o_t *= alpha[None, :]
+            tl.store(
+                tle.gpu.local_ptr(p_smem.slot(0)),
+                p.to(kv_cache_ptr.dtype.element_ty),
+            )
+
+            tle.gpu.barrier_wait(kv_full[buf_idx], phaseIdx=v_phase)
+            tl.debug_barrier()
+            acc_o_t = tle.gpu.wgmma(
+                kv_smem.slot(buf_idx),
+                p_smem.slot(0),
+                acc_o_t,
+                trans_a=True,
+                trans_b=True,
+            )
+            acc_o_t = tle.gpu.wgmma_wait(0, acc_o_t)
+            tle.gpu.barrier_arrive(kv_empty[buf_idx], phaseIdx=v_phase)
+
+            l_i = tl.math.fma(l_i, alpha, l_ij)
+            m_i = m_ij
+    else:
+        causal_offsets = q_abs[:, None] - off_n[None, :]
+        p_smem = tle.gpu.alloc(
+            [1, BLOCK_SIZE_QH, BLOCK_SIZE_K],
+            dtype=kv_cache_ptr.dtype.element_ty,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+        kv_smem = tle.gpu.alloc(
+            [1, BLOCK_SIZE_K, BLOCK_SIZE_D],
+            dtype=kv_cache_ptr.dtype.element_ty,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+        kv_stage_bytes: tl.constexpr = BLOCK_SIZE_K * BLOCK_SIZE_D * 2
+        kv_empty = tle.gpu.alloc_barriers(
+            num_barriers=1,
+            arrive_count=1,
+            init=tle.gpu.READY,
+        )
+        kv_full = tle.gpu.alloc_barriers(
+            num_barriers=1,
+            arrive_count=1,
+            expect_bytes=kv_stage_bytes,
+        )
+        # Resolve page(0) before the loop. Each iteration consumes the carried
+        # row/offset, then resolves page(i + 1) while V(i) is in flight.
+        cur_kv_row = tl.full((), 0, dtype=tl.int32)
+        cur_c = tl.full((), 0, dtype=tl.int32)
+        if loop_blocks > 0:
+            first_blk = tl.load(topk_ptr).to(tl.int32)
+            first_page = tl.load(bt_row + first_blk).to(tl.int32)
+            cur_kv_row = (
+                first_page * num_kv_heads + pid_kh
+            ) * BLOCK_SIZE_K
+            cur_c = first_blk * BLOCK_SIZE_K
+
+        for block_iter in tl.range(loop_blocks, disable_licm=True, num_stages=1):
+            k_phase = block_iter * 2
+            v_phase = k_phase + 1
+            kv_row = cur_kv_row
+            c = cur_c
+            pos = c + off_n
+            pos_mask = pos < seq_len
+
+            tle.gpu.barrier_wait(kv_empty[0], phaseIdx=k_phase)
+            tle.gpu.copy(
+                kv_cache_desc,
+                kv_smem.slot(0),
+                [BLOCK_SIZE_K, BLOCK_SIZE_D],
+                [kv_row, 0],
+                barrier=kv_full[0],
+            )
+            tle.gpu.barrier_wait(kv_full[0], phaseIdx=k_phase)
+
+            qk_t = tle.gpu.wgmma(
+                kv_smem.slot(0),
+                q_smem.slot(0),
+                out_dtype=tl.float32,
+                trans_b=True,
+            )
+            qk_t = tle.gpu.wgmma_wait(0, qk_t)
+            qk_t *= sm_scale_log2e
+            qk = tl.reshape(
+                tl.trans(qk_t),
+                (BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_K),
+            )
+
+            tle.gpu.barrier_arrive(kv_empty[0], phaseIdx=k_phase)
+            tle.gpu.barrier_wait(kv_empty[0], phaseIdx=v_phase)
+            tle.gpu.copy(
+                kv_cache_desc,
+                kv_smem.slot(0),
+                [BLOCK_SIZE_K, BLOCK_SIZE_D],
+                [kv_row, BLOCK_SIZE_D],
+                barrier=kv_full[0],
+            )
+
+            if block_iter + 1 < loop_blocks:
+                next_blk = tl.load(
+                    topk_ptr + (block_iter + 1) * stride_tk
+                ).to(tl.int32)
+                next_page = tl.load(bt_row + next_blk).to(tl.int32)
+                cur_kv_row = (
+                    next_page * num_kv_heads + pid_kh
+                ) * BLOCK_SIZE_K
+                cur_c = next_blk * BLOCK_SIZE_K
+
+            if (c + BLOCK_SIZE_K) > (prefix_len + q_tile_start):
+                qk += tl.where(causal_offsets[:, None, :] >= c, 0, float("-inf"))
+            qk = tl.reshape(qk, BLOCK_SIZE_QH, BLOCK_SIZE_K)
+            if (c + BLOCK_SIZE_K) > seq_len:
+                qk += tl.where(pos_mask[None, :], 0, float("-inf"))
+
+            m_ij = tl.maximum(m_i, tl.max(qk, axis=1))
+            p = tl.exp2(qk - m_ij[:, None])
+            alpha = tl.exp2(m_i - m_ij)
+            l_ij = tl.sum(p, axis=1)
+            acc_o_t *= alpha[None, :]
+            tl.store(
+                tle.gpu.local_ptr(p_smem.slot(0)),
+                p.to(kv_cache_ptr.dtype.element_ty),
+            )
+
+            tle.gpu.barrier_wait(kv_full[0], phaseIdx=v_phase)
+            tl.debug_barrier()
+            acc_o_t = tle.gpu.wgmma(
+                kv_smem.slot(0),
+                p_smem.slot(0),
+                acc_o_t,
+                trans_a=True,
+                trans_b=True,
+            )
+            acc_o_t = tle.gpu.wgmma_wait(0, acc_o_t)
+            tle.gpu.barrier_arrive(kv_empty[0], phaseIdx=v_phase)
+
+            l_i = tl.math.fma(l_i, alpha, l_ij)
+            m_i = m_ij
+
+    inv_l = tl.where(l_i > 0, 1.0 / l_i, 0.0)
+    acc_o_t *= inv_l[None, :]
+    acc_o = tl.trans(acc_o_t)
+    acc_o = tl.reshape(acc_o, BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D)
+    o_ptrs = tl.make_block_ptr(
+        base=o_ptr + q_start * stride_on + pid_h * stride_oh,
+        shape=(q_len, gqa_group_size, head_dim),
+        strides=(stride_on, stride_oh, stride_od),
+        offsets=(q_tile_start, 0, 0),
+        block_shape=(BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D),
+        order=(2, 1, 0),
+    )
+    tl.store(o_ptrs, acc_o.to(o_ptr.dtype.element_ty), boundary_check=(0, 1, 2))
+
+
+# ---------------------------------------------------------------------------
+# Decode kernels (split-K). Decode batches are flattened request-major, with a
+# runtime query length used to map each query token back to its request metadata.
+# This parallelizes over the selected top-k blocks, producing partials that the
+# merge kernel combines (flash-decoding). All chunk counts depend only on shape
+# constants so the grid is fixed within a cuda graph. Base-2 (exp2/log2)
+# softmax matches the prefill kernel.
+# ---------------------------------------------------------------------------
+@triton.heuristics(
+    {
+        "BLOCK_SIZE_H": lambda args: max(
+            16, triton.next_power_of_2(args["gqa_group_size"])
+        ),
+        "BLOCK_SIZE_D": lambda args: triton.next_power_of_2(args["head_dim"]),
+    }
+)
+@triton.jit(do_not_specialize=["decode_query_len"])
+def _gqa_sparse_decode_kernel(
+    q_ptr,  # [total_q, num_heads, head_dim]
+    kv_cache_ptr,  # main cache: [num_blocks, num_kv_heads, 128, 2*head_dim]
+    k_scale_ptr,
+    v_scale_ptr,
+    t_ptr,  # topk_idx: [num_kv_heads, total_q, topk]
+    o_ptr,  # partial out: [NUM_TOPK_CHUNKS, total_q, num_heads, head_dim]
+    lse_ptr,  # partial lse (log2): [NUM_TOPK_CHUNKS, total_q, num_heads]
+    block_table_ptr,  # [num_reqs, max_blocks]
+    seq_lens,  # [num_reqs]
+    total_q,
+    gqa_group_size,
+    head_dim,
+    max_topk,
+    sm_scale,
+    decode_query_len,
+    stride_qn,
+    stride_qh,
+    stride_qd,
+    stride_kv_blk,
+    stride_kv_h,
+    stride_kv_pos,
+    stride_kv_d,
+    stride_ks_h,
+    stride_ks_t,
+    stride_vs_h,
+    stride_vs_t,
+    stride_th,
+    stride_tn,
+    stride_tk,
+    stride_o_c,
+    stride_o_b,
+    stride_o_h,
+    stride_o_d,
+    stride_l_c,
+    stride_l_b,
+    stride_l_h,
+    stride_bt_b,
+    BLOCK_SIZE_K: tl.constexpr,  # decode tile; divides PAGE_SIZE
+    PAGE_SIZE: tl.constexpr,
+    NUM_TOPK_CHUNKS: tl.constexpr,
+    BLOCK_SIZE_H: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+    USE_FP8: tl.constexpr,  # fp8 KV cache: dequantize K/V to q.dtype on load
+    KV_SCALE_MODE: tl.constexpr,  # 0: none, 1: scalar, 2: [kv_head, token]
+    USE_PDL: tl.constexpr,
+):
+    tl.static_assert(PAGE_SIZE % BLOCK_SIZE_K == 0)
+    sm_scale_log2e = sm_scale * 1.4426950409
+    # split-K over the topk dimension: pid(0) folds (query-token, chunk).
+    pid_bc, pid_kh = tl.program_id(0), tl.program_id(1)
+    pid_b = pid_bc % total_q
+    pid_c = pid_bc // total_q
+    req_id = pid_b // decode_query_len
+    q_offset = pid_b - req_id * decode_query_len
+    pid_h = pid_kh * gqa_group_size
+    chunk_size_topk = (max_topk + NUM_TOPK_CHUNKS - 1) // NUM_TOPK_CHUNKS
+    chunk_start_topk = pid_c * chunk_size_topk
+    chunk_end_compiletime = chunk_start_topk + chunk_size_topk
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
+
+    seq_len = tl.load(seq_lens + req_id)
+    query_pos = seq_len - decode_query_len + q_offset
+    # Full-CG padding uses zero-length request rows. Clamp to an empty
+    # attention range instead of letting padded rows produce negative lengths.
+    kv_len = tl.maximum(query_pos + 1, 0)
+
+    # Valid block count from seq_len (no sentinel): min(topk, cdiv(kv_len, blk)).
+    idx_base = t_ptr + pid_kh * stride_th + pid_b * stride_tn
+    num_blocks = (kv_len + PAGE_SIZE - 1) // PAGE_SIZE
+    real_topk = tl.minimum(max_topk, num_blocks)
+    chunk_end_topk = tl.minimum(chunk_end_compiletime, real_topk)
+
+    off_n = tl.arange(0, BLOCK_SIZE_K)
+    off_d = tl.arange(0, BLOCK_SIZE_D)
+    d_mask = off_d < head_dim
+    bt_row = block_table_ptr + req_id * stride_bt_b
+
+    m_i = tl.full((BLOCK_SIZE_H,), float("-inf"), dtype=tl.float32)
+    lse_i = tl.full((BLOCK_SIZE_H,), float("-inf"), dtype=tl.float32)
+    acc_o = tl.zeros((BLOCK_SIZE_H, BLOCK_SIZE_D), dtype=tl.float32)
+    q_ptrs = tl.make_block_ptr(
+        base=q_ptr + pid_b * stride_qn + pid_h * stride_qh,
+        shape=(gqa_group_size, head_dim),
+        strides=(stride_qh, stride_qd),
+        offsets=(0, 0),
+        block_shape=(BLOCK_SIZE_H, BLOCK_SIZE_D),
+        order=(1, 0),
+    )
+    q = tl.load(q_ptrs, boundary_check=(0, 1), padding_option="zero")
+
+    cur_idx_ptr = idx_base + chunk_start_topk * stride_tk
+    for _ in tl.range(chunk_start_topk, chunk_end_topk):
+        blk = tl.load(cur_idx_ptr).to(tl.int32)
+        cur_idx_ptr = cur_idx_ptr + stride_tk
+        for page_offset in tl.static_range(0, PAGE_SIZE, BLOCK_SIZE_K):
+            c = blk * PAGE_SIZE + page_offset
+            page = tl.load(bt_row + blk).to(tl.int64)
+            pos = c + off_n
+            pos_mask = pos < kv_len
+            k = tl.load(
+                kv_cache_ptr
+                + page * stride_kv_blk
+                + pid_kh * stride_kv_h
+                + (page_offset + off_n[None, :]) * stride_kv_pos
+                + off_d[:, None] * stride_kv_d,
+                mask=d_mask[:, None] & pos_mask[None, :],
+                other=0.0,
+            )
+            if USE_FP8:
+                k = k.to(q.dtype)
+                if KV_SCALE_MODE == 1:
+                    k = (k * tl.load(k_scale_ptr)).to(q.dtype)
+                elif KV_SCALE_MODE == 2:
+                    k_scale = tl.load(
+                        k_scale_ptr
+                        + pid_kh * stride_ks_h
+                        + (page * PAGE_SIZE + page_offset + off_n) * stride_ks_t,
+                        mask=pos_mask,
+                        other=1.0,
+                    )
+                    k = (k * k_scale[None, :]).to(q.dtype)
+            qk = tl.zeros((BLOCK_SIZE_H, BLOCK_SIZE_K), dtype=tl.float32)
+            qk += tl.where(pos_mask[None, :], 0, float("-inf"))
+            qk += tl.dot(q, k) * sm_scale_log2e
+            m_ij = tl.maximum(m_i, tl.max(qk, axis=1))
+            p = tl.exp2(qk - m_ij[:, None])
+            l_ij = tl.sum(p, axis=1)
+            acc_o = acc_o * tl.exp2(m_i - m_ij)[:, None]
+            v = tl.load(
+                kv_cache_ptr
+                + page * stride_kv_blk
+                + pid_kh * stride_kv_h
+                + (page_offset + off_n[:, None]) * stride_kv_pos
+                + (head_dim + off_d[None, :]) * stride_kv_d,
+                mask=pos_mask[:, None] & d_mask[None, :],
+                other=0.0,
+            )
+            if USE_FP8:
+                v = v.to(q.dtype)
+                if KV_SCALE_MODE == 1:
+                    v = (v * tl.load(v_scale_ptr)).to(q.dtype)
+                elif KV_SCALE_MODE == 2:
+                    v_scale = tl.load(
+                        v_scale_ptr
+                        + pid_kh * stride_vs_h
+                        + (page * PAGE_SIZE + page_offset + off_n) * stride_vs_t,
+                        mask=pos_mask,
+                        other=1.0,
+                    )
+                    v = (v * v_scale[:, None]).to(q.dtype)
+            acc_o += tl.dot(p.to(v.dtype), v)
+            m_i = m_ij
+            lse_i = m_ij + tl.log2(tl.exp2(lse_i - m_ij) + l_ij)
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
+    # Empty chunks for active rows must store zero output; otherwise the merge
+    # can hit 0 * NaN. All-empty padded rows may still produce NaNs in merge.
+    scale = tl.where(lse_i > float("-inf"), tl.exp2(m_i - lse_i), tl.zeros_like(lse_i))
+    acc_o = acc_o * scale[:, None]
+    o_ptrs = tl.make_block_ptr(
+        base=o_ptr + pid_c * stride_o_c + pid_b * stride_o_b + pid_h * stride_o_h,
+        shape=(gqa_group_size, head_dim),
+        strides=(stride_o_h, stride_o_d),
+        offsets=(0, 0),
+        block_shape=(BLOCK_SIZE_H, BLOCK_SIZE_D),
+        order=(1, 0),
+    )
+    tl.store(o_ptrs, acc_o.to(o_ptr.dtype.element_ty), boundary_check=(0, 1))
+    lse_ptrs = tl.make_block_ptr(
+        base=lse_ptr + pid_c * stride_l_c + pid_b * stride_l_b + pid_h * stride_l_h,
+        shape=(gqa_group_size,),
+        strides=(stride_l_h,),
+        offsets=(0,),
+        block_shape=(BLOCK_SIZE_H,),
+        order=(0,),
+    )
+    tl.store(lse_ptrs, lse_i.to(lse_ptr.dtype.element_ty), boundary_check=(0,))
+
+
+@triton.heuristics(
+    {"BLOCK_SIZE_D": lambda args: triton.next_power_of_2(args["head_dim"])}
+)
+@triton.jit
+def _merge_topk_attn_out_kernel(
+    o_ptr,  # partials: [NUM_TOPK_CHUNKS, total_q, num_heads, head_dim]
+    lse_ptr,  # partials (log2): [NUM_TOPK_CHUNKS, total_q, num_heads]
+    out_ptr,  # merged out: [total_q, num_heads, head_dim]
+    head_dim,
+    stride_o_c,
+    stride_o_b,
+    stride_o_h,
+    stride_o_d,
+    stride_l_c,
+    stride_l_b,
+    stride_l_h,
+    stride_out_n,
+    stride_out_h,
+    stride_out_d,
+    NUM_TOPK_CHUNKS: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+    USE_PDL: tl.constexpr,
+):
+    pid_b, pid_h = tl.program_id(0), tl.program_id(1)
+
+    # NOTE: assume seq_lens is safe to load before gdc_wait()
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    off_c = tl.arange(0, NUM_TOPK_CHUNKS)
+    off_d = tl.arange(0, BLOCK_SIZE_D)
+    o_ptrs = tl.make_block_ptr(
+        base=o_ptr + pid_b * stride_o_b + pid_h * stride_o_h,
+        shape=(NUM_TOPK_CHUNKS, head_dim),
+        strides=(stride_o_c, stride_o_d),
+        offsets=(0, 0),
+        block_shape=(NUM_TOPK_CHUNKS, BLOCK_SIZE_D),
+        order=(1, 0),
+    )
+    lse_ptrs = lse_ptr + pid_b * stride_l_b + pid_h * stride_l_h + off_c * stride_l_c
+    o = tl.load(o_ptrs, boundary_check=(0, 1), padding_option="zero")
+    lse = tl.load(lse_ptrs)  # empty chunks contribute -inf -> weight 0
+    lse_max = tl.max(lse, axis=0)
+    weights = tl.exp2(lse - lse_max)
+    weights = weights / tl.sum(weights, axis=0)
+    o_merged = tl.sum(o * weights[:, None], axis=0)
+    out_ptrs = (
+        out_ptr + pid_b * stride_out_n + pid_h * stride_out_h + off_d * stride_out_d
+    )
+    tl.store(out_ptrs, o_merged.to(out_ptr.dtype.element_ty), mask=off_d < head_dim)
+
+
+# ---------------------------------------------------------------------------
+# Python wrappers
+# ---------------------------------------------------------------------------
+_KV_SCALE_NONE = 0
+_KV_SCALE_SCALAR = 1
+_KV_SCALE_PER_TOKEN_HEAD = 2
+
+
+def _kv_scale_args(
+    output: torch.Tensor,
+    num_kv_heads: int,
+    k_scale: torch.Tensor | None,
+    v_scale: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor, int, int, int, int, int]:
+    if k_scale is None and v_scale is None:
+        return output, output, 0, 0, 0, 0, _KV_SCALE_NONE
+    if k_scale is None or v_scale is None:
+        raise ValueError("k_scale and v_scale must be both provided or both None")
+    if k_scale.device != output.device or v_scale.device != output.device:
+        raise ValueError("k_scale and v_scale must be on the same device as output")
+    if k_scale.numel() == 1 and v_scale.numel() == 1:
+        return k_scale, v_scale, 0, 0, 0, 0, _KV_SCALE_SCALAR
+    if k_scale.dim() == 2 and v_scale.dim() == 2:
+        if k_scale.shape[0] != num_kv_heads or v_scale.shape[0] != num_kv_heads:
+            raise ValueError(
+                "per-token/head KV scales must have shape "
+                f"[{num_kv_heads}, max_kv_tokens]"
+            )
+        if k_scale.shape != v_scale.shape:
+            raise ValueError("k_scale and v_scale must have matching shapes")
+        return (
+            k_scale,
+            v_scale,
+            k_scale.stride(0),
+            k_scale.stride(1),
+            v_scale.stride(0),
+            v_scale.stride(1),
+            _KV_SCALE_PER_TOKEN_HEAD,
+        )
+    raise ValueError(
+        "MiniMax-M3 sparse attention supports scalar KV scales or "
+        "[num_kv_heads, max_kv_tokens] per-token/head scales"
+    )
+
+
+@torch.no_grad()
+def minimax_m3_sparse_attn(
+    q: torch.Tensor,  # [total_q, num_heads, head_dim]
+    kv_cache: torch.Tensor,  # [num_blocks, num_kv_heads, 128, 2*head_dim]
+    topk_idx: torch.Tensor,  # [num_kv_heads, total_q, topk]
+    block_table: torch.Tensor,  # [batch, max_blocks]
+    cu_seqlens_q: torch.Tensor,  # [batch+1] int32
+    seq_lens: torch.Tensor,  # [batch] int32
+    prefix_lens: torch.Tensor,  # [batch] int32
+    max_query_len: int,
+    num_kv_heads: int,
+    sm_scale: float,
+    output: torch.Tensor,  # [total_q, num_heads, head_dim]
+    k_scale: torch.Tensor | None = None,
+    v_scale: torch.Tensor | None = None,
+) -> None:
+    """GQA block-sparse attention over the selected blocks. block_size_q == 1."""
+    total_q, num_heads, head_dim = q.shape
+    batch = cu_seqlens_q.shape[0] - 1
+    topk = topk_idx.shape[-1]
+    gqa_group_size = num_heads // num_kv_heads
+    use_fp8 = kv_cache.dtype in _FP8_DTYPES
+    (
+        k_scale_arg,
+        v_scale_arg,
+        stride_ks_h,
+        stride_ks_t,
+        stride_vs_h,
+        stride_vs_t,
+        kv_scale_mode,
+    ) = (
+        _kv_scale_args(output, num_kv_heads, k_scale, v_scale)
+        if use_fp8
+        else (
+            output,
+            output,
+            0,
+            0,
+            0,
+            0,
+            _KV_SCALE_NONE,
+        )
+    )
+    grid = (max_query_len, num_kv_heads, batch)
+    block_size_h = triton.next_power_of_2(gqa_group_size)
+
+    # FP8 KV has a dtype mismatch with BF16 Q, and a GQA tile below eight heads
+    # cannot form a legal WGMMA result. Keep those cases on the direct kernel.
+    # Otherwise prefer the complete asynchronous TLE path, then MetaX's
+    # synchronous TLE shared-memory subset, and use direct Triton only when
+    # neither TLE capability set is available.
+    use_tle_async = not use_fp8 and block_size_h >= 8 and _HAS_TLE_ASYNC_MMA
+    use_tle_sync = (
+        not use_fp8
+        and not use_tle_async
+        and _HAS_TLE_SYNC
+    )
+    use_direct = not use_tle_async and not use_tle_sync
+    if use_direct:
+        direct_block_size_h = (
+            max(16, block_size_h) if current_platform.is_metax() else block_size_h
+        )
+        launch_kwargs = {"num_warps": 4, "num_stages": 3}
+        launch_kwargs.update(
+            current_platform.attention_launch_kwargs(
+                num_stages=1, scenario="flashattn-fwd;unprefetch"
+            )
+        )
+        _gqa_sparse_fwd_direct[grid](
+            q,
+            kv_cache,
+            k_scale_arg,
+            v_scale_arg,
+            topk_idx,
+            output,
+            block_table,
+            cu_seqlens_q,
+            cu_seqlens_q,
+            seq_lens,
+            prefix_lens,
+            num_kv_heads,
+            gqa_group_size,
+            head_dim,
+            topk,
+            1,  # num_q_loop
+            sm_scale,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            kv_cache.stride(0),
+            kv_cache.stride(1),
+            kv_cache.stride(2),
+            kv_cache.stride(3),
+            stride_ks_h,
+            stride_ks_t,
+            stride_vs_h,
+            stride_vs_t,
+            topk_idx.stride(0),
+            topk_idx.stride(1),
+            topk_idx.stride(2),
+            output.stride(0),
+            output.stride(1),
+            output.stride(2),
+            block_table.stride(0),
+            BLOCK_SIZE_Q=1,
+            BLOCK_SIZE_K=SPARSE_BLOCK_SIZE,
+            BLOCK_SIZE_D=triton.next_power_of_2(head_dim),
+            BLOCK_SIZE_H=direct_block_size_h,
+            BLOCK_SIZE_QH=direct_block_size_h,
+            USE_FP8=use_fp8,
+            KV_SCALE_MODE=kv_scale_mode,
+            **launch_kwargs,
+        )
+        return
+
+    if use_tle_sync:
+        sync_block_size_h = max(16, block_size_h)
+        launch_kwargs = {"num_warps": _PREFILL_SYNC_NUM_WARPS, "num_stages": 1}
+        launch_kwargs.update(
+            current_platform.attention_launch_kwargs(
+                num_warps=_PREFILL_SYNC_NUM_WARPS,
+                num_stages=1,
+                scenario="flashattn-fwd;unprefetch",
+            )
+        )
+        _gqa_sparse_fwd_tle_sync[grid](
+            q,
+            kv_cache,
+            topk_idx,
+            output,
+            block_table,
+            cu_seqlens_q,
+            cu_seqlens_q,
+            seq_lens,
+            prefix_lens,
+            num_kv_heads,
+            gqa_group_size,
+            head_dim,
+            topk,
+            sm_scale,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            kv_cache.stride(0),
+            kv_cache.stride(1),
+            kv_cache.stride(2),
+            kv_cache.stride(3),
+            topk_idx.stride(0),
+            topk_idx.stride(1),
+            topk_idx.stride(2),
+            output.stride(0),
+            output.stride(1),
+            output.stride(2),
+            block_table.stride(0),
+            BLOCK_SIZE_Q=1,
+            BLOCK_SIZE_K=_PREFILL_SYNC_BLOCK_SIZE_K,
+            PAGE_SIZE=SPARSE_BLOCK_SIZE,
+            BLOCK_SIZE_D=triton.next_power_of_2(head_dim),
+            BLOCK_SIZE_H=sync_block_size_h,
+            BLOCK_SIZE_QH=sync_block_size_h,
+            **launch_kwargs,
+        )
+        return
+
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    def alloc_fn(size: int, align: int, stream):
+        _ = align
+        _ = stream
+        return torch.empty(size, dtype=torch.int8, device=kv_cache.device)
+
+    triton.set_allocator(alloc_fn)
+    use_half_kv_pipe = (
+        block_size_h <= _PREFILL_HALF_KV_MAX_BLOCK_SIZE_QH
+    )
+    kv_tma_rows = SPARSE_BLOCK_SIZE // 2 if use_half_kv_pipe else SPARSE_BLOCK_SIZE
+    kv_cache_2d = kv_cache.view(-1, 2 * head_dim)
+    kv_cache_desc = TensorDescriptor(
+        kv_cache_2d,
+        shape=[kv_cache_2d.shape[0], kv_cache_2d.shape[1]],
+        strides=[kv_cache_2d.stride(0), kv_cache_2d.stride(1)],
+        block_shape=[kv_tma_rows, head_dim],
+    )
+    _gqa_sparse_fwd_kernel[grid](
+        q,
+        kv_cache,
+        kv_cache_desc,
+        k_scale_arg,
+        v_scale_arg,
+        topk_idx,
+        output,
+        block_table,
+        cu_seqlens_q,
+        cu_seqlens_q,
+        seq_lens,
+        prefix_lens,
+        num_kv_heads,
+        gqa_group_size,
+        head_dim,
+        topk,
+        1,  # num_q_loop
+        sm_scale,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        kv_cache.stride(0),
+        kv_cache.stride(1),
+        kv_cache.stride(2),
+        kv_cache.stride(3),
+        stride_ks_h,
+        stride_ks_t,
+        stride_vs_h,
+        stride_vs_t,
+        topk_idx.stride(0),
+        topk_idx.stride(1),
+        topk_idx.stride(2),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        block_table.stride(0),
+        BLOCK_SIZE_Q=1,
+        BLOCK_SIZE_K=SPARSE_BLOCK_SIZE,
+        USE_DIRECT=False,
+        USE_FP8=use_fp8,
+        KV_SCALE_MODE=kv_scale_mode,
+        USE_HALF_KV_PIPE=use_half_kv_pipe,
+        num_warps=4,
+        num_stages=1,
+    )
+
+
+@torch.no_grad()
+def minimax_m3_sparse_attn_decode(
+    q: torch.Tensor,  # [total_q, num_heads, head_dim]
+    kv_cache: torch.Tensor,  # [num_blocks, num_kv_heads, 128, 2*head_dim]
+    topk_idx: torch.Tensor,  # [num_kv_heads, total_q, topk]
+    block_table: torch.Tensor,  # [num_reqs, max_blocks]
+    seq_lens: torch.Tensor,  # [num_reqs] int32
+    num_kv_heads: int,
+    sm_scale: float,
+    output: torch.Tensor,  # [total_q, num_heads, head_dim]
+    decode_query_len: int,
+    k_scale: torch.Tensor | None = None,
+    v_scale: torch.Tensor | None = None,
+) -> None:
+    """GQA block-sparse attention for decode (split-K over the top-k blocks)."""
+    total_q, num_heads, head_dim = q.shape
+    assert total_q == seq_lens.shape[0] * decode_query_len
+    max_topk = topk_idx.shape[-1]
+    gqa_group_size = num_heads // num_kv_heads
+    use_fp8 = kv_cache.dtype in _FP8_DTYPES
+    (
+        k_scale_arg,
+        v_scale_arg,
+        stride_ks_h,
+        stride_ks_t,
+        stride_vs_h,
+        stride_vs_t,
+        kv_scale_mode,
+    ) = (
+        _kv_scale_args(output, num_kv_heads, k_scale, v_scale)
+        if use_fp8
+        else (
+            output,
+            output,
+            0,
+            0,
+            0,
+            0,
+            _KV_SCALE_NONE,
+        )
+    )
+    use_pdl = current_platform.is_arch_support_pdl()
+    # `launch_pdl` is a Triton runtime kwarg only some backends accept (CUDA
+    # SM9+); this ROCm Triton rejects it even when False ("Keyword argument
+    # launch_pdl was specified but unrecognised"). Only pass it when PDL is
+    # actually supported -- on ROCm use_pdl is always False, so it's omitted.
+    pdl_launch = {"launch_pdl": True} if use_pdl else {}
+    # split-K over the selected blocks; chunk count is shape-constant (cuda graph).
+    TARGET_GRID = 256
+    target = max(1, min(max_topk, TARGET_GRID // max(1, total_q * num_kv_heads)))
+    num_topk_chunks = 1 << (target.bit_length() - 1)
+    o_partial = torch.empty(
+        num_topk_chunks, total_q, num_heads, head_dim, dtype=q.dtype, device=q.device
+    )
+    lse_partial = torch.empty(
+        num_topk_chunks, total_q, num_heads, dtype=torch.float32, device=q.device
+    )
+    grid = (total_q * num_topk_chunks, num_kv_heads)
+    _gqa_sparse_decode_kernel[grid](
+        q,
+        kv_cache,
+        k_scale_arg,
+        v_scale_arg,
+        topk_idx,
+        o_partial,
+        lse_partial,
+        block_table,
+        seq_lens,
+        total_q,
+        gqa_group_size,
+        head_dim,
+        max_topk,
+        sm_scale,
+        decode_query_len,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        kv_cache.stride(0),
+        kv_cache.stride(1),
+        kv_cache.stride(2),
+        kv_cache.stride(3),
+        stride_ks_h,
+        stride_ks_t,
+        stride_vs_h,
+        stride_vs_t,
+        topk_idx.stride(0),
+        topk_idx.stride(1),
+        topk_idx.stride(2),
+        o_partial.stride(0),
+        o_partial.stride(1),
+        o_partial.stride(2),
+        o_partial.stride(3),
+        lse_partial.stride(0),
+        lse_partial.stride(1),
+        lse_partial.stride(2),
+        block_table.stride(0),
+        BLOCK_SIZE_K=SPARSE_BLOCK_SIZE // 2,
+        PAGE_SIZE=SPARSE_BLOCK_SIZE,
+        NUM_TOPK_CHUNKS=num_topk_chunks,
+        USE_FP8=use_fp8,
+        KV_SCALE_MODE=kv_scale_mode,
+        USE_PDL=use_pdl,
+        **current_platform.attention_launch_kwargs(
+            num_stages=1, scenario="flashattn-fwd;unprefetch"
+        ),
+        **pdl_launch,
+    )
+    merge_grid = (total_q, num_heads)
+    _merge_topk_attn_out_kernel[merge_grid](
+        o_partial,
+        lse_partial,
+        output,
+        head_dim,
+        o_partial.stride(0),
+        o_partial.stride(1),
+        o_partial.stride(2),
+        o_partial.stride(3),
+        lse_partial.stride(0),
+        lse_partial.stride(1),
+        lse_partial.stride(2),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        NUM_TOPK_CHUNKS=num_topk_chunks,
+        USE_PDL=use_pdl,
+        **pdl_launch,
+    )

--- a/src/flaggems_vllm/runtime/backend/_metax/ops/minimax_sparse_attention/utils.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/ops/minimax_sparse_attention/utils.py
@@ -1,0 +1,178 @@
+# Copyright 2026 FlagOS Contributors
+# Copyright contributors to the vLLM project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runtime compatibility helpers for the MetaX MSA kernels."""
+
+import inspect
+import re
+from collections.abc import Callable, Iterable
+from typing import Any, TypeVar, overload
+
+import torch
+
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+def _triton_target() -> Any | None:
+    """Return Triton's active target without making platform detection fatal."""
+    try:
+        import triton
+
+        return triton.runtime.driver.active.get_current_target()
+    except Exception:
+        return None
+
+
+def _torch_device_name() -> str:
+    if not torch.cuda.is_available():
+        return ""
+    try:
+        return str(torch.cuda.get_device_name()).lower()
+    except (AssertionError, RuntimeError):
+        return ""
+
+
+class _CurrentPlatform:
+    """Small platform adapter used by the MSA Triton kernels."""
+
+    def triton_backend(self) -> str:
+        target = _triton_target()
+        return str(getattr(target, "backend", "")).lower()
+
+    def is_metax(self) -> bool:
+        """Return whether the active Triton target is MetaX/MACA.
+
+        MetaX exposes the CUDA PyTorch ABI, so ``torch.version.cuda`` and the
+        ``cuda`` device type do not distinguish it from NVIDIA. mcTriton does:
+        its active target backend is named ``maca``. The device-name fallback
+        keeps detection useful in stripped-down or pre-initialization setups.
+        """
+        backend = self.triton_backend()
+        if backend in {"maca", "metax"}:
+            return True
+        device_name = _torch_device_name()
+        return "metax" in device_name or "曦云" in device_name
+
+    def is_c550(self) -> bool:
+        if not self.is_metax():
+            return False
+        target = _triton_target()
+        arch = getattr(target, "arch", 0)
+        try:
+            if int(arch) >= 90:
+                return True
+        except (TypeError, ValueError):
+            pass
+        return "c550" in _torch_device_name()
+
+    def is_arch_support_pdl(self) -> bool:
+        if not torch.cuda.is_available():
+            return False
+        # HIP/ROCm and MetaX mcTriton do not accept CUDA's launch_pdl runtime
+        # argument. C550 reports CUDA capability 9.0 through the compatibility
+        # ABI, so the backend check must happen before the capability check.
+        if torch.version.hip is not None:
+            return False
+        if self.is_metax():
+            return False
+        try:
+            capability = torch.cuda.get_device_capability()
+        except RuntimeError:
+            return False
+        # PDL is enabled only for CUDA devices with the required capability.
+        return capability >= (9, 0)
+
+    def attention_launch_kwargs(
+        self,
+        *,
+        num_warps: int = 4,
+        num_stages: int = 2,
+        scenario: str = "flashattn-fwd",
+    ) -> dict[str, int | str]:
+        """Return backend-safe launch options for dot-heavy attention kernels."""
+        if not self.is_metax():
+            return {}
+        # mcTriton accepts these MACAOptions at the launch site. The
+        # flash-attention scenario enables its chain-dot scheduling path.
+        return {
+            "num_warps": num_warps,
+            "num_stages": num_stages,
+            "pipeline": "basic",
+            "scenario": scenario,
+        }
+
+
+current_platform = _CurrentPlatform()
+
+
+def round_up(n: int, d: int) -> int:
+    """Round n up to the nearest multiple of d."""
+    return (n + d - 1) // d * d
+
+
+def has_triton_tle(major: int = 0, minor: int = 0, patch: int = 0) -> bool:
+    """Return whether the installed Triton exposes the TLE language module."""
+    try:
+        import triton
+        import triton.experimental.tle.language as _tle  # noqa: F401
+    except Exception:
+        return False
+    version = str(getattr(triton, "__version__", "0.0.0"))
+    release = [int(value) for value in re.findall(r"\d+", version)[:3]]
+    release += [0] * (3 - len(release))
+    return tuple(release[:3]) >= (major, minor, patch)
+
+
+@overload
+def triton_jit(fn: _F) -> Any: ...
+
+
+@overload
+def triton_jit(
+    fn: None = None,
+    *,
+    do_not_specialize_on_alignment: Iterable[int | str] | None = None,
+    **kwargs: Any,
+) -> Callable[[_F], Any]: ...
+
+
+def triton_jit(
+    fn: _F | None = None,
+    *,
+    do_not_specialize_on_alignment: Iterable[int | str] | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Call ``triton.jit`` across upstream Triton and mcTriton 3.0.
+
+    ``do_not_specialize_on_alignment`` was added after the Triton version used
+    by the C550 FlagOS image. On older releases, mapping those arguments to
+    ``do_not_specialize`` also removes the pointer-alignment cache key and is a
+    conservative compatibility fallback.
+    """
+    import triton
+
+    alignment_args = tuple(do_not_specialize_on_alignment or ())
+    if alignment_args:
+        jit_params = inspect.signature(triton.jit).parameters
+        if "do_not_specialize_on_alignment" in jit_params:
+            kwargs["do_not_specialize_on_alignment"] = alignment_args
+        else:
+            existing = tuple(kwargs.get("do_not_specialize", ()))
+            kwargs["do_not_specialize"] = tuple(dict.fromkeys(existing + alignment_args))
+
+    if fn is not None:
+        return triton.jit(fn, **kwargs)
+    return triton.jit(**kwargs)

--- a/tests/test_minimax_m3_sparse_attention.py
+++ b/tests/test_minimax_m3_sparse_attention.py
@@ -1,0 +1,393 @@
+# Copyright 2026 FlagOS Contributors
+# Copyright contributors to the vLLM project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Correctness tests for the MetaX MiniMax M3 sparse-attention kernels."""
+
+import pytest
+import torch
+
+import flaggems_vllm
+from flaggems_vllm.runtime.backend._metax.ops.minimax_sparse_attention import (
+    SPARSE_BLOCK_SIZE,
+    minimax_m3_index_decode,
+    minimax_m3_index_score,
+    minimax_m3_index_topk,
+    minimax_m3_sparse_attn,
+    minimax_m3_sparse_attn_decode,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    flaggems_vllm.vendor_name != "metax",
+    reason="MiniMax M3 specialization requires MetaX",
+)
+
+DEVICE = flaggems_vllm.device
+HEAD_DIM = 128
+
+
+def _assert_topk_equal_unordered(actual, expected):
+    assert actual.shape == expected.shape
+    actual_rows = actual.cpu().reshape(-1, actual.shape[-1]).tolist()
+    expected_rows = expected.cpu().reshape(-1, expected.shape[-1]).tolist()
+    for actual_row, expected_row in zip(actual_rows, expected_rows):
+        assert set(actual_row) == set(expected_row)
+
+
+def _reference_index_topk(
+    idx_q,
+    index_kv_cache,
+    block_table,
+    q_lens,
+    seq_lens,
+    prefix_lens,
+    topk,
+    init_blocks,
+    local_blocks,
+):
+    total_q, num_idx_heads, _ = idx_q.shape
+    out = torch.full(
+        (num_idx_heads, total_q, topk),
+        -1,
+        device=idx_q.device,
+        dtype=torch.int32,
+    )
+    q_start = 0
+    for req_id, (q_len, seq_len, prefix_len) in enumerate(
+        zip(q_lens.tolist(), seq_lens.tolist(), prefix_lens.tolist())
+    ):
+        q = idx_q[q_start : q_start + q_len]
+        num_blocks = (seq_len + SPARSE_BLOCK_SIZE - 1) // SPARSE_BLOCK_SIZE
+        pages = block_table[req_id, :num_blocks]
+        k = index_kv_cache[pages].reshape(num_blocks * SPARSE_BLOCK_SIZE, -1)
+        score = torch.einsum("qhd,kd->hqk", q.float(), k.float())
+
+        q_pos = prefix_len + torch.arange(q_len, device=idx_q.device)
+        k_pos = torch.arange(k.shape[0], device=idx_q.device)
+        score.masked_fill_(k_pos[None, :] > q_pos[:, None], -float("inf"))
+        score = score.reshape(
+            num_idx_heads, q_len, num_blocks, SPARSE_BLOCK_SIZE
+        ).max(dim=3).values
+
+        valid_blocks = (q_pos + SPARSE_BLOCK_SIZE) // SPARSE_BLOCK_SIZE
+        for local_q, num_valid in enumerate(valid_blocks.tolist()):
+            score[:, local_q, : min(init_blocks, num_valid)] = 1e30
+            local_start = max(0, num_valid - local_blocks)
+            score[:, local_q, local_start:num_valid] = 1e29
+            selected = min(topk, num_valid)
+            out[:, q_start + local_q, :selected] = score[
+                :, local_q, :num_valid
+            ].topk(selected, dim=1).indices
+        q_start += q_len
+    return out
+
+
+def _reference_sparse_attention(
+    q,
+    kv_cache,
+    topk_idx,
+    block_table,
+    q_lens,
+    seq_lens,
+    prefix_lens,
+    num_kv_heads,
+    sm_scale,
+):
+    total_q, num_heads, head_dim = q.shape
+    group_size = num_heads // num_kv_heads
+    out = torch.empty_like(q)
+    token_start = 0
+
+    for req_id, (q_len, seq_len, prefix_len) in enumerate(
+        zip(q_lens.tolist(), seq_lens.tolist(), prefix_lens.tolist())
+    ):
+        for local_q in range(q_len):
+            token = token_start + local_q
+            query_position = prefix_len + local_q
+            for kv_head in range(num_kv_heads):
+                logical_blocks = topk_idx[kv_head, token]
+                logical_blocks = logical_blocks[logical_blocks >= 0].long()
+                keys = []
+                values = []
+                for logical_block in logical_blocks.tolist():
+                    physical_page = int(block_table[req_id, logical_block])
+                    block_start = logical_block * SPARSE_BLOCK_SIZE
+                    valid_tokens = min(
+                        SPARSE_BLOCK_SIZE,
+                        seq_len - block_start,
+                        query_position - block_start + 1,
+                    )
+                    if valid_tokens <= 0:
+                        continue
+                    page = kv_cache[physical_page, kv_head, :valid_tokens]
+                    keys.append(page[:, :head_dim])
+                    values.append(page[:, head_dim:])
+
+                k = torch.cat(keys, dim=0).float()
+                v = torch.cat(values, dim=0).float()
+                head_start = kv_head * group_size
+                head_end = head_start + group_size
+                query = q[token, head_start:head_end].float()
+                scores = torch.einsum("hd,kd->hk", query, k) * sm_scale
+                probs = torch.softmax(scores, dim=-1)
+                out[token, head_start:head_end] = torch.einsum(
+                    "hk,kd->hd", probs, v
+                ).to(q.dtype)
+        token_start += q_len
+    assert token_start == total_q
+    return out
+
+
+def _make_block_table(batch, max_blocks):
+    pages = torch.randperm(batch * max_blocks, device=DEVICE, dtype=torch.int32)
+    return pages.reshape(batch, max_blocks)
+
+
+def test_public_exports_use_metax_implementation():
+    assert flaggems_vllm.minimax_m3_index_decode is minimax_m3_index_decode
+    assert flaggems_vllm.minimax_m3_sparse_attn is minimax_m3_sparse_attn
+
+
+@torch.inference_mode()
+def test_minimax_m3_prefill_index_topk_matches_reference():
+    torch.manual_seed(0)
+    q_lens = torch.tensor([4, 3], device=DEVICE, dtype=torch.int32)
+    prefix_lens = torch.tensor([0, 1024], device=DEVICE, dtype=torch.int32)
+    seq_lens = prefix_lens + q_lens
+    max_query_len = int(q_lens.max())
+    max_seq_len = int(seq_lens.max())
+    batch = q_lens.numel()
+    max_blocks = (max_seq_len + SPARSE_BLOCK_SIZE - 1) // SPARSE_BLOCK_SIZE
+    block_table = _make_block_table(batch, max_blocks)
+
+    cu_seqlens = torch.zeros(batch + 1, device=DEVICE, dtype=torch.int32)
+    cu_seqlens[1:] = q_lens.cumsum(0)
+    idx_q = torch.ones(
+        int(q_lens.sum()), 2, HEAD_DIM, device=DEVICE, dtype=torch.bfloat16
+    )
+    index_kv_cache = torch.empty(
+        batch * max_blocks,
+        SPARSE_BLOCK_SIZE,
+        HEAD_DIM,
+        device=DEVICE,
+        dtype=torch.bfloat16,
+    )
+    for req_id in range(batch):
+        for logical_block in range(max_blocks):
+            page = block_table[req_id, logical_block]
+            index_kv_cache[page].fill_(logical_block + 1)
+
+    score = minimax_m3_index_score(
+        idx_q,
+        index_kv_cache,
+        block_table,
+        cu_seqlens,
+        seq_lens,
+        prefix_lens,
+        max_query_len,
+        max_seq_len,
+        num_kv_heads=2,
+    )
+    actual = minimax_m3_index_topk(
+        score,
+        cu_seqlens,
+        prefix_lens,
+        max_query_len,
+        topk=6,
+        init_blocks=0,
+        local_blocks=1,
+    )
+    expected = _reference_index_topk(
+        idx_q,
+        index_kv_cache,
+        block_table,
+        q_lens,
+        seq_lens,
+        prefix_lens,
+        topk=6,
+        init_blocks=0,
+        local_blocks=1,
+    )
+    _assert_topk_equal_unordered(actual, expected)
+
+
+@torch.inference_mode()
+def test_minimax_m3_decode_index_topk_matches_reference():
+    torch.manual_seed(1)
+    seq_lens = torch.tensor([1024, 1536, 2048], device=DEVICE, dtype=torch.int32)
+    q_lens = torch.ones_like(seq_lens)
+    prefix_lens = seq_lens - 1
+    max_seq_len = int(seq_lens.max())
+    batch = seq_lens.numel()
+    max_blocks = (max_seq_len + SPARSE_BLOCK_SIZE - 1) // SPARSE_BLOCK_SIZE
+    block_table = _make_block_table(batch, max_blocks)
+    idx_q = torch.ones(
+        batch, 1, HEAD_DIM, device=DEVICE, dtype=torch.bfloat16
+    )
+    index_kv_cache = torch.empty(
+        batch * max_blocks,
+        SPARSE_BLOCK_SIZE,
+        HEAD_DIM,
+        device=DEVICE,
+        dtype=torch.bfloat16,
+    )
+    for req_id in range(batch):
+        for logical_block in range(max_blocks):
+            page = block_table[req_id, logical_block]
+            index_kv_cache[page].fill_(logical_block + 1)
+
+    actual = minimax_m3_index_decode(
+        idx_q,
+        index_kv_cache,
+        block_table,
+        seq_lens,
+        max_seq_len,
+        topk=4,
+        init_blocks=1,
+        local_blocks=1,
+        num_kv_heads=1,
+        decode_query_len=1,
+        max_decode_query_len=1,
+    )
+    expected = _reference_index_topk(
+        idx_q,
+        index_kv_cache,
+        block_table,
+        q_lens,
+        seq_lens,
+        prefix_lens,
+        topk=4,
+        init_blocks=1,
+        local_blocks=1,
+    )
+    _assert_topk_equal_unordered(actual, expected)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@torch.inference_mode()
+def test_minimax_m3_sparse_prefill_matches_reference(dtype):
+    torch.manual_seed(2)
+    q_lens = torch.tensor([3, 2], device=DEVICE, dtype=torch.int32)
+    prefix_lens = torch.tensor([256, 128], device=DEVICE, dtype=torch.int32)
+    seq_lens = prefix_lens + q_lens
+    batch = q_lens.numel()
+    max_blocks = 3
+    block_table = _make_block_table(batch, max_blocks)
+    cu_seqlens = torch.zeros(batch + 1, device=DEVICE, dtype=torch.int32)
+    cu_seqlens[1:] = q_lens.cumsum(0)
+
+    num_kv_heads = 1
+    num_heads = 8
+    q = torch.randn(
+        int(q_lens.sum()), num_heads, HEAD_DIM, device=DEVICE, dtype=dtype
+    ) * 0.1
+    kv_cache = torch.randn(
+        batch * max_blocks,
+        num_kv_heads,
+        SPARSE_BLOCK_SIZE,
+        2 * HEAD_DIM,
+        device=DEVICE,
+        dtype=dtype,
+    ) * 0.1
+    topk_idx = torch.empty(
+        num_kv_heads, int(q_lens.sum()), 2, device=DEVICE, dtype=torch.int32
+    )
+    topk_idx[:, :3] = torch.tensor([1, 2], device=DEVICE, dtype=torch.int32)
+    topk_idx[:, 3:] = torch.tensor([0, 1], device=DEVICE, dtype=torch.int32)
+    output = torch.empty_like(q)
+    scale = HEAD_DIM**-0.5
+
+    minimax_m3_sparse_attn(
+        q,
+        kv_cache,
+        topk_idx,
+        block_table,
+        cu_seqlens,
+        seq_lens,
+        prefix_lens,
+        max_query_len=int(q_lens.max()),
+        num_kv_heads=num_kv_heads,
+        sm_scale=scale,
+        output=output,
+    )
+    expected = _reference_sparse_attention(
+        q,
+        kv_cache,
+        topk_idx,
+        block_table,
+        q_lens,
+        seq_lens,
+        prefix_lens,
+        num_kv_heads,
+        scale,
+    )
+    torch.testing.assert_close(output, expected, rtol=3e-2, atol=3e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@torch.inference_mode()
+def test_minimax_m3_sparse_decode_matches_reference(dtype):
+    torch.manual_seed(3)
+    seq_lens = torch.tensor([129, 257, 385, 513], device=DEVICE, dtype=torch.int32)
+    q_lens = torch.ones_like(seq_lens)
+    prefix_lens = seq_lens - 1
+    batch = seq_lens.numel()
+    max_blocks = 5
+    block_table = _make_block_table(batch, max_blocks)
+    num_kv_heads = 1
+    num_heads = 8
+    q = torch.randn(batch, num_heads, HEAD_DIM, device=DEVICE, dtype=dtype) * 0.1
+    kv_cache = torch.randn(
+        batch * max_blocks,
+        num_kv_heads,
+        SPARSE_BLOCK_SIZE,
+        2 * HEAD_DIM,
+        device=DEVICE,
+        dtype=dtype,
+    ) * 0.1
+    topk_idx = torch.empty(
+        num_kv_heads, batch, 2, device=DEVICE, dtype=torch.int32
+    )
+    for req_id, seq_len in enumerate(seq_lens.tolist()):
+        visible = (seq_len + SPARSE_BLOCK_SIZE - 1) // SPARSE_BLOCK_SIZE
+        topk_idx[0, req_id] = torch.tensor(
+            [max(0, visible - 2), visible - 1], device=DEVICE, dtype=torch.int32
+        )
+    output = torch.empty_like(q)
+    scale = HEAD_DIM**-0.5
+
+    minimax_m3_sparse_attn_decode(
+        q,
+        kv_cache,
+        topk_idx,
+        block_table,
+        seq_lens,
+        num_kv_heads,
+        scale,
+        output,
+        decode_query_len=1,
+    )
+    expected = _reference_sparse_attention(
+        q,
+        kv_cache,
+        topk_idx,
+        block_table,
+        q_lens,
+        seq_lens,
+        prefix_lens,
+        num_kv_heads,
+        scale,
+    )
+    torch.testing.assert_close(output, expected, rtol=3e-2, atol=3e-2)

--- a/tools/select_tests.py
+++ b/tools/select_tests.py
@@ -116,6 +116,18 @@ EXPLICIT_SOURCE_TO_TESTS = {
     "src/flaggems_vllm/runtime/backend/_metax/fused/fused_moe.py": [
         "tests/test_fused_experts_impl.py",
     ],
+    "src/flaggems_vllm/runtime/backend/_metax/ops/minimax_sparse_attention/__init__.py": [
+        "tests/test_minimax_m3_sparse_attention.py",
+    ],
+    "src/flaggems_vllm/runtime/backend/_metax/ops/minimax_sparse_attention/index_topk.py": [
+        "tests/test_minimax_m3_sparse_attention.py",
+    ],
+    "src/flaggems_vllm/runtime/backend/_metax/ops/minimax_sparse_attention/sparse_attn.py": [
+        "tests/test_minimax_m3_sparse_attention.py",
+    ],
+    "src/flaggems_vllm/runtime/backend/_metax/ops/minimax_sparse_attention/utils.py": [
+        "tests/test_minimax_m3_sparse_attention.py",
+    ],
 }
 
 # Same for benchmarks: keep explicit entries only for non-standard names that cannot be inferred from the source stem.
@@ -168,6 +180,18 @@ EXPLICIT_SOURCE_TO_BENCHMARKS = {
     ],
     "src/flaggems_vllm/runtime/backend/_metax/fused/fused_moe.py": [
         "benchmark/test_fused_moe.py",
+    ],
+    "src/flaggems_vllm/runtime/backend/_metax/ops/minimax_sparse_attention/__init__.py": [
+        "benchmark/test_minimax_m3_sparse_attention.py",
+    ],
+    "src/flaggems_vllm/runtime/backend/_metax/ops/minimax_sparse_attention/index_topk.py": [
+        "benchmark/test_minimax_m3_sparse_attention.py",
+    ],
+    "src/flaggems_vllm/runtime/backend/_metax/ops/minimax_sparse_attention/sparse_attn.py": [
+        "benchmark/test_minimax_m3_sparse_attention.py",
+    ],
+    "src/flaggems_vllm/runtime/backend/_metax/ops/minimax_sparse_attention/utils.py": [
+        "benchmark/test_minimax_m3_sparse_attention.py",
     ],
 }
 


### PR DESCRIPTION
### PR Category

Operator / OP Test / Benchmark

### Type of Change

New Feature / Performance Optimization

### Description

- Add MetaX C550 kernels for the MiniMax M3 sparse-attention pipeline.
- Add index scoring and block top-k selection for prefill and decode.
- Add sparse-attention prefill and decode kernels for FP16 and BF16.
- Export the six MiniMax M3 entry points through the MetaX backend.
- Add MetaX correctness tests, benchmark coverage, and explicit CI test/benchmark mappings.
- Add a small `triton_jit` compatibility wrapper for upstream Triton and the mcTriton version used by C550.

The production path uses Triton/TLE kernels. PyTorch is used only for tensor allocation, metadata inspection, and the test/benchmark reference implementations; there is no PyTorch compute fallback in the production kernels.

### Supported configurations

- Device: MetaX C550
- Query/KV dtype: `torch.float16` and `torch.bfloat16`
- Index dtype: `torch.int32`
- Sparse block size: 128 tokens
- Prefill and single-token decode paths
- Grouped-query attention through configurable KV-head counts

### Issue

N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Correctness

Command:

```bash
python -m pytest tests/test_minimax_m3_sparse_attention.py -v
```

Result:

```text
7 passed
```

The result was revalidated after rebasing the branch onto the latest upstream `main`. The C550 FlagTree environment used `adjust_block_size=False` for its optional autotuning block-size adjustment.

The tests cover:

- MetaX public-export routing
- Prefill index scoring and top-k selection
- Decode index scoring and top-k selection
- Sparse-attention prefill in FP16 and BF16
- Sparse-attention decode in FP16 and BF16

### Performance

Environment:

- Device: MetaX C550
- Mode: kernel
- Benchmark level: comprehensive
- Unit: milliseconds; lower is better
- Baseline: correctness-oriented PyTorch reference implementation

| Shape `(B, SEQ_LEN, TOPK, H, D)` | Torch FP16 (ms) | MetaX FP16 (ms) | FP16 speedup | Torch BF16 (ms) | MetaX BF16 (ms) | BF16 speedup |
|---|---:|---:|---:|---:|---:|---:|
| `(1, 4096, 16, 32, 128)` | 0.189696 | 0.049920 | 3.800x | 0.190208 | 0.050432 | 3.772x |
| `(4, 4096, 16, 32, 128)` | 0.359936 | 0.066816 | 5.387x | 0.361216 | 0.066304 | 5.448x |
| `(8, 8192, 32, 32, 128)` | 0.666624 | 0.179456 | 3.715x | 0.664960 | 0.172544 | 3.854x |
| `(16, 16384, 64, 32, 128)` | 1.533952 | 0.593152 | 2.586x | 1.536512 | 0.565760 | 2.716x |
| `(32, 32768, 64, 32, 128)` | 2.310528 | 1.145088 | 2.018x | 2.309888 | 1.091712 | 2.116x |
| **Geometric mean** | — | — | **3.309x** | — | — | **3.401x** |

The combined geometric-mean speedup across both dtypes is **3.355x**. These speedups are measured against the benchmark's PyTorch reference implementation, not another optimized accelerator kernel.