### PR TITLE
[KMCompiler][Mthreads]top_k_per_row_prefill&top_k_per_row_decode: adopt FlagGems' suite, fix two vendor-blocking defects, add an MTT prefill override

### DIFF
--- a/benchmark/test_top_k_per_row_decode.py
+++ b/benchmark/test_top_k_per_row_decode.py
@@ -19,92 +19,83 @@ The baseline uses vLLM's CUDA kernel when available,
 falling back to a pure-PyTorch reference (torch.topk).
 """
 
-import inspect
-
 import pytest
 import torch
-import triton.language as tl
 
-from flaggems_vllm.ops import top_k_per_row_decode
+import flaggems_vllm
 
 from . import base
 
 
-def _has_histogram_mask():
-    if not hasattr(tl, "histogram"):
-        return False
-    try:
-        return "mask" in inspect.signature(tl.histogram).parameters
-    except (ValueError, TypeError):
-        return False
-
-
 pytestmark = pytest.mark.skipif(
-    not _has_histogram_mask(),
-    reason="tl.histogram with mask parameter not available",
+    not flaggems_vllm.runtime.torch_device_fn.is_available(),
+    reason="accelerator device required",
 )
 
 # --- vLLM CUDA baseline (preferred) with PyTorch fallback ---
 try:
     import vllm._custom_ops  # noqa: F401 — loads torch.ops._C
 
+    # Importing vLLM is NOT proof the op exists: a non-CUDA build (e.g. MUSA)
+    # imports fine but exposes no top_k_per_row_decode, and HAS_VLLM would
+    # then be a lie -- the benchmark would report a SpeedUp against a baseline
+    # that does not exist. Check for the symbol itself, after the import.
+    if not hasattr(torch.ops._C, "top_k_per_row_decode"):
+        raise AttributeError("vLLM build exposes no top_k_per_row_decode")
+
     def _vllm_top_k_per_row_decode(
         logits, next_n, seq_lens, indices, num_rows, stride0, stride1, top_k
     ):
         torch.ops._C.top_k_per_row_decode(
-            logits,
-            next_n,
-            seq_lens,
-            indices,
-            num_rows,
-            stride0,
-            stride1,
-            top_k,
+            logits, next_n, seq_lens, indices, num_rows, stride0, stride1, top_k
         )
 
     HAS_VLLM = True
-except (ImportError, AttributeError):
+except (ImportError, AttributeError, RuntimeError):
+    # RuntimeError because a misconfigured vLLM should mean "no baseline", not a
+    # collection error: with two platform plugins registered it raises
+    # "Only one platform plugin can be activated" at import, which aborted
+    # collection of this whole file on an MTT box.
     HAS_VLLM = False
     _vllm_top_k_per_row_decode = None
 
 
-def _torch_topk_ref(
-    logits, next_n, seq_lens, indices, num_rows, stride0, stride1, top_k
-):
-    """Pure-PyTorch fallback reference using torch.topk."""
-    seq_len = seq_lens[0].item()
-    valid_logits = logits[:, :seq_len]
-    _, top_idx = torch.topk(valid_logits, top_k, dim=1, largest=True, sorted=False)
-    indices.copy_(top_idx.to(torch.int32))
-
-
-_baseline_op = _vllm_top_k_per_row_decode if HAS_VLLM else _torch_topk_ref
-
-
 class TopKPerRowDecodeBenchmark(base.Benchmark):
-    DEFAULT_SHAPE_DESC = "vocab_size, top_k"
+    DEFAULT_SHAPE_DESC = "num_rows, vocab_size, next_n, top_k, stride0, stride1"
 
     def set_shapes(self, shape_file_path=None):
         self.shapes = [
-            (129280, 1024),
-            (32768, 512),
-            (16384, 256),
-            (8192, 128),
-            (4096, 64),
+            # DeepSeek-V4-Flash
+            (1, 262144, 1, 512, 262144, 1),
+            (496, 262144, 1, 512, 262144, 1),
+            (512, 262144, 1, 512, 262144, 1),
+            (16, 262144, 1, 512, 262144, 1),
+            (32, 262144, 1, 512, 262144, 1),
+            (48, 262144, 1, 512, 262144, 1),
+            (40, 262144, 1, 512, 262144, 1),
+            (56, 262144, 1, 512, 262144, 1),
+            (4, 262144, 1, 512, 262144, 1),
+            (8, 262144, 1, 512, 262144, 1),
+            (24, 262144, 1, 512, 262144, 1),
         ]
 
     def get_input_iter(self, dtype):
-        for vocab_size, top_k in self.shapes:
+        for num_rows, vocab_size, next_n, top_k, stride0, stride1 in self.shapes:
             torch.manual_seed(42)
-            logits = torch.randn(
-                (1, vocab_size), dtype=torch.float32, device=self.device
+            buf = torch.randn(
+                (num_rows - 1) * stride0 + (vocab_size - 1) * stride1 + 1,
+                device=self.device,
+                dtype=torch.float32,
             )
-            seq_lens = torch.tensor([vocab_size], dtype=torch.int32, device=self.device)
-            indices = torch.zeros((1, top_k), dtype=torch.int32, device=self.device)
-            num_rows = 1
-            next_n = 1
-            stride0 = logits.stride(0)
-            stride1 = logits.stride(1)
+            logits = torch.as_strided(buf, (num_rows, vocab_size), (stride0, stride1))
+
+            batch_size = num_rows // next_n
+            seq_lens = torch.full(
+                (batch_size,), vocab_size, dtype=torch.int32, device=self.device
+            )
+            indices = torch.zeros(
+                (num_rows, top_k), dtype=torch.int32, device=self.device
+            )
 
             yield (
                 logits,
@@ -119,11 +110,12 @@ class TopKPerRowDecodeBenchmark(base.Benchmark):
 
 
 @pytest.mark.top_k_per_row_decode
+@pytest.mark.skipif(not HAS_VLLM, reason="vLLM not installed")
 def test_top_k_per_row_decode():
     bench = TopKPerRowDecodeBenchmark(
         op_name="top_k_per_row_decode",
-        torch_op=_baseline_op,
-        gems_op=top_k_per_row_decode,
+        torch_op=_vllm_top_k_per_row_decode,
+        gems_op=flaggems_vllm.top_k_per_row_decode,
         dtypes=[torch.float32],
     )
     bench.run()

--- a/benchmark/test_top_k_per_row_decode.py
+++ b/benchmark/test_top_k_per_row_decode.py
@@ -15,8 +15,8 @@
 """Benchmark for top_k_per_row_decode (DeepSeek V4 decode-phase top-K).
 
 Shapes match DeepSeek V4 production config (vocab=129280, top_k=1024).
-The baseline uses vLLM's CUDA kernel when available,
-falling back to a pure-PyTorch reference (torch.topk).
+The baseline is vLLM's own top_k_per_row_decode op, falling back to a
+pure-PyTorch reference (torch.topk) when that op is absent.
 """
 
 import pytest
@@ -32,14 +32,17 @@ pytestmark = pytest.mark.skipif(
     reason="accelerator device required",
 )
 
-# --- vLLM CUDA baseline (preferred) with PyTorch fallback ---
+# --- vLLM's own kernel as the baseline, non-TLE Triton path as fallback ---
 try:
     import vllm._custom_ops  # noqa: F401 — loads torch.ops._C
 
-    # Importing vLLM is NOT proof the op exists: a non-CUDA build (e.g. MUSA)
-    # imports fine but exposes no top_k_per_row_decode, and HAS_VLLM would
-    # then be a lie -- the benchmark would report a SpeedUp against a baseline
-    # that does not exist. Check for the symbol itself, after the import.
+    # Importing vLLM is NOT proof the op exists. A build can import fine and
+    # still expose no top_k_per_row_decode -- and the vendor of the build is not
+    # the test: the MUSA build on the Moore Threads box DOES export it, while
+    # some others do not. HAS_VLLM would then be a lie and the benchmark would
+    # report a SpeedUp against a baseline that is not there. Check the symbol
+    # itself, after the import, with hasattr -- never dir(), since
+    # torch.ops._C is a lazy namespace that lists only what it has resolved.
     if not hasattr(torch.ops._C, "top_k_per_row_decode"):
         raise AttributeError("vLLM build exposes no top_k_per_row_decode")
 

--- a/benchmark/test_top_k_per_row_prefill.py
+++ b/benchmark/test_top_k_per_row_prefill.py
@@ -17,79 +17,147 @@
 Shapes match DeepSeek V4 production config:
     - vocab_size=129280: DeepSeek V4 vocabulary size (full BPE vocab)
     - top_k=1024: number of KV cache slots selected per token in sparse attention
-    - num_rows=1: single-token decode (latency-critical path)
+    - num_rows=1: single-token prefill/decode-like latency-sensitive path
     - num_rows=32: typical prefill micro-batch
     - num_rows=64: larger prefill batch
     - num_rows=2048: max prefill sequence length
 
-The torch reference uses torch.topk directly (no masking), representing the
-theoretical minimum for selection-only. The Triton kernel additionally handles
-masking and index adjustment.
+The baseline uses vLLM's persistent_topk CUDA kernel when available,
+falling back to FlagGems' non-TLE implementation so the benchmark can run
+in plain Triton-TLE development environments.
 """
+
+from importlib import import_module
 
 import pytest
 import torch
 
 import flaggems_vllm
-from flaggems_vllm.ops import top_k_per_row_prefill
 
 from . import base
 
 device = flaggems_vllm.device
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(),
-    reason="CUDA device required",
+    not flaggems_vllm.runtime.torch_device_fn.is_available(),
+    reason="accelerator device required",
 )
+
+# --- vLLM CUDA baseline (preferred) with PyTorch fallback ---
+try:
+    import vllm._custom_ops  # noqa: F401 — loads torch.ops._C
+
+    # Importing vLLM is NOT proof the op exists: a non-CUDA build (e.g. MUSA)
+    # imports fine but exposes no top_k_per_row_prefill, and HAS_VLLM would
+    # then be a lie -- the benchmark would report a SpeedUp against a baseline
+    # that does not exist. Check for the symbol itself, after the import.
+    if not hasattr(torch.ops._C, "top_k_per_row_prefill"):
+        raise AttributeError("vLLM build exposes no top_k_per_row_prefill")
+
+    def _vllm_top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+    ):
+        torch.ops._C.top_k_per_row_prefill(
+            logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+        )
+
+    HAS_VLLM = True
+except (ImportError, AttributeError, RuntimeError):
+    # RuntimeError because a misconfigured vLLM should mean "no baseline", not a
+    # collection error: with two platform plugins registered it raises
+    # "Only one platform plugin can be activated" at import, which aborted
+    # collection of this whole file on an MTT box.
+    HAS_VLLM = False
+    _vllm_top_k_per_row_prefill = None
+
+
+_top_k_per_row_prefill_module = import_module("flaggems_vllm.ops.top_k_per_row_prefill")
+
+
+def _non_tle_top_k_per_row_prefill(
+    logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+):
+    device = logits.device
+    s_histogram_ptr = torch.empty(
+        (num_rows, _top_k_per_row_prefill_module.NUM_BINS),
+        device=device,
+        dtype=torch.int32,
+    )
+    s_final_logits_ptr = torch.empty(
+        (num_rows, _top_k_per_row_prefill_module.NUM_FILNAL_ITEMS),
+        device=device,
+        dtype=torch.float32,
+    )
+    s_final_cnt_ptr = torch.empty((num_rows,), device=device, dtype=torch.int32)
+    s_threshold_bin_idx_ptr = torch.empty((num_rows,), device=device, dtype=torch.int32)
+    s_final_bin_size_ptr = torch.empty((num_rows,), device=device, dtype=torch.int32)
+    s_found_topk_values_ptr = torch.empty((num_rows,), device=device, dtype=torch.int32)
+    block_size = _top_k_per_row_prefill_module.NUM_THREADS_PER_BLOCK
+
+    _top_k_per_row_prefill_module.non_tle_top_k_per_row_prefill[(num_rows,)](
+        logits,
+        indices,
+        row_starts,
+        row_ends,
+        stride0,
+        stride1,
+        logits.shape[1],
+        s_histogram_ptr,
+        s_final_logits_ptr,
+        s_final_cnt_ptr,
+        s_threshold_bin_idx_ptr,
+        s_final_bin_size_ptr,
+        s_found_topk_values_ptr,
+        TOPK=top_k,
+        BLOCK_SIZE=block_size,
+        ROW_OFFSET=0,
+        num_warps=block_size // 32,
+    )
 
 
 class TopKPerRowPrefillBenchmark(base.Benchmark):
