### PR TITLE
fix(enflame): avoid grid.x overflow in scaled_int8_quant static path

### DIFF
--- a/src/flaggems_vllm/runtime/backend/_enflame/ops/scaled_int8_quant.py
+++ b/src/flaggems_vllm/runtime/backend/_enflame/ops/scaled_int8_quant.py
@@ -151,7 +151,7 @@ def _dyn_asym_kernel(
 
 @triton.jit
 def _static_sym_kernel(input_ptr, scale_ptr, output_ptr, numel, BLOCK: tl.constexpr):
-    pid = tl.program_id(0)
+    pid = tl.program_id(0) + tl.program_id(1) * tl.num_programs(0)
     offs = pid * BLOCK + tl.arange(0, BLOCK)
     mask = offs < numel
     x = tl.load(input_ptr + offs, mask=mask, other=0.0).to(tl.float32)
@@ -165,7 +165,7 @@ def _static_sym_kernel(input_ptr, scale_ptr, output_ptr, numel, BLOCK: tl.conste
 def _static_asym_kernel(
     input_ptr, scale_ptr, azp_ptr, output_ptr, numel, BLOCK: tl.constexpr
 ):
-    pid = tl.program_id(0)
+    pid = tl.program_id(0) + tl.program_id(1) * tl.num_programs(0)
     offs = pid * BLOCK + tl.arange(0, BLOCK)
     mask = offs < numel
     x = tl.load(input_ptr + offs, mask=mask, other=0.0).to(tl.float32)
@@ -280,7 +280,12 @@ def _run_static(input, scale, azp, sym):
         BLOCK, nw = 512, 8
     else:
         BLOCK, nw = 256, 2
-    grid = (triton.cdiv(numel, BLOCK),)
+    # grid.x is hardware-limited (e.g. 65535 on Enflame GCU). Spread blocks
+    # across a 2-D grid so the tuned BLOCK size is unaffected by tensor size;
+    # the kernels recombine (pid_x, pid_y) into a single flat block index.
+    num_blocks = triton.cdiv(numel, BLOCK)
+    grid_x = min(num_blocks, 65535)
+    grid = (grid_x, triton.cdiv(num_blocks, grid_x))
     if sym:
         _static_sym_kernel[grid](input, scale, output, numel, BLOCK=BLOCK, num_warps=nw)
         return output, scale, None


### PR DESCRIPTION
<!--
 Copyright 2026 FlagOS Contributors

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->

### PR Category
Operator

### Type of Change
Bug Fix

### Description
Fix `OutOfResources: grid.x` crash in the Enflame (GCU) [scaled_int8_quant](cci:1://file:///d:/worksapce/sx/FlagGems-vllm/src/flaggems_vllm/ops/scaled_int8_quant.py:448:0-567:60) static quantization path.
<img width="3098" height="956" alt="image" src="https://github.com/user-attachments/assets/9a253a98-d203-4811-807d-7856dbaf4900" />

[_run_static](cci:1://file:///d:/worksapce/sx/FlagGems-vllm/src/flaggems_vllm/runtime/backend/_enflame/ops/scaled_int8_quant.py:272:0-294:29) launched [_static_sym_kernel](cci:1://file:///d:/worksapce/sx/FlagGems-vllm/src/flaggems_vllm/runtime/backend/_enflame/ops/scaled_int8_quant.py:151:0-160:57) / [_static_asym_kernel](cci:1://file:///d:/worksapce/sx/FlagGems-vllm/src/flaggems_vllm/runtime/backend/_enflame/ops/scaled_int8_quant.py:163:0-175:57) with a flat 1-D grid sized `cdiv(numel, BLOCK)`. For large tensors (e.g. `4096 x 5137`, `4096 x 8193`) this exceeds the Enflame GCU hardware limit of `grid.x <= 65535` (required `82192` / `131088`), causing every static symmetric/asymmetric quant call on those shapes to fail.

Fix: dispatch over a 2-D grid instead, and recombine the two program ids into a single flat block index inside the kernels:

```python
pid = tl.program_id(0) + tl.program_id(1) * tl.num_programs(0)
num_blocks = triton.cdiv(numel, BLOCK)
grid_x = min(num_blocks, 65535)
grid = (grid_x, triton.cdiv(num_blocks, grid_x))
```

This keeps grid.x within the hardware limit for any tensor size while leaving the on-target-tuned BLOCK/num_warps selection (512/8 for numel <= 16384, 256/2 otherwise) completely unchanged, so no perf regression is introduced for previously-passing shapes.

The dynamic quantization path (_run_dynamic) is out of scope for this PR — its grid is sized by num_tokens (rows), which does not exceed the grid limit for the shapes currently covered by the test suite.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Result
<img width="1788" height="1020" alt="image" src="https://github.com/user-attachments/assets/4bfe1d9e-6ceb-45d8-93b6-3f554ff50a06" />