-    DEFAULT_SHAPE_DESC = "num_rows, vocab_size, top_k"
+    DEFAULT_SHAPE_DESC = "num_rows, vocab_size, top_k, stride0, stride1"
 
     def set_shapes(self, shape_file_path=None):
-        # DeepSeek V4 production shapes:
-        # - (1, 129280, 1024): decode path, single token, latency-critical
-        # - (32, 129280, 1024): typical prefill micro-batch
-        # - (64, 129280, 1024): larger prefill batch
-        # - (2048, 129280, 1024): max sequence length prefill
         self.shapes = [
-            (1, 129280, 1024),
-            (32, 129280, 1024),
-            (64, 129280, 1024),
-            (2048, 129280, 1024),
+            # DeepSeek V4 full vocabulary
+            (64, 129280, 1024, 129280, 1),
+            # DeepSeek-V4-Flash
+            (4, 8193, 512, 8456, 1),
+            (16383, 4095, 512, 4352, 1),
+            (4, 16385, 512, 16648, 1),
+            (12961, 4100, 512, 4360, 1),
+            (16380, 5115, 512, 5376, 1),
+            (4100, 1025, 512, 1288, 1),
         ]
 
     def get_input_iter(self, dtype):
-        for num_rows, vocab_size, top_k in self.shapes:
-            logits = torch.randn(
-                num_rows, vocab_size, device=device, dtype=torch.float32
+        for num_rows, vocab_size, top_k, stride0, stride1 in self.shapes:
+            torch.manual_seed(42)
+            buf = torch.randn(
+                (num_rows - 1) * stride0 + (vocab_size - 1) * stride1 + 1,
+                device=device,
+                dtype=torch.float32,
             )
-            # Full vocab range: row_starts=0, row_ends=vocab_size (common case)
+            logits = torch.as_strided(buf, (num_rows, vocab_size), (stride0, stride1))
             row_starts = torch.zeros(num_rows, dtype=torch.int32, device=device)
             row_ends = torch.full(
                 (num_rows,), vocab_size, dtype=torch.int32, device=device
             )
-            # Pre-allocated output buffer (matches vLLM calling convention)
             indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
-            stride0 = logits.stride(0)  # = vocab_size for contiguous
-            stride1 = logits.stride(1)  # = 1 for contiguous
 
             yield logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
 
 
-def _torch_topk_ref(
-    logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
-):
-    _, top_idx = torch.topk(logits, top_k, dim=1, largest=True, sorted=False)
-    indices.copy_(top_idx.to(torch.int32))
-
-
 @pytest.mark.top_k_per_row_prefill
 def test_top_k_per_row_prefill():
+    baseline_op = (
+        _vllm_top_k_per_row_prefill if HAS_VLLM else _non_tle_top_k_per_row_prefill
+    )
     bench = TopKPerRowPrefillBenchmark(
         op_name="top_k_per_row_prefill",
-        torch_op=_torch_topk_ref,
-        gems_op=top_k_per_row_prefill,
+        torch_op=baseline_op,
+        gems_op=flaggems_vllm.top_k_per_row_prefill,
         dtypes=[torch.float32],
     )
     bench.run()

--- a/benchmark/test_top_k_per_row_prefill.py
+++ b/benchmark/test_top_k_per_row_prefill.py
@@ -22,9 +22,10 @@ Shapes match DeepSeek V4 production config:
     - num_rows=64: larger prefill batch
     - num_rows=2048: max prefill sequence length
 
-The baseline uses vLLM's persistent_topk CUDA kernel when available,
-falling back to FlagGems' non-TLE implementation so the benchmark can run
-in plain Triton-TLE development environments.
+The baseline is vLLM's own top_k_per_row_prefill op. Without it the
+benchmark falls back to FlagGems' non-TLE implementation -- i.e. it would
+compare FlagGems against FlagGems -- so HAS_VLLM below is checked on the
+symbol, not assumed from the import.
 """
 
 from importlib import import_module
@@ -43,14 +44,17 @@ pytestmark = pytest.mark.skipif(
     reason="accelerator device required",
 )
 
-# --- vLLM CUDA baseline (preferred) with PyTorch fallback ---
+# --- vLLM's own kernel as the baseline, non-TLE Triton path as fallback ---
 try:
     import vllm._custom_ops  # noqa: F401 — loads torch.ops._C
 
-    # Importing vLLM is NOT proof the op exists: a non-CUDA build (e.g. MUSA)
-    # imports fine but exposes no top_k_per_row_prefill, and HAS_VLLM would
-    # then be a lie -- the benchmark would report a SpeedUp against a baseline
-    # that does not exist. Check for the symbol itself, after the import.
+    # Importing vLLM is NOT proof the op exists. A build can import fine and
+    # still expose no top_k_per_row_prefill -- and the vendor of the build is not
+    # the test: the MUSA build on the Moore Threads box DOES export it, while
+    # some others do not. HAS_VLLM would then be a lie and the benchmark would
+    # report a SpeedUp against a baseline that is not there. Check the symbol
+    # itself, after the import, with hasattr -- never dir(), since
+    # torch.ops._C is a lazy namespace that lists only what it has resolved.
     if not hasattr(torch.ops._C, "top_k_per_row_prefill"):
         raise AttributeError("vLLM build exposes no top_k_per_row_prefill")
 

--- a/src/flaggems_vllm/ops/top_k_per_row_decode.py
+++ b/src/flaggems_vllm/ops/top_k_per_row_decode.py
@@ -20,14 +20,84 @@ https://github.com/flagos-ai/FlagTree.git, align with vLLM implementation.
 """
 
 import logging
+import os
 
 import torch
 import triton
 import triton.language as tl
 
+from flaggems_vllm import runtime
 from flaggems_vllm.utils.triton_version_utils import has_triton_tle
 
-if has_triton_tle(3, 6, 0):
+
+
+_LAUNCH_GEOMETRY = None
+
+
+def _launch_geometry():
+    """(warp_size, max_threads_per_block) for this device, cached."""
+    global _LAUNCH_GEOMETRY
+    if _LAUNCH_GEOMETRY is None:
+        warp, maxt = 32, 1024
+        try:
+            props = runtime.torch_device_fn.get_device_properties(0)
+            warp = getattr(props, "warp_size", 0) or 32
+            maxt = getattr(props, "max_threads_per_block", 0) or 1024
+        except Exception:  # noqa: BLE001 - never let detection break dispatch
+            pass
+        _LAUNCH_GEOMETRY = (warp, maxt)
+    return _LAUNCH_GEOMETRY
+
+
+def _num_warps(block_size):
+    """Warps needed to cover a BLOCK_SIZE-wide tile, within the thread ceiling.
+
+    This used to be `block_size // 32`, which silently assumes a 32-lane warp.
+    On MetaX C550 the warp is 64 lanes and the per-block ceiling is 512 threads,
+    so BLOCK_SIZE=512 asked for 16 warps x 64 = 1024 threads and every launch
+    failed with OutOfResources -- the op could not run on that card at all.
+
+    Dividing by the real warp size is an identity on 32-lane parts (512 -> 16
+    warps either way), so NVIDIA and Moore Threads are unchanged. The clamp
+    matters where a tile is wider than the device can staff: the tile stays the
+    same width and each thread simply covers more of it.
+    """
+    warp, maxt = _launch_geometry()
+    return max(1, min(block_size // warp, maxt // warp))
+
+
+def _vendor_tle_enabled() -> bool:
+    """Does this backend actually support TLE, per its own VendorDescriptor?
+
+    `has_triton_tle()` only proves the Python module imports. It does not prove
+    the backend can LOWER tle.gpu.alloc. MetaX C550 is exactly that case: every
+    tle symbol resolves, but compilation dies with
+
+        'triton._C.libtriton.ir.builder' object has no attribute
+        'make_swizzled_shared_encoding_attr'
+
+    which took both ops from "slow" to "cannot run at all", when the non-TLE
+    fallback would have worked fine.
+
+    The VendorDescriptor already carries `tle_enabled`, and it is already correct
+    -- nvidia/mthreads/enflame declare True, everyone else defaults False. It was
+    simply never read by anything. Reading it here makes the non-TLE path the
+    default for any backend that has not declared TLE support, which is the safe
+    direction: that path is plain Triton over global scratch and works everywhere.
+
+    FLAGGEMS_FORCE_TLE=1 overrides, so a vendor can test whether its TLE works
+    without editing the descriptor.
+    """
+    override = os.environ.get("FLAGGEMS_FORCE_TLE")
+    if override is not None:
+        return override.lower() not in {"0", "false", "off", "no"}
+    try:
+        return bool(getattr(runtime.device.info, "tle_enabled", False))
+    except Exception:  # noqa: BLE001 - never let detection break the import
+        return False
+
+
+if has_triton_tle(3, 6, 0) and _vendor_tle_enabled():
     try:
         import triton.experimental.tle.language as tle
 
@@ -1258,7 +1328,7 @@ def top_k_per_row_decode(
                 MULTIPLE_BLOCKS_PER_ROW=False,
                 MULTIPLE_BLOCKS_NUM=1,
                 MERGE_BLOCKS=False,
-                num_warps=NUM_THREADS_PER_BLOCK // 32,
+                num_warps=_num_warps(NUM_THREADS_PER_BLOCK),
             )
         else:
             device = logits.device
@@ -1294,7 +1364,7 @@ def top_k_per_row_decode(
                 MULTIPLE_BLOCKS_PER_ROW=True,
                 MULTIPLE_BLOCKS_NUM=MULTIPLE_BLOCKS_PER_ROW_CONFIG,
                 MERGE_BLOCKS=False,
-                num_warps=NUM_THREADS_PER_BLOCK // 32,
+                num_warps=_num_warps(NUM_THREADS_PER_BLOCK),
             )
             tle_top_k_per_row_decode[(num_rows,)](
                 out_logits_aux,
@@ -1313,7 +1383,7 @@ def top_k_per_row_decode(
                 MULTIPLE_BLOCKS_PER_ROW=False,
                 MULTIPLE_BLOCKS_NUM=MULTIPLE_BLOCKS_PER_ROW_CONFIG,
                 MERGE_BLOCKS=True,
-                num_warps=NUM_THREADS_PER_BLOCK_MERGE // 32,
+                num_warps=_num_warps(NUM_THREADS_PER_BLOCK_MERGE),
             )
     else:
         # based on tle version
@@ -1350,5 +1420,5 @@ def top_k_per_row_decode(
             s_found_topk_values_ptr,
             TOPK=top_k,
             BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
-            num_warps=NUM_THREADS_PER_BLOCK // 32,
+            num_warps=_num_warps(NUM_THREADS_PER_BLOCK),
         )

--- a/src/flaggems_vllm/ops/top_k_per_row_prefill.py
+++ b/src/flaggems_vllm/ops/top_k_per_row_prefill.py
@@ -20,14 +20,84 @@ https://github.com/flagos-ai/FlagTree.git, align with vLLM implementation.
 """
 
 import logging
+import os
 
 import torch
 import triton
 import triton.language as tl
 
+from flaggems_vllm import runtime
+
 from flaggems_vllm.utils.triton_version_utils import has_triton_tle
 
-if has_triton_tle(3, 6, 0):
+
+_LAUNCH_GEOMETRY = None
+
+
+def _launch_geometry():
+    """(warp_size, max_threads_per_block) for this device, cached."""
+    global _LAUNCH_GEOMETRY
+    if _LAUNCH_GEOMETRY is None:
+        warp, maxt = 32, 1024
+        try:
+            props = runtime.torch_device_fn.get_device_properties(0)
+            warp = getattr(props, "warp_size", 0) or 32
+            maxt = getattr(props, "max_threads_per_block", 0) or 1024
+        except Exception:  # noqa: BLE001 - never let detection break dispatch
+            pass
+        _LAUNCH_GEOMETRY = (warp, maxt)
+    return _LAUNCH_GEOMETRY
+
+
+def _num_warps(block_size):
+    """Warps needed to cover a BLOCK_SIZE-wide tile, within the thread ceiling.
+
+    This used to be `block_size // 32`, which silently assumes a 32-lane warp.
+    On MetaX C550 the warp is 64 lanes and the per-block ceiling is 512 threads,
+    so BLOCK_SIZE=512 asked for 16 warps x 64 = 1024 threads and every launch
+    failed with OutOfResources -- the op could not run on that card at all.
+
+    Dividing by the real warp size is an identity on 32-lane parts (512 -> 16
+    warps either way), so NVIDIA and Moore Threads are unchanged. The clamp
+    matters where a tile is wider than the device can staff: the tile stays the
+    same width and each thread simply covers more of it.
+    """
+    warp, maxt = _launch_geometry()
+    return max(1, min(block_size // warp, maxt // warp))
+
+
+def _vendor_tle_enabled() -> bool:
+    """Does this backend actually support TLE, per its own VendorDescriptor?
+
+    `has_triton_tle()` only proves the Python module imports. It does not prove
+    the backend can LOWER tle.gpu.alloc. MetaX C550 is exactly that case: every
+    tle symbol resolves, but compilation dies with
+
+        'triton._C.libtriton.ir.builder' object has no attribute
+        'make_swizzled_shared_encoding_attr'
+
+    which took both ops from "slow" to "cannot run at all", when the non-TLE
+    fallback would have worked fine.
+
+    The VendorDescriptor already carries `tle_enabled`, and it is already correct
+    -- nvidia/mthreads/enflame declare True, everyone else defaults False. It was
+    simply never read by anything. Reading it here makes the non-TLE path the
+    default for any backend that has not declared TLE support, which is the safe
+    direction: that path is plain Triton over global scratch and works everywhere.
+
+    FLAGGEMS_FORCE_TLE=1 overrides, so a vendor can test whether its TLE works
+    without editing the descriptor.
+    """
+    override = os.environ.get("FLAGGEMS_FORCE_TLE")
+    if override is not None:
+        return override.lower() not in {"0", "false", "off", "no"}
+    try:
+        return bool(getattr(runtime.device.info, "tle_enabled", False))
+    except Exception:  # noqa: BLE001 - never let detection break the import
+        return False
+
+
+if has_triton_tle(3, 6, 0) and _vendor_tle_enabled():
     try:
         import triton.experimental.tle.language as tle
 
@@ -49,6 +119,8 @@ SPLIT_WORK_THRESHOLD = 200 * 1000
 NUM_THREADS_PER_BLOCK = 512
 MULTIPLE_BLOCKS_PER_ROW_CONFIG = 10
 NUM_THREADS_PER_BLOCK_MERGE = 1024
+
+
 NUM_FILNAL_ITEMS = 2048
 NUM_BINS = 2048
 RADIX_BITS_FINAL = 8
@@ -1225,7 +1297,7 @@ def top_k_per_row_prefill(
                 BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
                 USE_RADIX_FINAL=False,
                 ROW_OFFSET=0,
-                num_warps=NUM_THREADS_PER_BLOCK // 32,
+                num_warps=_num_warps(NUM_THREADS_PER_BLOCK),
             )
         if num_rows > num_insert_sort_blocks:
             num_radix_sort_blocks = num_rows - num_insert_sort_blocks
@@ -1242,7 +1314,7 @@ def top_k_per_row_prefill(
                 BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
                 USE_RADIX_FINAL=True,
                 ROW_OFFSET=num_insert_sort_blocks,
-                num_warps=NUM_THREADS_PER_BLOCK // 32,
+                num_warps=_num_warps(NUM_THREADS_PER_BLOCK),
             )
     else:
         # based on tle version
@@ -1280,5 +1352,5 @@ def top_k_per_row_prefill(
             TOPK=top_k,
             BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
             ROW_OFFSET=0,
-            num_warps=NUM_THREADS_PER_BLOCK // 32,
+            num_warps=_num_warps(NUM_THREADS_PER_BLOCK),
         )

--- a/src/flaggems_vllm/runtime/backend/_mthreads/fused/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_mthreads/fused/__init__.py
@@ -17,9 +17,13 @@ from flaggems_vllm.runtime.backend._mthreads.fused.fused_moe import (
     inplace_fused_experts,
     outplace_fused_experts,
 )
+from flaggems_vllm.runtime.backend._mthreads.fused.top_k_per_row_prefill import (
+    top_k_per_row_prefill,
+)
 
 __all__ = [
     "fused_experts_impl",
     "inplace_fused_experts",
     "outplace_fused_experts",
+    "top_k_per_row_prefill",
 ]

--- a/src/flaggems_vllm/runtime/backend/_mthreads/fused/top_k_per_row_prefill.py
+++ b/src/flaggems_vllm/runtime/backend/_mthreads/fused/top_k_per_row_prefill.py
@@ -116,8 +116,8 @@ MIN_SPAN = int(os.environ.get("FLAGGEMS_MTT_PREFILL_MIN_SPAN", "16384"))
 # retry still work in the operator's full NUM_BINS space.
 #
 # MEASURED, and coarsening loses. The threshold scan is a cumsum over this many
-# bins and a 2048-wide cumsum costs ~10 us, so narrowing it looked like the last
-# 7 us needed to reach 0.9. At (64, 129280) it is catastrophic instead:
+# bins, and narrowing it looked like a way to buy the last few us to reach 0.9.
+# At (64, 129280) it is catastrophic instead:
 #
 #     SBINS  2048 -> 0.856    512 -> 0.379    256 -> 0.368
 #
@@ -125,8 +125,15 @@ MIN_SPAN = int(os.environ.get("FLAGGEMS_MTT_PREFILL_MIN_SPAN", "16384"))
 # up to one coarse bin's population. At top_k=1024 the acceptance window is only
 # NFINAL/top_k = 2x wide and the target sits at the 1.1% quantile, deep in the
 # tail where one coarse bin is enough to clear the buffer -- so the ~211 us retry
-# fires on every row and eats the 7 us ten times over. Same failure mode as
+# fires on every row and eats the saving many times over. Same failure mode as
 # SSTRIDE=64 had, reached through a different parameter.
+#
+# The scan was not worth attacking anyway. Timing this kernel at four round
+# widths and solving for the model (R rounds of 2048/R cost R*a + 2048*b) gives
+# a = 1.5 us per round from three independent points, and a conditional
+# single-round variant then pins b, putting the whole 2048-wide scan at ~4.1 us
+# -- 2.6% of the operator, not the ~10 us assumed here earlier. Even deleting it
+# outright would only reach 0.924.
 #
 # It does help where the window is wide: at top_k=512 (4x window, 6.25% quantile)
 # SBINS=256 gains about 5% once the baseline drift in that 37 us shape is

--- a/src/flaggems_vllm/runtime/backend/_mthreads/fused/top_k_per_row_prefill.py
+++ b/src/flaggems_vllm/runtime/backend/_mthreads/fused/top_k_per_row_prefill.py
@@ -243,6 +243,14 @@ def _sampled_prefill(
     # tle.cumsum is the right primitive for rounds -- it returns
     # (prefix, total), and it beats tl.cumsum rounds by 3-6% on two of the three
     # shapes -- but rounds themselves lose here whichever primitive runs them.
+    #
+    # Cross-checked by wiring the generic loop into this operator for real and
+    # running the acceptance benchmark: (64, 129280) came out 0.903 against the
+    # probe's predicted 0.903 and this kernel's 0.902, the five run-stable
+    # shapes moved by at most 0.4% and their geomean by 0.001, and correctness
+    # held at 20/20. Two independent timing frameworks, one answer. The change
+    # is not worth taking, and the reproducer is the `scan-tle-experiment`
+    # branch.
     sbins = tl.arange(0, SBINS)
     cum = tl.cumsum(tl.load(hp + sbins), axis=0)
     target = TARGET_RANK // SSTRIDE + 1

--- a/src/flaggems_vllm/runtime/backend/_mthreads/fused/top_k_per_row_prefill.py
+++ b/src/flaggems_vllm/runtime/backend/_mthreads/fused/top_k_per_row_prefill.py
@@ -223,6 +223,26 @@ def _sampled_prefill(
     # acceptance window [TOPK, NFINAL] rather than its upper edge, which is what
     # the first version did -- aiming at the edge meant half the sampling error
     # pushed the count straight out of the window and into the retry.
+    # One wide scan, deliberately, where the generic operator loops in
+    # BLOCK_SIZE-wide rounds with tle.cumsum, a carried total and an early exit.
+    # That structure is not free: each round also pays a carry add, a threshold
+    # mask, two masked stores and a reduce_or. The generic operator needs all of
+    # it, because every round must yield threshold_bin_idx to prefix the next
+    # refinement step and final_bin_size to decide whether to take one -- and it
+    # splits elements three ways. This kernel needs a single cut and nothing
+    # else, so the bookkeeping has no reader and the scan can be one shot.
+    #
+    # Measured, transcribing the generic loop into this kernel verbatim
+    # (tools/mtt_scan_rounds.py), against this one wide scan:
+    #
+    #                    one 2048   tle x512   tle x1024
+    #     (64,129280)      157.1      156.8      157.6
+    #     (4,16385)         38.2       43.0       40.5
+    #     (16,65536)        63.7       65.2       65.6
+    #
+    # tle.cumsum is the right primitive for rounds -- it returns
+    # (prefix, total), and it beats tl.cumsum rounds by 3-6% on two of the three
+    # shapes -- but rounds themselves lose here whichever primitive runs them.
     sbins = tl.arange(0, SBINS)
     cum = tl.cumsum(tl.load(hp + sbins), axis=0)
     target = TARGET_RANK // SSTRIDE + 1

--- a/src/flaggems_vllm/runtime/backend/_mthreads/fused/top_k_per_row_prefill.py
+++ b/src/flaggems_vllm/runtime/backend/_mthreads/fused/top_k_per_row_prefill.py
@@ -1,0 +1,431 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sampled-threshold prefill top-K for Moore Threads.
+
+The generic operator reads each row TWICE per refinement step: once to build a
+2048-bin histogram so the top-K threshold can be found, and again to compact the
+elements at or above it. Measured on S5000 at (64, 129280):
+
+    Pass A  build histogram      75.2 us
+    Pass B  re-read and compact 131.8 us
+    final select                 10.2 us
+    operator                    217.2 us      vLLM 141.6   -> 0.651
+
+Pass A exists only to find a threshold. This estimates that threshold from
+1/SSTRIDE of the row instead and spends the saving on a deliberately loose
+threshold, so the single remaining pass collects several times top_k candidates
+rather than exactly top_k.
+
+Measured by driving the generic _process_bins at a loose threshold:
+
+    rank target   trigger   pass    sample + pass + final   speedup
+      2 x top_k    1.6%    135.7            146.8            0.965
+      4 x top_k    3.2%    139.0            150.2            0.943
+      8 x top_k    6.3%    141.6            152.7            0.927
+
+It pays because compaction barely tracks the trigger rate -- four times the hits
+cost 4% more -- so the atomics are per-lane issue overhead, not per-hit traffic,
+and trading a looser threshold for a whole scan is close to free.
+
+Two parameters decide whether that theoretical win survives contact with a real
+sample, and the first version got both wrong (0.383 against the generic 0.652):
+the sample must be large enough that the estimate's error is small compared with
+the acceptance window, and the target must sit in the MIDDLE of that window
+rather than against its edge. See SSTRIDE and TARGET_RANK below.
+
+Correctness does not depend on the estimate being good. A sample can under- or
+over-shoot, so the row's collected count is checked against [TOPK,
+NUM_FINAL_ITEMS] and a miss redoes the threshold exactly, from a full histogram,
+before compacting again. That fallback costs about what the generic operator
+costs, so a bad estimate is slow, never wrong.
+"""
+
+import math
+import os
+
+import triton
+import triton.language as tl
+
+from flaggems_vllm import runtime
+from flaggems_vllm.ops.top_k_per_row_prefill import (
+    NUM_BINS,
+    NUM_FILNAL_ITEMS,
+    NUM_THREADS_PER_BLOCK,
+    SORTING_ALGORITHM_THRESHOLD,
+    _extract_bin_idx,
+    _final_select_radix,
+    _num_warps,
+    _use_radix_final_for_prefill,
+    tle_top_k_per_row_prefill,
+)
+from flaggems_vllm.ops.top_k_per_row_prefill import (
+    top_k_per_row_prefill as _generic_prefill,
+)
+from flaggems_vllm.utils.triton_version_utils import has_triton_tle
+
+if has_triton_tle(3, 6, 0):
+    try:
+        import triton.experimental.tle.language as tle
+
+        HAS_TLE = True
+    except ImportError:
+        tle = None
+        HAS_TLE = False
+else:
+    tle = None
+    HAS_TLE = False
+
+
+# One element in SSTRIDE feeds the estimate.
+#
+# 64 was the first choice and it was wrong: it leaves only ~2000 samples, of
+# which ~32 land in the tail being estimated, for a relative standard deviation
+# near 18%. The collected count then sits 95% inside [1324, 2772] against a
+# buffer of 2048, so the retry fired almost every row and the operator ran
+# sample + collect + full histogram + collect again -- 357 us predicted against
+# 373 measured, worse than the generic two passes it replaced.
+#
+# 8 gives ~16000 samples and ~256 in the tail, cutting the deviation to ~6%,
+# while the sample pass still costs 75.2/8 = 9.4 us against the 75.2 it removes.
+SSTRIDE = int(os.environ.get("FLAGGEMS_MTT_PREFILL_SSTRIDE", "8"))
+
+# Below this the sampled path loses. Measured on S5000, generic -> sampled:
+#
+#     vocab   8193   0.875 -> 0.706   loses
+#     vocab  16385   0.765 -> 0.835   wins
+#     vocab 129280   0.652 -> 0.869   wins
+#
+# A short row is dominated by fixed cost, so adding a sample pass and a 2048-bin
+# cumsum on top costs more than the scan they remove. The crossover sits between
+# 8193 and 16385; 16384 is the safe side of it.
+MIN_SPAN = int(os.environ.get("FLAGGEMS_MTT_PREFILL_MIN_SPAN", "16384"))
+
+# Bins used for the SAMPLE histogram only; the collection pass and the exact
+# retry still work in the operator's full NUM_BINS space.
+#
+# MEASURED, and coarsening loses. The threshold scan is a cumsum over this many
+# bins and a 2048-wide cumsum costs ~10 us, so narrowing it looked like the last
+# 7 us needed to reach 0.9. At (64, 129280) it is catastrophic instead:
+#
+#     SBINS  2048 -> 0.856    512 -> 0.379    256 -> 0.368
+#
+# A coarse bin spans NUM_BINS/SAMPLE_BINS fine ones, so the count overshoots by
+# up to one coarse bin's population. At top_k=1024 the acceptance window is only
+# NFINAL/top_k = 2x wide and the target sits at the 1.1% quantile, deep in the
+# tail where one coarse bin is enough to clear the buffer -- so the ~211 us retry
+# fires on every row and eats the 7 us ten times over. Same failure mode as
+# SSTRIDE=64 had, reached through a different parameter.
+#
+# It does help where the window is wide: at top_k=512 (4x window, 6.25% quantile)
+# SBINS=256 gains about 5% once the baseline drift in that 37 us shape is
+# discounted. Too small a gain, on too noisy a shape, to justify a rule fitted to
+# two points -- so the default stays at the full width.
+SAMPLE_BINS = int(os.environ.get("FLAGGEMS_MTT_PREFILL_SBINS", str(NUM_BINS)))
+
+
+@triton.jit
+def _sampled_prefill(
+    logits_ptr,
+    out_indices_ptr,
+    row_starts,
+    row_ends,
+    stride0,
+    stride1,
+    TOPK: tl.constexpr,
+    TOPKP: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    VEC: tl.constexpr,
+    SSTRIDE: tl.constexpr,
+    TARGET_RANK: tl.constexpr,
+    SBINS: tl.constexpr,
+    SSHIFT: tl.constexpr,
+    NBINS: tl.constexpr,
+    NFINAL: tl.constexpr,
+):
+    row_id = tl.program_id(0)
+    row_start = tl.load(row_starts + row_id)
+    row_end = tl.load(row_ends + row_id)
+    span = row_end - row_start
+    # Base at the row's valid start, so every offset below is already in the
+    # caller's convention: indices relative to row_starts[row_id].
+    base = logits_ptr + row_id * stride0 + row_start * stride1
+    out = out_indices_ptr + row_id * TOPK
+
+    hist = tle.gpu.alloc(
+        [NBINS], dtype=tl.int32, layout=None, scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    fin = tle.gpu.alloc(
+        [NFINAL], dtype=tl.float32, layout=None, scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    oidx = tle.gpu.alloc(
+        [TOPKP], dtype=tl.int32, layout=None, scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    ccnt = tle.gpu.alloc(
+        [1], dtype=tl.int32, layout=None, scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    cfound = tle.gpu.alloc(
+        [1], dtype=tl.int32, layout=None, scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    hp = tle.gpu.local_ptr(hist, (0,))
+    fp = tle.gpu.local_ptr(fin, (0,))
+    op = tle.gpu.local_ptr(oidx, (0,))
+    cp = tle.gpu.local_ptr(ccnt, (0,))
+    fvp = tle.gpu.local_ptr(cfound, (0,))
+
+    lane = tl.arange(0, BLOCK_SIZE)
+    vec = tl.arange(0, VEC)
+    bins = tl.arange(0, NBINS)
+    one1 = tl.full([BLOCK_SIZE], 1, tl.int32)
+    one2 = tl.full([BLOCK_SIZE, VEC], 1, tl.int32)
+
+    # ---- pass 1: histogram of every SSTRIDE-th element -------------------
+    # Only the first SBINS entries are used here, so only those need clearing.
+    for z in tl.range(0, SBINS, BLOCK_SIZE):
+        tl.store(hp + z + lane, 0)
+    tl.debug_barrier()
+
+    n_s = span // SSTRIDE
+    for t in tl.range(0, tl.cdiv(n_s, BLOCK_SIZE)):
+        i = (t * BLOCK_SIZE + lane) * SSTRIDE
+        m = i < span
+        b, _ = _extract_bin_idx(tl.load(base + i * stride1, mask=m, other=0.0),
+                                m, 0, STEP=0)
+        tl.atomic_add(hp + (b >> SSHIFT), one1, mask=m, sem="relaxed",
+                      scope="cta")
+    tl.debug_barrier()
+
+    # A lower bin is a larger value, so the prefix count over bins is the count
+    # of the largest elements. TARGET_RANK aims at the GEOMETRIC MIDPOINT of the
+    # acceptance window [TOPK, NFINAL] rather than its upper edge, which is what
+    # the first version did -- aiming at the edge meant half the sampling error
+    # pushed the count straight out of the window and into the retry.
+    sbins = tl.arange(0, SBINS)
+    cum = tl.cumsum(tl.load(hp + sbins), axis=0)
+    target = TARGET_RANK // SSTRIDE + 1
+    thr_c = tl.min(tl.where(cum >= target, sbins, SBINS - 1), axis=0)
+    # Map back to the full bin space taking the WHOLE boundary coarse bin: at
+    # SSHIFT=0 this is the exact threshold, and coarser settings deliberately
+    # over-collect rather than under-collect, because falling short of TOPK
+    # forces the expensive exact retry while overshooting only wastes buffer.
+    thr = (thr_c + 1) << SSHIFT
+
+    # ---- pass 2: collect everything below the threshold -------------------
+    # Two attempts. The first uses the sampled threshold; if the count lands
+    # outside [TOPK, NFINAL] the estimate was bad, and the retry derives the
+    # threshold exactly from a full histogram, which is what the generic
+    # operator does anyway.
+    for attempt in tl.static_range(0, 2):
+        redo = attempt == 1
+        if (attempt == 0) or (tl.load(cp) < TOPK) or (tl.load(cp) > NFINAL):
+            if redo:
+                for z in tl.range(0, NBINS, BLOCK_SIZE):
+                    tl.store(hp + z + lane, 0)
+                tl.debug_barrier()
+                for t in tl.range(0, tl.cdiv(span, BLOCK_SIZE)):
+                    i = t * BLOCK_SIZE + lane
+                    m = i < span
+                    b, _ = _extract_bin_idx(
+                        tl.load(base + i * stride1, mask=m, other=0.0), m, 0,
+                        STEP=0,
+                    )
+                    tl.atomic_add(hp + b, one1, mask=m, sem="relaxed",
+                                  scope="cta")
+                tl.debug_barrier()
+                cum2 = tl.cumsum(tl.load(hp + bins), axis=0)
+                thr = tl.min(tl.where(cum2 >= TOPK, bins, NBINS - 1), axis=0) + 1
+
+            # hist doubles as the candidate index buffer from here on
+            for z in tl.range(0, NBINS, BLOCK_SIZE):
+                tl.store(hp + z + lane, 0)
+            tl.store(cp, 0)
+            tl.store(fvp, 0)
+            tl.debug_barrier()
+
+            n_vec = span // (BLOCK_SIZE * VEC)
+            for t in tl.range(0, n_vec):
+                offs = (t * BLOCK_SIZE * VEC + lane * VEC)[:, None] + vec[None, :]
+                x = tl.load(base + offs * stride1)
+                b, _ = _extract_bin_idx(x, True, 0, STEP=0)
+                # Cast explicitly: b is uint32 and thr int32, and leaving that
+                # promotion implicit is what silently selected every element in
+                # an earlier version of this kernel.
+                take = b.to(tl.int32) < thr
+                pos = tl.atomic_add(cp + tl.zeros([BLOCK_SIZE, VEC], tl.int32),
+                                    one2, mask=take, sem="relaxed", scope="cta")
+                keep = take & (pos < NFINAL)
+                tl.store(fp + pos, x, mask=keep)
+                tl.store(hp + pos, offs.to(tl.int32), mask=keep)
+            tail = n_vec * BLOCK_SIZE * VEC
+            for t in tl.range(0, tl.cdiv(span - tail, BLOCK_SIZE)):
+                i = tail + t * BLOCK_SIZE + lane
+                m = i < span
+                x = tl.load(base + i * stride1, mask=m, other=0.0)
+                b, _ = _extract_bin_idx(x, m, 0, STEP=0)
+                take = m & (b.to(tl.int32) < thr)
+                pos = tl.atomic_add(cp + tl.zeros([BLOCK_SIZE], tl.int32),
+                                    one1, mask=take, sem="relaxed", scope="cta")
+                keep = take & (pos < NFINAL)
+                tl.store(fp + pos, x, mask=keep)
+                tl.store(hp + pos, i.to(tl.int32), mask=keep)
+            tl.debug_barrier()
+
+    # ---- select TOPK out of the candidates --------------------------------
+    _final_select_radix(
+        hp, fp, cp, fvp, op, None,
+        TOPK=TOPK, BLOCK_SIZE=BLOCK_SIZE, MULTIPLE_BLOCKS_PER_ROW=False,
+    )
+    tl.debug_barrier()
+
+    n_have = tl.minimum(tl.load(cp), TOPK)
+    for z in tl.range(0, TOPK, BLOCK_SIZE):
+        o = z + lane
+        m = o < TOPK
+        v = tl.load(op + o, mask=m & (o < n_have), other=-1)
+        tl.store(out + o, tl.where(o < n_have, v, -1), mask=m)
+
+
+# A wider block buys warps per SM, which is what a small num_rows cannot get from
+# the grid: prefill launches grid=(num_rows,), so a handful of rows leaves most of
+# the device idle however much work each row carries.
+#
+# Measured here, and the crossover lands exactly on the SM count with no
+# misclassification across ten points at two vocabularies:
+#
+#     rows        2     4     8    16    32    48    60  |    61    64   128
+#     v=8193   1.08  1.14  1.13  1.14  1.21  1.14  1.13  |  0.68  0.65  0.52
+#     v=129280 1.50  1.57  1.53  1.52  1.52  1.52  1.48  |  0.83  0.82  0.63
+#
+# The mechanism fixes the boundary: the wide block takes 32 warps and this SM
+# tops out at 32, so it holds ONE program per SM where the narrow block holds
+# two, and past the SM count the grid needs a second wave. That 32->64 step costs
+# exactly 1.91x, and the independently measured concurrent capacity at
+# BLOCK_SIZE=512 was ~120, i.e. the same 32-warp ceiling seen from the other side.
+#
+# This lives in the vendor override rather than the generic dispatcher on
+# purpose. Both the threshold and the reasoning behind it come from this part's
+# occupancy structure, and whether they carry to a device with a different warp
+# ceiling is unmeasured.
+_WIDE_BLOCK = 1024
+_WIDE_MAX_ROWS = None
+
+
+def _wide_max_rows():
+    """Largest num_rows for which the wide block still fits in one wave."""
+    global _WIDE_MAX_ROWS
+    if _WIDE_MAX_ROWS is None:
+        override = os.environ.get("FLAGGEMS_MTT_PREFILL_WIDE_MAX_ROWS")
+        if override is not None:
+            _WIDE_MAX_ROWS = int(override)
+        else:
+            try:
+                props = runtime.torch_device_fn.get_device_properties(0)
+                warp = getattr(props, "warp_size", 32) or 32
+                sm = getattr(props, "multi_processor_count", 0)
+                # num_warps here is BLOCK_SIZE // 32, so a part whose warp is not
+                # 32 lanes would ask for a different thread count than the one
+                # this crossover was measured at.
+                _WIDE_MAX_ROWS = sm if (warp == 32 and sm) else 0
+            except Exception:  # noqa: BLE001 - detection must not break dispatch
+                _WIDE_MAX_ROWS = 0
+    return _WIDE_MAX_ROWS
+
+
+def _generic_at_block(
+    logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k, block
+):
+    """The generic TLE dispatch, at a chosen BLOCK_SIZE.
+
+    Mirrors top_k_per_row_prefill's own TLE branch, including its split between
+    insertion-sort and radix-final rows, and reuses its kernel unchanged.
+    """
+    vocab_size = logits.shape[1]
+    topkp = triton.next_power_of_2(top_k)
+    use_radix_final = _use_radix_final_for_prefill(vocab_size)
+    n_insert = 0 if use_radix_final else min(num_rows, SORTING_ALGORITHM_THRESHOLD)
+    nw = _num_warps(block)
+
+    if n_insert > 0:
+        tle_top_k_per_row_prefill[(n_insert,)](
+            logits, indices, row_starts, row_ends, stride0, stride1, vocab_size,
+            TOPK=top_k, TOPKP=topkp, BLOCK_SIZE=block,
+            USE_RADIX_FINAL=False, ROW_OFFSET=0, num_warps=nw,
+        )
+    if num_rows > n_insert:
+        tle_top_k_per_row_prefill[(num_rows - n_insert,)](
+            logits, indices, row_starts, row_ends, stride0, stride1, vocab_size,
+            TOPK=top_k, TOPKP=topkp, BLOCK_SIZE=block,
+            USE_RADIX_FINAL=True, ROW_OFFSET=n_insert, num_warps=nw,
+        )
+
+
+def _can_sample(num_rows, vocab_size, stride1, top_k):
+    """Route to the sampled kernel only where it was measured to pay."""
+    if not HAS_TLE:
+        return False
+    if stride1 != 1:
+        return False
+    # The candidate buffer is the generic op's, so the margin has to fit in it.
+    if top_k <= 0 or NUM_FILNAL_ITEMS // top_k < 2:
+        return False
+    return vocab_size >= MIN_SPAN
+
+
+def top_k_per_row_prefill(
+    logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+):
+    """Top-K per row for DeepSeek V4 prefill, with a sampled threshold.
+
+    Falls back by *calling* the generic implementation, not by claiming to.
+    """
+    vocab_size = logits.shape[1]
+    if not _can_sample(num_rows, vocab_size, stride1, top_k):
+        # Short rows skip sampling, but a small num_rows can still be starved of
+        # warps, and widening the block is the fix for that.
+        if HAS_TLE and 0 < num_rows <= _wide_max_rows():
+            return _generic_at_block(
+                logits, row_starts, row_ends, indices, num_rows, stride0,
+                stride1, top_k, _WIDE_BLOCK,
+            )
+        return _generic_prefill(
+            logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+        )
+
+    # Midpoint of [top_k, NUM_FILNAL_ITEMS] in log space: maximum room on both
+    # sides for the sample's error, instead of hugging one edge.
+    target_rank = int(math.sqrt(top_k * NUM_FILNAL_ITEMS))
+    _sampled_prefill[(num_rows,)](
+        logits,
+        indices,
+        row_starts,
+        row_ends,
+        stride0,
+        stride1,
+        TOPK=top_k,
+        TOPKP=triton.next_power_of_2(top_k),
+        BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
+        VEC=4,
+        SSTRIDE=SSTRIDE,
+        TARGET_RANK=target_rank,
+        SBINS=SAMPLE_BINS,
+        SSHIFT=(NUM_BINS // SAMPLE_BINS).bit_length() - 1,
+        NBINS=NUM_BINS,
+        NFINAL=NUM_FILNAL_ITEMS,
+        num_warps=_num_warps(NUM_THREADS_PER_BLOCK),
+    )

--- a/src/flaggems_vllm/runtime/backend/_mthreads/fused/top_k_per_row_prefill.py
+++ b/src/flaggems_vllm/runtime/backend/_mthreads/fused/top_k_per_row_prefill.py
@@ -270,7 +270,6 @@ def _sampled_prefill(
                 pos = tl.atomic_add(cp + tl.zeros([BLOCK_SIZE, VEC], tl.int32),
                                     one2, mask=take, sem="relaxed", scope="cta")
                 keep = take & (pos < NFINAL)
-                tl.store(fp + pos, x, mask=keep)
                 tl.store(hp + pos, offs.to(tl.int32), mask=keep)
             tail = n_vec * BLOCK_SIZE * VEC
             for t in tl.range(0, tl.cdiv(span - tail, BLOCK_SIZE)):
@@ -282,9 +281,38 @@ def _sampled_prefill(
                 pos = tl.atomic_add(cp + tl.zeros([BLOCK_SIZE], tl.int32),
                                     one1, mask=take, sem="relaxed", scope="cta")
                 keep = take & (pos < NFINAL)
-                tl.store(fp + pos, x, mask=keep)
                 tl.store(hp + pos, i.to(tl.int32), mask=keep)
             tl.debug_barrier()
+
+    # ---- re-read the candidate values -------------------------------------
+    # The collection loop keeps only the INDEX. Its two scattered shared-memory
+    # stores per hit were the largest remaining cost; re-reading the values
+    # afterwards, from global, in one short fully parallel pass is cheaper.
+    #
+    # Measured on S5000 at (64, 129280), kernel truncated after collection so
+    # the three costs separate (tools/mtt_store_split.py in the working branch):
+    #
+    #     store value + index   150.5 us
+    #     store index only      141.9        <- this
+    #     store neither         119.8        <- the two stores cost 30.7
+    #
+    # Dropping the value store returns about half of that 30.7 and the gather
+    # spends ~7 of it back, for a net 8.6. Whole operator 166.0 -> 157.2 us
+    # against vLLM's 142.4, i.e. 0.858 -> 0.906, confirmed independently by the
+    # benchmark at 0.906.
+    #
+    # A third variant, replacing the atomic with a deterministic pos, came out
+    # 18 us SLOWER and bounds nothing: modulo positions are scattered duplicate
+    # addresses, while the atomic's are dense, so it measured a different store
+    # pattern rather than the absence of an atomic. Recorded so the experiment
+    # is not repeated.
+    c_have = tl.minimum(tl.load(cp), NFINAL)
+    for t in tl.range(0, tl.cdiv(NFINAL, BLOCK_SIZE)):
+        j = t * BLOCK_SIZE + lane
+        m = j < c_have
+        gi = tl.load(hp + j, mask=m, other=0)
+        tl.store(fp + j, tl.load(base + gi * stride1, mask=m, other=0.0), mask=m)
+    tl.debug_barrier()
 
     # ---- select TOPK out of the candidates --------------------------------
     _final_select_radix(

--- a/src/flaggems_vllm/runtime/backend/_mthreads/fused/top_k_per_row_prefill.py
+++ b/src/flaggems_vllm/runtime/backend/_mthreads/fused/top_k_per_row_prefill.py
@@ -438,6 +438,29 @@ def top_k_per_row_prefill(
     # Midpoint of [top_k, NUM_FILNAL_ITEMS] in log space: maximum room on both
     # sides for the sample's error, instead of hugging one edge.
     target_rank = int(math.sqrt(top_k * NUM_FILNAL_ITEMS))
+    # One row per program, so a grid smaller than the device leaves SMs idle and
+    # the kernel is latency-bound rather than bandwidth-bound: at 4 rows x 129280
+    # it moves ~18 GB/s against the 645 this card reaches on the same access
+    # pattern. Widening puts twice the threads on each row.
+    #
+    # Same gate as the non-sampled path above, which the sampled path simply
+    # never called. Measured wide/narrow ratio at span 129280, top_k 1024:
+    #
+    #     rows      4     32     60     64     96
+    #           0.718  0.733  0.794  1.246  1.138
+    #
+    # The cliff is exactly at the SM count -- 1024 threads is 32 warps against a
+    # 32-warp SM ceiling, so capacity falls to one program per SM and 64 rows
+    # needs a second wave. Across span at 32 rows the gain grows monotonically,
+    # 0.966 at 16384 to 0.737 at 129280, and never inverts, so no span condition
+    # is added: the sampled path already requires span >= MIN_SPAN, and 16384 is
+    # its weakest point.
+    #
+    # This moves no benchmark shape -- (4, 16385) is below the span where
+    # widening matters and (64, 129280) is four rows past the cliff -- but is
+    # worth 1.24x to 1.42x against vLLM for num_rows 4..60 at large
+    # vocabularies, which core_shapes.yaml does not sample.
+    block = _WIDE_BLOCK if 0 < num_rows <= _wide_max_rows() else NUM_THREADS_PER_BLOCK
     _sampled_prefill[(num_rows,)](
         logits,
         indices,
@@ -447,7 +470,7 @@ def top_k_per_row_prefill(
         stride1,
         TOPK=top_k,
         TOPKP=triton.next_power_of_2(top_k),
-        BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
+        BLOCK_SIZE=block,
         VEC=4,
         SSTRIDE=SSTRIDE,
         TARGET_RANK=target_rank,
@@ -455,5 +478,5 @@ def top_k_per_row_prefill(
         SSHIFT=(NUM_BINS // SAMPLE_BINS).bit_length() - 1,
         NBINS=NUM_BINS,
         NFINAL=NUM_FILNAL_ITEMS,
-        num_warps=_num_warps(NUM_THREADS_PER_BLOCK),
+        num_warps=_num_warps(block),
     )

--- a/tests/test_top_k_per_row_decode.py
+++ b/tests/test_top_k_per_row_decode.py
@@ -14,7 +14,7 @@
 
 """Accuracy tests for top_k_per_row_decode (DeepSeek V4 decode-phase top-K).
 
-Tests the Triton radix-select kernel against the vLLM CUDA reference.
+Tests the Triton radix-select kernel against vLLM's own kernel.
 Uses value-based comparison (sorted selected values must match) to handle
 non-deterministic tie-breaking between implementations.
 """
@@ -47,12 +47,15 @@ else:
     VOCAB_SIZE_LIST = [4096, 8192, 16384, 32768, 129280, 262144]
     TOP_K_LIST = [64, 128, 256, 512, 1024]
 
-# --- vLLM CUDA reference (optional) ---
+# --- vLLM's own kernel as reference (optional) ---
 try:
     import vllm._custom_ops  # noqa: F401 — loads torch.ops._C
 
-    # Importing vLLM is NOT proof the op exists: a non-CUDA build (e.g. MUSA)
-    # imports fine but exposes no top_k_per_row_decode, and HAS_VLLM would
+    # Importing vLLM is NOT proof the op exists; the vendor of the build
+    # is not the test either -- this box's MUSA build DOES export
+    # top_k_per_row_decode. Check the symbol itself with hasattr, never
+    # dir(): torch.ops._C lists only what it has already resolved.
+    # Without this check HAS_VLLM would
     # then be a lie -- the benchmark would report a SpeedUp against a baseline
     # that does not exist. Check for the symbol itself, after the import.
     if not hasattr(torch.ops._C, "top_k_per_row_decode"):

--- a/tests/test_top_k_per_row_decode.py
+++ b/tests/test_top_k_per_row_decode.py
@@ -19,80 +19,91 @@ Uses value-based comparison (sorted selected values must match) to handle
 non-deterministic tie-breaking between implementations.
 """
 
-import inspect
-
 import pytest
 import torch
-import triton.language as tl
 
 import flaggems_vllm
-from flaggems_vllm.ops import top_k_per_row_decode
+from flaggems_vllm.ops.top_k_per_row_decode import (
+    top_k_per_row_decode as _generic_impl,
+)
 
 from . import conftest as cfg
 
 device = flaggems_vllm.device
 
-
-def _has_histogram_mask():
-    if not hasattr(tl, "histogram"):
-        return False
-    try:
-        return "mask" in inspect.signature(tl.histogram).parameters
-    except (ValueError, TypeError):
-        return False
-
-
 pytestmark = pytest.mark.skipif(
-    not _has_histogram_mask(),
-    reason="tl.histogram with mask parameter not available",
+    not flaggems_vllm.runtime.torch_device_fn.is_available(),
+    reason="accelerator device required",
 )
+
 
 # --- Shape configuration with QUICK_MODE support ---
 if cfg.QUICK_MODE:
-    VOCAB_SIZE_LIST = [129280]
-    TOP_K_LIST = [1024]
+    BATCH_SIZE_LIST = [1]
+    VOCAB_SIZE_LIST = [262144]
+    TOP_K_LIST = [512]
 else:
-    VOCAB_SIZE_LIST = [4096, 8192, 16384, 32768, 129280]
+    BATCH_SIZE_LIST = [1, 496]
+    VOCAB_SIZE_LIST = [4096, 8192, 16384, 32768, 129280, 262144]
     TOP_K_LIST = [64, 128, 256, 512, 1024]
 
 # --- vLLM CUDA reference (optional) ---
 try:
     import vllm._custom_ops  # noqa: F401 — loads torch.ops._C
 
+    # Importing vLLM is NOT proof the op exists: a non-CUDA build (e.g. MUSA)
+    # imports fine but exposes no top_k_per_row_decode, and HAS_VLLM would
+    # then be a lie -- the benchmark would report a SpeedUp against a baseline
+    # that does not exist. Check for the symbol itself, after the import.
+    if not hasattr(torch.ops._C, "top_k_per_row_decode"):
+        raise AttributeError("vLLM build exposes no top_k_per_row_decode")
+
     def _vllm_top_k_per_row_decode(
         logits, next_n, seq_lens, indices, num_rows, stride0, stride1, top_k
     ):
         torch.ops._C.top_k_per_row_decode(
-            logits,
-            next_n,
-            seq_lens,
-            indices,
-            num_rows,
-            stride0,
-            stride1,
-            top_k,
+            logits, next_n, seq_lens, indices, num_rows, stride0, stride1, top_k
         )
 
     HAS_VLLM = True
-except (ImportError, AttributeError):
+except (ImportError, AttributeError, RuntimeError):
+    # RuntimeError because a misconfigured vLLM should mean "no baseline", not a
+    # collection error: with two platform plugins registered it raises
+    # "Only one platform plugin can be activated" at import, which aborted
+    # collection of this whole file on an MTT box.
     HAS_VLLM = False
     _vllm_top_k_per_row_decode = None
 
 
-def _selected_values(logits, indices):
-    """Gather values at selected indices, sort for order-independent comparison."""
-    return logits.gather(1, indices.long()).sort(dim=1).values
+def check_topk_values_match(logits, indices_test, indices_ref, top_k):
+    num_rows = logits.shape[0]
+    for i in range(num_rows):
+        abs_test = indices_test[i].long()
+        abs_ref = indices_ref[i].long()
+
+        valid_test = abs_test[abs_test >= 0]
+        valid_ref = abs_ref[abs_ref >= 0]
+
+        vals_test = logits[i].gather(0, valid_test)
+        vals_ref = logits[i].gather(0, valid_ref)
+
+        vals_test_sorted, _ = vals_test.sort(descending=True)
+        vals_ref_sorted, _ = vals_ref.sort(descending=True)
+
+        if not torch.allclose(vals_test_sorted, vals_ref_sorted, atol=1e-6, rtol=1e-6):
+            return False
+    return True
 
 
-def _make_inputs(vocab_size, top_k, seq_len=None):
+def _make_inputs(batch_size, vocab_size, top_k, seq_len=None):
     """Generate test inputs matching DeepSeek V4 decode config."""
     if seq_len is None:
         seq_len = vocab_size
-    logits = torch.randn(1, vocab_size, dtype=torch.float32, device=device)
-    seq_lens = torch.tensor([seq_len], dtype=torch.int32, device=device)
-    indices = torch.zeros(1, top_k, dtype=torch.int32, device=device)
-    num_rows = 1
     next_n = 1
+    num_rows = batch_size * next_n
+    logits = torch.randn(num_rows, vocab_size, dtype=torch.float32, device=device)
+    seq_lens = torch.full((num_rows,), seq_len, dtype=torch.int32, device=device)
+    indices = torch.zeros(num_rows, top_k, dtype=torch.int32, device=device)
     stride0 = logits.stride(0)
     stride1 = logits.stride(1)
     return logits, next_n, seq_lens, indices, num_rows, stride0, stride1, top_k
@@ -102,35 +113,45 @@ def _torch_topk_ref(
     logits, next_n, seq_lens, indices, num_rows, stride0, stride1, top_k
 ):
     """Pure-PyTorch fallback reference using torch.topk."""
-    seq_len = seq_lens[0].item()
-    valid_logits = logits[:, :seq_len]
-    _, top_idx = torch.topk(valid_logits, top_k, dim=1, largest=True, sorted=False)
-    indices.copy_(top_idx.to(torch.int32))
+    for i in range(num_rows):
+        batch_id = i // next_n
+        batch_offset = i % next_n
+        seq_len = seq_lens[batch_id]
+        row_len = seq_len - next_n + batch_offset + 1
+        row_slice = logits[i, :row_len]
+        k = min(top_k, row_len)
+        _, topk_idx = torch.topk(row_slice, k, largest=True, sorted=False)
+        indices[i, :k] = topk_idx.to(torch.int32)
+        if k < top_k:
+            indices[i, k:] = -1
 
 
 @pytest.mark.top_k_per_row_decode
 @pytest.mark.parametrize(
-    "vocab_size, top_k",
-    [(v, k) for v, k in zip(VOCAB_SIZE_LIST, TOP_K_LIST)],
-    ids=[f"V{v}_K{k}" for v, k in zip(VOCAB_SIZE_LIST, TOP_K_LIST)],
+    "batch_size, vocab_size, top_k",
+    [(b, v, k) for b, v, k in zip(BATCH_SIZE_LIST, VOCAB_SIZE_LIST, TOP_K_LIST)],
+    ids=[
+        f"B{b}_V{v}_K{k}"
+        for b, v, k in zip(BATCH_SIZE_LIST, VOCAB_SIZE_LIST, TOP_K_LIST)
+    ],
 )
-def test_top_k_per_row_decode(vocab_size, top_k):
+def test_top_k_per_row_decode(batch_size, vocab_size, top_k):
     """Test top-k correctness: selected values must match reference."""
     torch.manual_seed(42)
-    ref_fn = _vllm_top_k_per_row_decode if HAS_VLLM else _torch_topk_ref
+    ref_fn = _torch_topk_ref
 
     logits, next_n, seq_lens, indices, num_rows, s0, s1, k = _make_inputs(
-        vocab_size, top_k
+        batch_size, vocab_size, top_k
     )
     logits_ref = logits.clone()
     indices_ref = torch.zeros_like(indices)
 
-    top_k_per_row_decode(logits, next_n, seq_lens, indices, num_rows, s0, s1, k)
+    flaggems_vllm.top_k_per_row_decode(
+        logits, next_n, seq_lens, indices, num_rows, s0, s1, k
+    )
     ref_fn(logits_ref, next_n, seq_lens, indices_ref, num_rows, s0, s1, k)
 
-    vals_tri = _selected_values(logits, indices)
-    vals_ref = _selected_values(logits_ref, indices_ref)
-    torch.testing.assert_close(vals_tri, vals_ref, rtol=1e-5, atol=1e-5)
+    assert check_topk_values_match(logits, indices, indices_ref, top_k)
 
 
 @pytest.mark.top_k_per_row_decode
@@ -146,56 +167,134 @@ def test_top_k_per_row_decode(vocab_size, top_k):
 def test_top_k_per_row_decode_partial_seqlen(vocab_size, top_k, seq_len):
     """Test with seq_len < vocab_size (partial valid range)."""
     torch.manual_seed(123)
-    ref_fn = _vllm_top_k_per_row_decode if HAS_VLLM else _torch_topk_ref
+    batch_size = 1
+    ref_fn = _torch_topk_ref
 
     logits, next_n, seq_lens, indices, num_rows, s0, s1, k = _make_inputs(
-        vocab_size, top_k, seq_len=seq_len
+        batch_size, vocab_size, top_k, seq_len=seq_len
     )
     logits_ref = logits.clone()
     indices_ref = torch.zeros_like(indices)
 
-    top_k_per_row_decode(logits, next_n, seq_lens, indices, num_rows, s0, s1, k)
+    flaggems_vllm.top_k_per_row_decode(
+        logits, next_n, seq_lens, indices, num_rows, s0, s1, k
+    )
     ref_fn(logits_ref, next_n, seq_lens, indices_ref, num_rows, s0, s1, k)
 
-    vals_tri = _selected_values(logits, indices)
-    vals_ref = _selected_values(logits_ref, indices_ref)
-    torch.testing.assert_close(vals_tri, vals_ref, rtol=1e-5, atol=1e-5)
+    assert check_topk_values_match(logits, indices, indices_ref, top_k)
 
 
 @pytest.mark.top_k_per_row_decode
-def test_top_k_per_row_decode_indices_in_range():
-    """Verify all selected indices are within [0, seq_len)."""
-    torch.manual_seed(7)
-    vocab_size, top_k, seq_len = 129280, 1024, 100000
+def test_topk_greater_than_row_len():
+    torch.manual_seed(456)
+    batch_size = 1
+    vocab_size = 262144
+    top_k = 512
+    seq_len = 496
+    ref_fn = _torch_topk_ref
+
     logits, next_n, seq_lens, indices, num_rows, s0, s1, k = _make_inputs(
-        vocab_size, top_k, seq_len=seq_len
+        batch_size, vocab_size, top_k, seq_len=seq_len
     )
-    top_k_per_row_decode(logits, next_n, seq_lens, indices, num_rows, s0, s1, k)
-    assert indices.min().item() >= 0
-    assert indices.max().item() < seq_len
+    logits_ref = logits.clone()
+    indices_ref = torch.zeros_like(indices)
+
+    flaggems_vllm.top_k_per_row_decode(
+        logits, next_n, seq_lens, indices, num_rows, s0, s1, k
+    )
+    ref_fn(logits_ref, next_n, seq_lens, indices_ref, num_rows, s0, s1, k)
+
+    assert check_topk_values_match(logits, indices, indices_ref, top_k)
+
+
+@pytest.mark.top_k_per_row_decode
+def test_logits_diff_in_8LSBits():
+    num_rows = 1
+    next_n = 1
+    vocab_size = 262144
+    top_k = 512
+    seq_len = vocab_size
+    ref_fn = _torch_topk_ref
+
+    random_8bit = torch.randint(
+        0,
+        2**8,
+        (num_rows, vocab_size),
+        dtype=torch.int32,
+        device=device,
+    )
+    logits_bits = 0x3F900000 | (random_8bit & 0xFF)
+    logits = logits_bits.view(torch.float32)
+    seq_lens = torch.full((num_rows,), seq_len, dtype=torch.int32, device=device)
+    indices = torch.zeros(num_rows, top_k, dtype=torch.int32, device=device)
+    s0 = logits.stride(0)
+    s1 = logits.stride(1)
+
+    logits_ref = logits.clone()
+    indices_ref = torch.zeros_like(indices)
+
+    flaggems_vllm.top_k_per_row_decode(
+        logits, next_n, seq_lens, indices, num_rows, s0, s1, top_k
+    )
+    ref_fn(logits_ref, next_n, seq_lens, indices_ref, num_rows, s0, s1, top_k)
+
+    assert check_topk_values_match(logits, indices, indices_ref, top_k)
 
 
 @pytest.mark.top_k_per_row_decode
 @pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
 @pytest.mark.parametrize(
-    "vocab_size, top_k",
-    [(129280, 1024), (32768, 512), (4096, 64)],
-    ids=["V129280_K1024", "V32768_K512", "V4096_K64"],
+    "vocab_size, top_k", [(129280, 1024), (32768, 512), (4096, 64)]
 )
 def test_top_k_per_row_decode_vs_vllm(vocab_size, top_k):
-    """Test against vLLM CUDA kernel."""
-    torch.manual_seed(42)
+    """Compare against vLLM's own kernel.
+
+    Kept separate from the accuracy tests on purpose: those pin their oracle to
+    the torch reference, so that a full-suite run and a single-file run cannot
+    silently disagree about what "correct" means depending on whether vLLM
+    happened to be importable.
+    """
+    torch.manual_seed(2024)
     logits, next_n, seq_lens, indices, num_rows, s0, s1, k = _make_inputs(
-        vocab_size, top_k
+        1, vocab_size, top_k
     )
     logits_ref = logits.clone()
     indices_ref = torch.zeros_like(indices)
 
-    top_k_per_row_decode(logits, next_n, seq_lens, indices, num_rows, s0, s1, k)
+    flaggems_vllm.top_k_per_row_decode(
+        logits, next_n, seq_lens, indices, num_rows, s0, s1, k
+    )
     _vllm_top_k_per_row_decode(
         logits_ref, next_n, seq_lens, indices_ref, num_rows, s0, s1, k
     )
 
-    vals_tri = _selected_values(logits, indices)
-    vals_ref = _selected_values(logits_ref, indices_ref)
-    torch.testing.assert_close(vals_tri, vals_ref, rtol=1e-5, atol=1e-5)
+    assert check_topk_values_match(logits, indices, indices_ref, k)
+
+
+_OVERRIDE_ACTIVE = flaggems_vllm.top_k_per_row_decode is not _generic_impl
+
+
+@pytest.mark.top_k_per_row_decode
+@pytest.mark.skipif(
+    not _OVERRIDE_ACTIVE,
+    reason="No backend override registered; the generic kernel is in use",
+)
+@pytest.mark.parametrize(
+    "batch_size, vocab_size, top_k",
+    [(b, v, k) for b, v, k in zip(BATCH_SIZE_LIST, VOCAB_SIZE_LIST, TOP_K_LIST)],
+)
+def test_backend_override_matches_reference(batch_size, vocab_size, top_k):
+    """Validate the vendor override itself. PASSES only when one is registered."""
+    torch.manual_seed(4242)
+    logits, next_n, seq_lens, indices, num_rows, s0, s1, k = _make_inputs(
+        batch_size, vocab_size, top_k
+    )
+    logits_ref = logits.clone()
+    indices_ref = torch.zeros_like(indices)
+
+    flaggems_vllm.top_k_per_row_decode(
+        logits, next_n, seq_lens, indices, num_rows, s0, s1, k
+    )
+    _torch_topk_ref(logits_ref, next_n, seq_lens, indices_ref, num_rows, s0, s1, k)
+
+    assert check_topk_values_match(logits, indices, indices_ref, k)

--- a/tests/test_top_k_per_row_prefill.py
+++ b/tests/test_top_k_per_row_prefill.py
@@ -14,8 +14,9 @@
 
 """Accuracy tests for top_k_per_row_prefill (DeepSeek V4 sparse attention).
 
-Tests the Triton kernel against a pure-PyTorch reference implementation.
-Verifies that the selected top-K values match (set comparison, order-independent).
+Tests the Triton kernel against vLLM CUDA reference (when available) and a
+pure-PyTorch fallback. Verifies that the selected top-K values match
+(set comparison, order-independent).
 
 Test shapes match DeepSeek V4 production config:
     - vocab_size=129280: DeepSeek V4 vocabulary size
@@ -24,18 +25,61 @@ Test shapes match DeepSeek V4 production config:
     - num_rows=32/64/2048: prefill batch sizes
 """
 
+from importlib import import_module
+
 import pytest
 import torch
 
 import flaggems_vllm
-from flaggems_vllm.ops import top_k_per_row_prefill
+from flaggems_vllm.ops.top_k_per_row_prefill import (
+    top_k_per_row_prefill as _generic_impl,
+)
+
+from . import conftest as cfg
 
 device = flaggems_vllm.device
 
+# Shape configs for QUICK_MODE
+if cfg.QUICK_MODE:
+    NUM_ROWS_FULL_VOCAB = [1, 64]
+    NUM_ROWS_VARIABLE = [4, 16383]
+    NUM_ROWS_NONZERO = [1]
+else:
+    NUM_ROWS_FULL_VOCAB = [1, 32, 64, 2048]
+    NUM_ROWS_VARIABLE = [4, 16383]
+    NUM_ROWS_NONZERO = [1, 16]
+
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(),
-    reason="CUDA device required",
+    not flaggems_vllm.runtime.torch_device_fn.is_available(),
+    reason="accelerator device required",
 )
+
+# --- vLLM CUDA reference (optional) ---
+try:
+    import vllm._custom_ops  # noqa: F401 — loads torch.ops._C
+
+    # Importing vLLM is NOT proof the op exists: a non-CUDA build (e.g. MUSA)
+    # imports fine but exposes no top_k_per_row_prefill, and HAS_VLLM would
+    # then be a lie -- the benchmark would report a SpeedUp against a baseline
+    # that does not exist. Check for the symbol itself, after the import.
+    if not hasattr(torch.ops._C, "top_k_per_row_prefill"):
+        raise AttributeError("vLLM build exposes no top_k_per_row_prefill")
+
+    def _vllm_top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+    ):
+        torch.ops._C.top_k_per_row_prefill(
+            logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+        )
+
+    HAS_VLLM = True
+except (ImportError, AttributeError, RuntimeError):
+    # RuntimeError because a misconfigured vLLM should mean "no baseline", not a
+    # collection error: with two platform plugins registered it raises
+    # "Only one platform plugin can be activated" at import, which aborted
+    # collection of this whole file on an MTT box.
+    HAS_VLLM = False
+    _vllm_top_k_per_row_prefill = None
 
 
 def reference_top_k_per_row(logits, row_starts, row_ends, top_k):
@@ -53,7 +97,6 @@ def reference_top_k_per_row(logits, row_starts, row_ends, top_k):
         row_slice = logits[i, start:end]
         k = min(top_k, end - start)
         _, topk_idx = torch.topk(row_slice, k, largest=True, sorted=False)
-        # topk_idx is already 0-based relative to start (since we sliced)
         indices[i, :k] = topk_idx.to(torch.int32)
         if k < top_k:
             indices[i, k:] = -1
@@ -65,26 +108,21 @@ def check_topk_values_match(logits, indices_test, indices_ref, row_starts, top_k
     """Value-based set comparison: verify that the actual logit values selected
     by test indices match those selected by reference indices.
 
-    This is order-independent — we only care that the same top-K values are found,
-    not that they appear in the same order. This is important because argsort and
-    topk may break ties differently.
+    Order-independent — we only care that the same top-K values are found,
+    not that they appear in the same order (argsort and topk break ties differently).
     """
     num_rows = logits.shape[0]
     for i in range(num_rows):
         offset = row_starts[i].item()
-        # Convert 0-based row-relative indices back to absolute vocab indices
         abs_test = indices_test[i].long() + offset
         abs_ref = indices_ref[i].long() + offset
 
-        # Filter out padding (-1 + offset could be invalid)
         valid_test = abs_test[abs_test >= offset]
         valid_ref = abs_ref[abs_ref >= offset]
 
         vals_test = logits[i].gather(0, valid_test)
         vals_ref = logits[i].gather(0, valid_ref)
 
-        # Sort values descending and compare — if same top-K values are selected,
-        # sorted arrays must match regardless of index order
         vals_test_sorted, _ = vals_test.sort(descending=True)
         vals_ref_sorted, _ = vals_ref.sort(descending=True)
 
@@ -94,7 +132,16 @@ def check_topk_values_match(logits, indices_test, indices_ref, row_starts, top_k
 
 
 @pytest.mark.top_k_per_row_prefill
-@pytest.mark.parametrize("num_rows", [1, 32, 64, 2048])
+def test_top_k_per_row_prefill_radix_final_config_prefers_large_vocab():
+    topk_prefill = import_module("flaggems_vllm.ops.top_k_per_row_prefill")
+
+    assert topk_prefill._use_radix_final_for_prefill(129280)
+    assert not topk_prefill._use_radix_final_for_prefill(8193)
+    assert not topk_prefill._use_radix_final_for_prefill(4095)
+
+
+@pytest.mark.top_k_per_row_prefill
+@pytest.mark.parametrize("num_rows", NUM_ROWS_FULL_VOCAB)
 @pytest.mark.parametrize("vocab_size", [129280])  # DeepSeek V4 vocab size
 @pytest.mark.parametrize("top_k", [1024])  # DeepSeek V4 KV cache topk
 def test_top_k_per_row_prefill_full_vocab(num_rows, vocab_size, top_k):
@@ -103,6 +150,9 @@ def test_top_k_per_row_prefill_full_vocab(num_rows, vocab_size, top_k):
     This is the most common case in inference: every token sees the full vocabulary.
     The masking kernel should early-exit for all rows.
     """
+    if top_k > vocab_size:
+        return
+
     torch.manual_seed(42)
 
     logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
@@ -111,19 +161,11 @@ def test_top_k_per_row_prefill_full_vocab(num_rows, vocab_size, top_k):
     stride0 = logits.stride(0)
     stride1 = logits.stride(1)
 
-    # Reference uses a clone because the Triton kernel modifies logits in-place
     indices_ref = reference_top_k_per_row(logits.clone(), row_starts, row_ends, top_k)
 
     indices_test = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
-    top_k_per_row_prefill(
-        logits,
-        row_starts,
-        row_ends,
-        indices_test,
-        num_rows,
-        stride0,
-        stride1,
-        top_k,
+    flaggems_vllm.top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices_test, num_rows, stride0, stride1, top_k
     )
 
     assert check_topk_values_match(
@@ -132,14 +174,38 @@ def test_top_k_per_row_prefill_full_vocab(num_rows, vocab_size, top_k):
 
 
 @pytest.mark.top_k_per_row_prefill
-@pytest.mark.parametrize("num_rows", [1, 32])
-@pytest.mark.parametrize(
-    "vocab_size",
-    [20000, 129280],  # 20000: smaller vocab for edge case coverage
+@pytest.mark.skipif(
+    not import_module("flaggems_vllm.ops.top_k_per_row_prefill").HAS_TLE,
+    reason="TLE top_k_per_row_prefill path is unavailable",
 )
-@pytest.mark.parametrize(
-    "top_k", [1024, 2048]  # 2048: tests larger top_k (used in some configs)
-)
+def test_top_k_per_row_prefill_large_vocab_partial_nonzero_range():
+    torch.manual_seed(321)
+    num_rows = 2
+    vocab_size = 65536
+    top_k = 1024
+
+    logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
+    row_starts = torch.tensor([128, 4096], dtype=torch.int32, device=device)
+    row_ends = torch.tensor([4096, 8192], dtype=torch.int32, device=device)
+    stride0 = logits.stride(0)
+    stride1 = logits.stride(1)
+
+    indices_ref = reference_top_k_per_row(logits.clone(), row_starts, row_ends, top_k)
+
+    indices_test = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
+    flaggems_vllm.top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices_test, num_rows, stride0, stride1, top_k
+    )
+
+    assert check_topk_values_match(
+        logits, indices_test, indices_ref, row_starts, top_k
+    ), "FAIL: large vocab partial nonzero range"
+
+
+@pytest.mark.top_k_per_row_prefill
+@pytest.mark.parametrize("num_rows", NUM_ROWS_VARIABLE)
+@pytest.mark.parametrize("vocab_size", [4095, 8193])
+@pytest.mark.parametrize("top_k", [512])
 def test_top_k_per_row_prefill_variable_lengths(num_rows, vocab_size, top_k):
     """Test with variable row lengths (partial vocab per row).
 
@@ -147,11 +213,13 @@ def test_top_k_per_row_prefill_variable_lengths(num_rows, vocab_size, top_k):
     KV ranges (e.g., due to causal masking or sequence packing).
     row_ends is randomized in [top_k, vocab_size] to ensure enough valid elements.
     """
+    if top_k > vocab_size:
+        return
+
     torch.manual_seed(123)
 
     logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
     row_starts = torch.zeros(num_rows, dtype=torch.int32, device=device)
-    # Ensure row_ends >= top_k so there are enough valid elements to select
     row_ends = torch.randint(
         top_k, vocab_size + 1, (num_rows,), dtype=torch.int32, device=device
     )
@@ -161,15 +229,8 @@ def test_top_k_per_row_prefill_variable_lengths(num_rows, vocab_size, top_k):
     indices_ref = reference_top_k_per_row(logits.clone(), row_starts, row_ends, top_k)
 
     indices_test = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
-    top_k_per_row_prefill(
-        logits,
-        row_starts,
-        row_ends,
-        indices_test,
-        num_rows,
-        stride0,
-        stride1,
-        top_k,
+    flaggems_vllm.top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices_test, num_rows, stride0, stride1, top_k
     )
 
     assert check_topk_values_match(
@@ -178,28 +239,21 @@ def test_top_k_per_row_prefill_variable_lengths(num_rows, vocab_size, top_k):
 
 
 @pytest.mark.top_k_per_row_prefill
-@pytest.mark.parametrize("num_rows", [1, 16])
+@pytest.mark.parametrize("num_rows", NUM_ROWS_NONZERO)
 def test_top_k_per_row_prefill_nonzero_starts(num_rows):
     """Test with non-zero row_starts.
 
     Verifies the index subtraction logic: output indices must be 0-based relative
-    to row_starts[i], not absolute vocab positions. This catches off-by-one errors
-    in the _fused_postprocess_kernel.
+    to row_starts[i], not absolute vocab positions.
     """
     torch.manual_seed(456)
     vocab_size = 50000
     top_k = 1024
 
     logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
-    # row_starts in [0, 1000): simulates offset within a packed sequence
     row_starts = torch.randint(0, 1000, (num_rows,), dtype=torch.int32, device=device)
-    # row_ends in [top_k+1000, vocab_size]: ensures enough valid range after start
     row_ends = torch.randint(
-        top_k + 1000,
-        vocab_size + 1,
-        (num_rows,),
-        dtype=torch.int32,
-        device=device,
+        top_k + 1000, vocab_size + 1, (num_rows,), dtype=torch.int32, device=device
     )
     stride0 = logits.stride(0)
     stride1 = logits.stride(1)
@@ -207,17 +261,116 @@ def test_top_k_per_row_prefill_nonzero_starts(num_rows):
     indices_ref = reference_top_k_per_row(logits.clone(), row_starts, row_ends, top_k)
 
     indices_test = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
-    top_k_per_row_prefill(
-        logits,
+    flaggems_vllm.top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices_test, num_rows, stride0, stride1, top_k
+    )
+
+    assert check_topk_values_match(
+        logits, indices_test, indices_ref, row_starts, top_k
+    ), f"FAIL: num_rows={num_rows}, nonzero starts"
+
+
+@pytest.mark.top_k_per_row_prefill
+@pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
+@pytest.mark.parametrize("num_rows", [1, 32, 64])
+def test_top_k_per_row_prefill_vs_vllm(num_rows):
+    """Test against vLLM CUDA kernel (persistent_topk)."""
+    torch.manual_seed(789)
+    vocab_size = 129280
+    top_k = 1024
+
+    logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
+    row_starts = torch.zeros(num_rows, dtype=torch.int32, device=device)
+    row_ends = torch.full((num_rows,), vocab_size, dtype=torch.int32, device=device)
+    stride0 = logits.stride(0)
+    stride1 = logits.stride(1)
+
+    # vLLM CUDA reference
+    logits_vllm = logits.clone()
+    indices_vllm = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
+    _vllm_top_k_per_row_prefill(
+        logits_vllm,
         row_starts,
         row_ends,
-        indices_test,
+        indices_vllm,
         num_rows,
         stride0,
         stride1,
         top_k,
     )
 
+    # FlagGems Triton kernel
+    indices_test = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
+    flaggems_vllm.top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices_test, num_rows, stride0, stride1, top_k
+    )
+
+    assert check_topk_values_match(
+        logits, indices_test, indices_vllm, row_starts, top_k
+    ), f"FAIL vs vLLM: num_rows={num_rows}"
+
+
+@pytest.mark.top_k_per_row_prefill
+def test_topk_greater_than_row_len():
+    torch.manual_seed(456)
+    num_rows = 4
+    vocab_size = 257
+    top_k = 512
+
+    logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
+    row_starts = torch.randint(
+        0, vocab_size // 2, (num_rows,), dtype=torch.int32, device=device
+    )
+    row_ends = torch.full((num_rows,), vocab_size, dtype=torch.int32, device=device)
+    stride0 = logits.stride(0)
+    stride1 = logits.stride(1)
+
+    indices_ref = reference_top_k_per_row(logits.clone(), row_starts, row_ends, top_k)
+
+    indices_test = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
+    flaggems_vllm.top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices_test, num_rows, stride0, stride1, top_k
+    )
+
+    assert check_topk_values_match(logits, indices_test, indices_ref, row_starts, top_k)
+
+
+_OVERRIDE_ACTIVE = flaggems_vllm.top_k_per_row_prefill is not _generic_impl
+
+
+@pytest.mark.top_k_per_row_prefill
+@pytest.mark.skipif(
+    not _OVERRIDE_ACTIVE,
+    reason="No backend override registered; the generic kernel is in use",
+)
+@pytest.mark.parametrize("num_rows", NUM_ROWS_FULL_VOCAB)
+def test_backend_override_matches_reference(num_rows):
+    """Validate the vendor override itself.
+
+    The other tests call the same top-level binding, so they cover the override
+    too. This one exists to make its presence *visible*: it PASSES only when a
+    vendor kernel is actually registered and SKIPS when the generic kernel is in
+    use, so a silently-unregistered override cannot look like a green run.
+    """
+    torch.manual_seed(4242)
+    vocab_size, top_k = 129280, 1024
+    logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
+    row_starts = torch.zeros(num_rows, dtype=torch.int32, device=device)
+    row_ends = torch.full((num_rows,), vocab_size, dtype=torch.int32, device=device)
+
+    indices_ref = reference_top_k_per_row(logits.clone(), row_starts, row_ends, top_k)
+    indices_test = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
+    flaggems_vllm.top_k_per_row_prefill(
+        logits,
+        row_starts,
+        row_ends,
+        indices_test,
+        num_rows,
+        logits.stride(0),
+        logits.stride(1),
+        top_k,
+    )
+
     assert check_topk_values_match(
         logits, indices_test, indices_ref, row_starts, top_k
-    ), f"FAIL: num_rows={num_rows}, nonzero starts"
+    ), f"FAIL: override, num_rows={num_rows}"

--- a/tests/test_top_k_per_row_prefill.py
+++ b/tests/test_top_k_per_row_prefill.py
@@ -14,7 +14,7 @@
 
 """Accuracy tests for top_k_per_row_prefill (DeepSeek V4 sparse attention).
 
-Tests the Triton kernel against vLLM CUDA reference (when available) and a
+Tests the Triton kernel against vLLM's own kernel (when available) and a
 pure-PyTorch fallback. Verifies that the selected top-K values match
 (set comparison, order-independent).
 
@@ -54,12 +54,15 @@ pytestmark = pytest.mark.skipif(
     reason="accelerator device required",
 )
 
-# --- vLLM CUDA reference (optional) ---
+# --- vLLM's own kernel as reference (optional) ---
 try:
     import vllm._custom_ops  # noqa: F401 — loads torch.ops._C
 
-    # Importing vLLM is NOT proof the op exists: a non-CUDA build (e.g. MUSA)
-    # imports fine but exposes no top_k_per_row_prefill, and HAS_VLLM would
+    # Importing vLLM is NOT proof the op exists; the vendor of the build
+    # is not the test either -- this box's MUSA build DOES export
+    # top_k_per_row_prefill. Check the symbol itself with hasattr, never
+    # dir(): torch.ops._C lists only what it has already resolved.
+    # Without this check HAS_VLLM would
     # then be a lie -- the benchmark would report a SpeedUp against a baseline
     # that does not exist. Check for the symbol itself, after the import.
     if not hasattr(torch.ops._C, "top_k_per_row_prefill"):
@@ -274,7 +277,7 @@ def test_top_k_per_row_prefill_nonzero_starts(num_rows):
 @pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
 @pytest.mark.parametrize("num_rows", [1, 32, 64])
 def test_top_k_per_row_prefill_vs_vllm(num_rows):
-    """Test against vLLM CUDA kernel (persistent_topk)."""
+    """Test against vLLM's own top_k_per_row_prefill."""
     torch.manual_seed(789)
     vocab_size = 129280
     top_k = 1024
@@ -285,7 +288,7 @@ def test_top_k_per_row_prefill_vs_vllm(num_rows):
     stride0 = logits.stride(0)
     stride1 = logits.stride(1)
 
-    # vLLM CUDA reference
+    # vLLM reference
     logits_vllm = logits.clone()
     indices_vllm = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
     _vllm_top_k_per_row_prefill(


### PR DESCRIPTION
### PR Category

[ Operator | OP Test | Benchmark ]

### Type of Change

[ Bug Fix | Performance Optimization ]

### Description

Brings `top_k_per_row_prefill` / `top_k_per_row_decode` up on non-NVIDIA backends and adds a Moore Threads (MTT S5000) prefill override.

1. **Adopt FlagGems' tests and benchmarks** for this op pair (`k > n`, vocab-262144 ties, per-row `[start, end)`, up to 16383 rows) and fix four harness defects:
   - call through the top-level `flaggems_vllm.<op>` entry, so vendor overrides are actually exercised (the `flaggems_vllm.ops` submodule attribute bypasses the registrar);
   - drop the decode file's `tl.histogram` gate (the op never calls it) and gate prefill on the resolved device instead of `torch.cuda.is_available()`;
   - pin the decode oracle to `torch.topk` instead of switching to vLLM depending on collection order;
   - set `HAS_VLLM` from `hasattr(torch.ops._C, ...)` rather than from the import alone.
2. **Two fixes that decide whether the op runs at all** (found on MetaX C550; identities on 32-lane / 1024-thread parts, so NVIDIA and MTT are unchanged):
   - respect `VendorDescriptor.tle_enabled` — `has_triton_tle()` only proves the module imports, not that the backend can lower `tle.gpu.alloc` (`FLAGGEMS_FORCE_TLE=1` overrides);
   - compute `num_warps` from the real `warp_size` instead of `BLOCK_SIZE // 32`, which requested 1024 threads on 64-lane MetaX and failed every launch with `OutOfResources`.
3. **MTT S5000 prefill override** (`_mthreads/fused/top_k_per_row_prefill.py`), three optimizations:
   - **Sampled threshold.** The generic op reads each row twice per refinement step: once to build a 2048-bin histogram whose only output is the threshold, once to compact against it. The override estimates the threshold from every 8th element, aims at the geometric midpoint of `[top_k, 2048]`, and redoes it exactly from a full histogram if the collected count lands outside that window. Gated on TLE, `stride1 == 1`, `top_k <= 1024`, `vocab >= 16384`.
   - **Index-only candidate buffer.** Collection wrote both value and index per hit; it now keeps only the index and re-reads the values from global memory in one short pass afterwards.
   - **Wide block when the grid cannot fill the device.** `BLOCK_SIZE` 512 → 1024 when `num_rows <= multi_processor_count` (60 on S5000). 1024 threads is 32 warps, the SM's warp ceiling, so capacity drops to one program per SM and widening only pays below the SM count; returns 0 (never widen) on non-32-lane parts.

### Issue

N/A (no related issue)

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.
  - MTT S5000: `tests/test_top_k_per_row_prefill.py` **20 passed**; prefill + decode **30 passed / 2 skipped** (skips are decode's `_OVERRIDE_ACTIVE` guard — only prefill is overridden).

### Performance

MTT S5000, `benchmark/test_top_k_per_row_{prefill,decode}.py --level core --iter 50 --warmup 10`, kernel mode, baseline = vLLM's own `torch.ops._C.top_k_per_row_*` (`csrc/sampler.cu`, MUSA build).

**prefill**

| num_rows, vocab, top_k | Torch (ms) | Gems (ms) | Speedup |
|---|---|---|---|
| 64, 129280, 1024 | 0.1432 | 0.1587 | **0.902** |
| 16383, 4095, 512 | 3.7044 | 2.3326 |  1.588 |
| 16380, 5115, 512 | 3.7681 | 2.4735 | 1.523 |
| 4100, 1025, 512 | 0.5680 | 0.3871 | 1.467 |
| 12961, 4100, 512 | 1.9080 | 1.7778 | 1.073 |
| 4, 16385, 512 | 0.0317 | 0.0383 | 0.829 |
| 4, 8193, 512 | 0.0258 | 0.0342 | 0.754 |
**avg:1.162**

**decode** (no override)

| num_rows (vocab 262144, top_k 512) | Torch (ms) | Gems (ms) | Speedup |
|---|---|---|---|
| 1 | 0.1482 | 0.1052 | 1.409 |
| 4 | 0.1632 | 0.1095 | 1.490 |
| 8 | 0.1798 | 0.1145 | 1.570 |
| 16 | 0.2173 | 0.1229 | 1.769 |
| 24 | 0.2580 | 0.1849 | 1.396 |
| 32 | 0.3408 | 0.1954 | 1.744 |
| 40 | 0.3724 | 0.2573 | 1.448 |
| 48 | 0.4099 | 0.2650 | 1.547 |
| 56 | 0.4868 | 0.3278 | 1.485 |
| 496 | 3.4472 | 2.1502 | 1.603 |
| 512 | 3.5581 | 2.2114 | 1.609 |
**avg:1.407**
