### PR TITLE
add gemma_rmsnorm op

### DIFF
--- a/benchmark/test_gemma_rmsnorm.py
+++ b/benchmark/test_gemma_rmsnorm.py
@@ -31,7 +31,7 @@ from . import consts  # noqa: E402
 
 vendor = flaggems_vllm.vendor_name
 
-if vendor == "nvidia":
+if vendor == "nvidia" or vendor == "thead":
     try:
         os.environ["FLASHINFER_DISABLE_VERSION_CHECK"] = "1"
         from flashinfer.norm import gemma_rmsnorm as baseline_op
@@ -91,7 +91,7 @@ class GemmaRmsNormBenchmark(Benchmark):
 )
 @pytest.mark.gemma_rmsnorm
 def test_gemma_rmsnorm():
-    if flaggems_vllm.vendor_name != "mthreads":
+    if flaggems_vllm.vendor_name not in ["mthreads", "thead"]:
         dtypes = consts.FLOAT_DTYPES
     else:
         dtypes = [torch.float16, torch.bfloat16]

--- a/benchmark/test_gemma_rmsnorm.py
+++ b/benchmark/test_gemma_rmsnorm.py
@@ -1,0 +1,85 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from itertools import product
+
+import pytest
+import torch
+
+import flaggems_vllm
+from benchmark.base import Benchmark
+
+from . import consts
+
+os.environ["FLASHINFER_DISABLE_VERSION_CHECK"] = "1"
+os.environ["FLAGTREE_ABBS"] = "0"
+
+if flaggems_vllm.vendor_name == "nvidia":
+    try:
+        from flashinfer.norm import gemma_rmsnorm as baseline_op
+
+        HAS_BASELINE_OP = True
+    except Exception as e:
+        print(e)
+        HAS_BASELINE_OP = False
+else:
+    pass
+
+
+class GemmaRmsNormBenchmark(Benchmark):
+    # Shapes aligned to powers of two and the hidden dimensions of the Gemma‑series models
+    _gemma_rmsnorm_ns = [128, 256, 1024] + [
+        1152,
+        2048,
+        2560,
+        3072,
+        3584,
+        3840,
+        4608,
+        5376,
+    ]
+    # Batch size
+    _gemma_rmsnorm_ms = [1, 256, 1024, 2048, 4096]
+    _gemma_rmsnorm_shapes = list(product(_gemma_rmsnorm_ms, _gemma_rmsnorm_ns))
+
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = GemmaRmsNormBenchmark._gemma_rmsnorm_shapes
+
+    def get_input_iter(self, dtype):
+        device = flaggems_vllm.runtime.device.name
+        for shape in self.shapes:
+            N = shape[-1]
+            x = torch.randn(shape, dtype=dtype, device=device)
+            w = torch.randn((N,), dtype=dtype, device=device)
+            eps = 1e-5
+            yield x, w, eps
+
+
+@pytest.mark.skipif(
+    not HAS_BASELINE_OP, reason="Missing baseline ops on current platform"
+)
+@pytest.mark.gemma_rmsnorm
+def test_gemma_rmsnorm():
+    if flaggems_vllm.vendor_name != "mthreads":
+        dtypes = consts.FLOAT_DTYPES
+    else:
+        dtypes = [torch.float16, torch.bfloat16]
+    bench = GemmaRmsNormBenchmark(
+        op_name="gemma_rmsnorm",
+        torch_op=baseline_op,
+        dtypes=dtypes,
+    )
+    bench.set_gems(flaggems_vllm.gemma_rmsnorm)
+    bench.run()

--- a/benchmark/test_gemma_rmsnorm.py
+++ b/benchmark/test_gemma_rmsnorm.py
@@ -13,22 +13,41 @@
 # limitations under the License.
 
 import os
-from itertools import product
 
-import pytest
-import torch
-
-import flaggems_vllm
-from benchmark.base import Benchmark
-
-from . import consts
-
+# ruff: noqa: I001
+os.environ["FLAGTREE_AABS"] = "0"
 os.environ["FLASHINFER_DISABLE_VERSION_CHECK"] = "1"
 os.environ["FLAGTREE_ABBS"] = "0"
 
-if flaggems_vllm.vendor_name == "nvidia":
+from itertools import product  # noqa: E402
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+
+import flaggems_vllm  # noqa: E402
+from benchmark.base import Benchmark  # noqa: E402
+
+from . import consts  # noqa: E402
+
+vendor = flaggems_vllm.vendor_name
+
+if vendor == "nvidia":
     try:
+        os.environ["FLASHINFER_DISABLE_VERSION_CHECK"] = "1"
         from flashinfer.norm import gemma_rmsnorm as baseline_op
+
+        HAS_BASELINE_OP = True
+    except Exception as e:
+        print(e)
+        HAS_BASELINE_OP = False
+elif vendor == "hygon":
+    try:
+        from lightop import op
+
+        def baseline_op(x, w, eps=1e-5):
+            out = torch.empty_like(x)
+            op.gemma_rmsnorm(out, x, w, eps)
+            return out
 
         HAS_BASELINE_OP = True
     except Exception as e:

--- a/src/flaggems_vllm/ops/__init__.py
+++ b/src/flaggems_vllm/ops/__init__.py
@@ -67,6 +67,7 @@ from flaggems_vllm.ops.fused_moe import (
 )
 from flaggems_vllm.ops.geglu import dgeglu, geglu
 from flaggems_vllm.ops.gelu_and_mul import gelu_and_mul
+from flaggems_vllm.ops.gemma_rmsnorm import gemma_rmsnorm
 from flaggems_vllm.ops.grouped_topk import grouped_topk
 from flaggems_vllm.ops.indexer_k_quant_and_cache import indexer_k_quant_and_cache
 from flaggems_vllm.ops.instance_norm import instance_norm
@@ -185,6 +186,7 @@ __all__ = [
     "fused_recurrent_gated_delta_rule_fwd",
     "geglu",
     "gelu_and_mul",
+    "gemma_rmsnorm",
     "grouped_topk",
     "hc_head_fused_kernel",
     "hc_head_fused_kernel_ref",

--- a/src/flaggems_vllm/ops/gemma_rmsnorm.py
+++ b/src/flaggems_vllm/ops/gemma_rmsnorm.py
@@ -7,136 +7,187 @@ import triton.language as tl
 logger = logging.getLogger(__name__)
 
 
-def get_gemma_rmsnorm_configs():
-    """Generate autotune configurations for gemma_rmsnorm.
-
-    Inspired by flashinfer's adaptive hyperparameter selection:
-    - Small N (≤1024): smaller BLOCK_N, more BLOCK_M parallelism
-    - Medium N (1024-4096): balanced tiling
-    - Large N (>4096): larger BLOCK_N, fewer warps for register pressure
-    """
+def get_gemma_rmsnorm_may_2d_splitn_configs():
     configs = []
-
-    # Small N: prioritize M parallelism
-    for block_m in [1, 4, 8, 16, 32]:
-        for block_n in [256, 512]:
-            for num_warps in [4, 8]:
-                configs.append(
-                    triton.Config(
-                        {"BLOCK_M": block_m, "BLOCK_N": block_n},
-                        num_warps=num_warps,
-                        num_stages=2,
-                    )
-                )
-
-    # Medium N: balanced
-    for block_m in [1, 4, 8, 16]:
-        for block_n in [1024, 2048]:
-            for num_warps in [4, 8, 16]:
-                configs.append(
-                    triton.Config(
-                        {"BLOCK_M": block_m, "BLOCK_N": block_n},
-                        num_warps=num_warps,
-                        num_stages=2,
-                    )
-                )
-
-    # Large N: prioritize N coverage, reduce M to control register pressure
     for block_m in [1, 4, 8]:
-        for block_n in [4096, 8192, 16384]:
-            for num_warps in [8, 16, 32]:
-                configs.append(
-                    triton.Config(
-                        {"BLOCK_M": block_m, "BLOCK_N": block_n},
-                        num_warps=num_warps,
-                        num_stages=2,
-                    )
+        for block_n in [128, 256, 512]:
+            configs.append(
+                triton.Config(
+                    {"BLOCK_M": block_m, "BLOCK_N": block_n},
+                    num_warps=4,
+                    num_stages=2,
                 )
+            )
 
+    for block_m in [1, 4, 8]:
+        configs.append(
+            triton.Config(
+                {"BLOCK_M": block_m, "BLOCK_N": 1024},
+                num_warps=8,
+                num_stages=2,
+            )
+        )
+
+    for block_m in [1, 4, 8]:
+        configs.append(
+            triton.Config(
+                {"BLOCK_M": block_m, "BLOCK_N": 2048},
+                num_warps=16,
+                num_stages=2,
+            )
+        )
+
+    for block_m in [16, 32]:
+        for block_n in [256, 512]:
+            configs.append(
+                triton.Config(
+                    {"BLOCK_M": block_m, "BLOCK_N": block_n},
+                    num_warps=8,
+                    num_stages=2,
+                )
+            )
+
+    for block_m in [4, 8]:
+        configs.append(
+            triton.Config(
+                {"BLOCK_M": block_m, "BLOCK_N": 1024},
+                num_warps=16,
+                num_stages=2,
+            )
+        )
     return configs
 
 
 @triton.autotune(
-    configs=get_gemma_rmsnorm_configs(),
+    configs=get_gemma_rmsnorm_may_2d_splitn_configs(),
     key=["M", "N"],
 )
 @triton.jit
-def gemma_rmsnorm_kernel(
+def gemma_rmsnorm_may_2d_splitn_kernel(
     x_ptr,
     w_ptr,
     out_ptr,
     M,
     N,
-    eps,
+    eps: float,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
-    # Process BLOCK_M rows at a time, with N chunked into BLOCK_N tiles
-    # This avoids loading the entire row at once for large N
-    pid_m = tl.program_id(0)
+    m_block_id = tl.program_id(0)
+    m_offs = m_block_id * BLOCK_M + tl.arange(0, BLOCK_M)
+    m_mask = m_offs < M
 
-    # Row indices for this M-block
-    rows = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    row_mask = rows < M
-
-    # Compute base offsets for these rows
-    offsets_base = rows[:, None] * N
-
-    # First pass: compute sum of squares across all N (in chunks)
+    offsets_base = m_offs[:, None] * N
     sum_sq = tl.zeros([BLOCK_M], dtype=tl.float32)
+
+    # pass‑1: accumulate sum‑of‑squares, split over N dimension
     for n_chunk in range(0, N, BLOCK_N):
-        chunk_cols = n_chunk + tl.arange(0, BLOCK_N)
-        chunk_mask = row_mask[:, None] & (chunk_cols[None, :] < N)
-        chunk_offsets = offsets_base + chunk_cols[None, :]
-        x_chunk = tl.load(x_ptr + chunk_offsets, mask=chunk_mask, other=0.0).to(
+        n_offs = n_chunk + tl.arange(0, BLOCK_N)
+        mn_mask = m_mask[:, None] & (n_offs[None, :] < N)
+        x = tl.load(x_ptr + offsets_base + n_offs[None, :], mask=mn_mask, other=0.0).to(
             tl.float32
         )
-        sum_sq += tl.sum(x_chunk * x_chunk, axis=1)
+        xq = x * x
+        sum_sq += tl.sum(xq, axis=1)
 
-    # Compute RMS normalization factor: 1 / sqrt(mean(x^2) + eps)
-    rrms = 1.0 / tl.sqrt(sum_sq / N + eps)
+    xq_mean = sum_sq / N
+    rrms = tl.rsqrt(xq_mean + eps)
 
-    # Second pass: apply normalization (in chunks)
+    # pass‑2: normalize & apply weight, split over N dimension
     for n_chunk in range(0, N, BLOCK_N):
-        chunk_cols = n_chunk + tl.arange(0, BLOCK_N)
-        chunk_mask = row_mask[:, None] & (chunk_cols[None, :] < N)
-        chunk_offsets = offsets_base + chunk_cols[None, :]
+        n_offs = n_chunk + tl.arange(0, BLOCK_N)
+        mn_mask = m_mask[:, None] & (n_offs[None, :] < N)
+        n_mask = n_offs < N
 
-        # Load input and weight for this chunk
-        x_chunk = tl.load(x_ptr + chunk_offsets, mask=chunk_mask, other=0.0).to(
+        x = tl.load(x_ptr + offsets_base + n_offs[None, :], mask=mn_mask, other=0.0).to(
             tl.float32
         )
-        weight_chunk = tl.load(w_ptr + chunk_cols, mask=(chunk_cols < N), other=0.0).to(
-            tl.float32
-        )
+        w = tl.load(w_ptr + n_offs, mask=n_mask, other=0.0).to(tl.float32)
 
-        # Apply normalization: y = x * (1/RMS) * (1 + weight)
-        y_chunk = x_chunk * rrms[:, None] * (1.0 + weight_chunk[None, :])
+        out = (1.0 + w[None, :]) * x * rrms[:, None]
+        tl.store(out_ptr + offsets_base + n_offs[None, :], out, mask=mn_mask)
 
-        # Store output
-        tl.store(out_ptr + chunk_offsets, y_chunk, mask=chunk_mask)
+
+def get_gemma_rmsnorm_may_2d_no_splitn_configs():
+    configs = []
+    for block_m in [1, 4, 8, 16]:
+        for num_warps in [1, 2, 4, 8, 16]:
+            configs.append(
+                triton.Config(
+                    {"BLOCK_M": block_m},
+                    num_warps=num_warps,
+                    num_stages=2,
+                )
+            )
+    return configs
+
+
+@triton.autotune(
+    configs=get_gemma_rmsnorm_may_2d_no_splitn_configs(),
+    key=["M", "N"],
+)
+@triton.jit
+def gemma_rmsnorm_may_2d_no_splitn_kernel(
+    x_ptr,
+    w_ptr,
+    out_ptr,
+    M,
+    N,
+    eps: float,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    if BLOCK_M == 1:
+        m = tl.program_id(0)
+        n_offs = tl.arange(0, BLOCK_N)
+        n_mask = n_offs < N
+        x = tl.load(x_ptr + m * N + n_offs, mask=n_mask, other=0.0).to(tl.float32)
+        w = tl.load(w_ptr + n_offs, mask=n_mask, other=0.0).to(tl.float32)
+        xq = x * x
+        xq_mean = tl.sum(xq, axis=-1, keep_dims=True) / N  # tensor<1xf32>
+        rrms = tl.rsqrt(xq_mean + eps)
+        out = (1 + w) * x * rrms
+        tl.store(out_ptr + m * N + n_offs, out, mask=n_mask)
+    else:
+        m_block_id = tl.program_id(0)
+        m = m_block_id * BLOCK_M
+        n_offs = tl.arange(0, BLOCK_N)
+        m_offs = m + tl.arange(0, BLOCK_M)
+        n_mask = n_offs < N
+        m_mask = m_offs < M
+        mn_mask = n_mask[None, :] & m_mask[:, None]
+        x = tl.load(
+            x_ptr + m_offs[:, None] * N + n_offs[None, :], mask=mn_mask, other=0.0
+        ).to(tl.float32)
+        w = tl.load(w_ptr + n_offs, mask=n_mask, other=0.0).to(tl.float32)
+        xq = x * x
+        xq_mean = tl.sum(xq, axis=-1, keep_dims=True) / N  # tensor<BLOCK_Mx1xf32>
+        rrms = tl.rsqrt(xq_mean + eps)
+        out = (1 + w) * x * rrms
+        tl.store(out_ptr + m_offs[:, None] * N + n_offs[None, :], out, mask=mn_mask)
 
 
 def gemma_rmsnorm(x: torch.Tensor, w: torch.Tensor, eps: float) -> torch.Tensor:
     logger.debug("GEMS GEMMA_RMSNORM")
     x = x.contiguous()
     w = w.contiguous()
-
     orig_shape = x.shape
     N = orig_shape[-1]
     x = x.reshape(-1, N)
     M = x.shape[0]
     out = torch.empty_like(x)
-
-    # Grid is 1D over M dimension only
     grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
-    gemma_rmsnorm_kernel[grid](
-        x,
-        w,
-        out,
-        M,
-        N,
-        eps,
-    )
-
+    if M == 1:
+        gemma_rmsnorm_may_2d_no_splitn_kernel[grid](
+            x, w, out, M, N, eps, BLOCK_N=triton.next_power_of_2(N)
+        )
+    else:
+        gemma_rmsnorm_may_2d_splitn_kernel[grid](
+            x,
+            w,
+            out,
+            M,
+            N,
+            eps,
+        )
     return out.reshape(orig_shape)

--- a/src/flaggems_vllm/ops/gemma_rmsnorm.py
+++ b/src/flaggems_vllm/ops/gemma_rmsnorm.py
@@ -1,0 +1,142 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+logger = logging.getLogger(__name__)
+
+
+def get_gemma_rmsnorm_configs():
+    """Generate autotune configurations for gemma_rmsnorm.
+
+    Inspired by flashinfer's adaptive hyperparameter selection:
+    - Small N (≤1024): smaller BLOCK_N, more BLOCK_M parallelism
+    - Medium N (1024-4096): balanced tiling
+    - Large N (>4096): larger BLOCK_N, fewer warps for register pressure
+    """
+    configs = []
+
+    # Small N: prioritize M parallelism
+    for block_m in [1, 4, 8, 16, 32]:
+        for block_n in [256, 512]:
+            for num_warps in [4, 8]:
+                configs.append(
+                    triton.Config(
+                        {"BLOCK_M": block_m, "BLOCK_N": block_n},
+                        num_warps=num_warps,
+                        num_stages=2,
+                    )
+                )
+
+    # Medium N: balanced
+    for block_m in [1, 4, 8, 16]:
+        for block_n in [1024, 2048]:
+            for num_warps in [4, 8, 16]:
+                configs.append(
+                    triton.Config(
+                        {"BLOCK_M": block_m, "BLOCK_N": block_n},
+                        num_warps=num_warps,
+                        num_stages=2,
+                    )
+                )
+
+    # Large N: prioritize N coverage, reduce M to control register pressure
+    for block_m in [1, 4, 8]:
+        for block_n in [4096, 8192, 16384]:
+            for num_warps in [8, 16, 32]:
+                configs.append(
+                    triton.Config(
+                        {"BLOCK_M": block_m, "BLOCK_N": block_n},
+                        num_warps=num_warps,
+                        num_stages=2,
+                    )
+                )
+
+    return configs
+
+
+@triton.autotune(
+    configs=get_gemma_rmsnorm_configs(),
+    key=["M", "N"],
+)
+@triton.jit
+def gemma_rmsnorm_kernel(
+    x_ptr,
+    w_ptr,
+    out_ptr,
+    M,
+    N,
+    eps,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    # Process BLOCK_M rows at a time, with N chunked into BLOCK_N tiles
+    # This avoids loading the entire row at once for large N
+    pid_m = tl.program_id(0)
+
+    # Row indices for this M-block
+    rows = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    row_mask = rows < M
+
+    # Compute base offsets for these rows
+    offsets_base = rows[:, None] * N
+
+    # First pass: compute sum of squares across all N (in chunks)
+    sum_sq = tl.zeros([BLOCK_M], dtype=tl.float32)
+    for n_chunk in range(0, N, BLOCK_N):
+        chunk_cols = n_chunk + tl.arange(0, BLOCK_N)
+        chunk_mask = row_mask[:, None] & (chunk_cols[None, :] < N)
+        chunk_offsets = offsets_base + chunk_cols[None, :]
+        x_chunk = tl.load(x_ptr + chunk_offsets, mask=chunk_mask, other=0.0).to(
+            tl.float32
+        )
+        sum_sq += tl.sum(x_chunk * x_chunk, axis=1)
+
+    # Compute RMS normalization factor: 1 / sqrt(mean(x^2) + eps)
+    rrms = 1.0 / tl.sqrt(sum_sq / N + eps)
+
+    # Second pass: apply normalization (in chunks)
+    for n_chunk in range(0, N, BLOCK_N):
+        chunk_cols = n_chunk + tl.arange(0, BLOCK_N)
+        chunk_mask = row_mask[:, None] & (chunk_cols[None, :] < N)
+        chunk_offsets = offsets_base + chunk_cols[None, :]
+
+        # Load input and weight for this chunk
+        x_chunk = tl.load(x_ptr + chunk_offsets, mask=chunk_mask, other=0.0).to(
+            tl.float32
+        )
+        weight_chunk = tl.load(w_ptr + chunk_cols, mask=(chunk_cols < N), other=0.0).to(
+            tl.float32
+        )
+
+        # Apply normalization: y = x * (1/RMS) * (1 + weight)
+        y_chunk = x_chunk * rrms[:, None] * (1.0 + weight_chunk[None, :])
+
+        # Store output
+        tl.store(out_ptr + chunk_offsets, y_chunk, mask=chunk_mask)
+
+
+def gemma_rmsnorm(x: torch.Tensor, w: torch.Tensor, eps: float) -> torch.Tensor:
+    logger.debug("GEMS GEMMA_RMSNORM")
+    x = x.contiguous()
+    w = w.contiguous()
+
+    orig_shape = x.shape
+    N = orig_shape[-1]
+    x = x.reshape(-1, N)
+    M = x.shape[0]
+    out = torch.empty_like(x)
+
+    # Grid is 1D over M dimension only
+    grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
+    gemma_rmsnorm_kernel[grid](
+        x,
+        w,
+        out,
+        M,
+        N,
+        eps,
+    )
+
+    return out.reshape(orig_shape)

--- a/src/flaggems_vllm/ops/gemma_rmsnorm.py
+++ b/src/flaggems_vllm/ops/gemma_rmsnorm.py
@@ -58,13 +58,13 @@ def _gemma_rmsnorm_may_2d_kernel(
     else:
         m = tl.program_id(0)
         n_offs = tl.arange(0, BLOCK_N)
-        offs = m * N + n_offs[None, :]
+        offs = m * N + n_offs
 
         n_mask = n_offs < N
         x = tl.load(x_ptr + offs, mask=n_mask, other=0.0).to(tl.float32)
         w = tl.load(w_ptr + n_offs, mask=n_mask, other=0.0).to(tl.float32)
 
-        inv_rms = 1.0 / tl.sqrt(tl.sum(x * x, axis=1) / N + eps)
+        inv_rms = 1.0 / tl.sqrt(tl.sum(x * x, axis=-1) / N + eps)
         y = x * inv_rms * (1.0 + w)
         tl.store(out_ptr + offs, y, mask=n_mask)
 

--- a/src/flaggems_vllm/ops/gemma_rmsnorm.py
+++ b/src/flaggems_vllm/ops/gemma_rmsnorm.py
@@ -7,164 +7,66 @@ import triton.language as tl
 logger = logging.getLogger(__name__)
 
 
-def get_gemma_rmsnorm_may_2d_splitn_configs():
-    configs = []
-    for block_m in [1, 4, 8]:
-        for block_n in [128, 256, 512]:
-            configs.append(
-                triton.Config(
-                    {"BLOCK_M": block_m, "BLOCK_N": block_n},
-                    num_warps=4,
-                    num_stages=2,
-                )
-            )
-
-    for block_m in [1, 4, 8]:
-        configs.append(
-            triton.Config(
-                {"BLOCK_M": block_m, "BLOCK_N": 1024},
-                num_warps=8,
-                num_stages=2,
-            )
-        )
-
-    for block_m in [1, 4, 8]:
-        configs.append(
-            triton.Config(
-                {"BLOCK_M": block_m, "BLOCK_N": 2048},
-                num_warps=16,
-                num_stages=2,
-            )
-        )
-
-    for block_m in [16, 32]:
-        for block_n in [256, 512]:
-            configs.append(
-                triton.Config(
-                    {"BLOCK_M": block_m, "BLOCK_N": block_n},
-                    num_warps=8,
-                    num_stages=2,
-                )
-            )
-
-    for block_m in [4, 8]:
-        configs.append(
-            triton.Config(
-                {"BLOCK_M": block_m, "BLOCK_N": 1024},
-                num_warps=16,
-                num_stages=2,
-            )
-        )
-    return configs
+_gemma_rmsnorm_may_2d_configs = [
+    triton.Config(kwargs={"BLOCK_M": 1}, num_warps=1),
+    triton.Config(kwargs={"BLOCK_M": 1}, num_warps=2),
+    triton.Config(kwargs={"BLOCK_M": 1}, num_warps=4),
+    triton.Config(kwargs={"BLOCK_M": 1}, num_warps=8),
+    triton.Config(kwargs={"BLOCK_M": 1}, num_warps=16),
+    triton.Config(kwargs={"BLOCK_M": 2}, num_warps=1),
+    triton.Config(kwargs={"BLOCK_M": 2}, num_warps=2),
+    triton.Config(kwargs={"BLOCK_M": 2}, num_warps=4),
+    triton.Config(kwargs={"BLOCK_M": 2}, num_warps=8),
+    triton.Config(kwargs={"BLOCK_M": 2}, num_warps=16),
+    triton.Config(kwargs={"BLOCK_M": 4}, num_warps=4),
+    triton.Config(kwargs={"BLOCK_M": 4}, num_warps=8),
+    triton.Config(kwargs={"BLOCK_M": 4}, num_warps=16),
+    triton.Config(kwargs={"BLOCK_M": 8}, num_warps=4),
+    triton.Config(kwargs={"BLOCK_M": 8}, num_warps=8),
+    triton.Config(kwargs={"BLOCK_M": 8}, num_warps=16),
+]
 
 
-@triton.autotune(
-    configs=get_gemma_rmsnorm_may_2d_splitn_configs(),
-    key=["M", "N"],
-)
+@triton.autotune(_gemma_rmsnorm_may_2d_configs, key=["M", "N"])
 @triton.jit
-def gemma_rmsnorm_may_2d_splitn_kernel(
+def _gemma_rmsnorm_may_2d_kernel(
     x_ptr,
     w_ptr,
     out_ptr,
     M,
     N,
-    eps: float,
+    eps,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
-    m_block_id = tl.program_id(0)
-    m_offs = m_block_id * BLOCK_M + tl.arange(0, BLOCK_M)
-    m_mask = m_offs < M
+    if BLOCK_M != 1:
+        m_block_id = tl.program_id(0)
+        m_offs = m_block_id * BLOCK_M + tl.arange(0, BLOCK_M)
+        n_offs = tl.arange(0, BLOCK_N)
+        offs = m_offs[:, None] * N + n_offs[None, :]
 
-    offsets_base = m_offs[:, None] * N
-    sum_sq = tl.zeros([BLOCK_M], dtype=tl.float32)
-
-    # pass‑1: accumulate sum‑of‑squares, split over N dimension
-    for n_chunk in range(0, N, BLOCK_N):
-        n_offs = n_chunk + tl.arange(0, BLOCK_N)
-        mn_mask = m_mask[:, None] & (n_offs[None, :] < N)
-        x = tl.load(x_ptr + offsets_base + n_offs[None, :], mask=mn_mask, other=0.0).to(
-            tl.float32
-        )
-        xq = x * x
-        sum_sq += tl.sum(xq, axis=1)
-
-    xq_mean = sum_sq / N
-    rrms = tl.rsqrt(xq_mean + eps)
-
-    # pass‑2: normalize & apply weight, split over N dimension
-    for n_chunk in range(0, N, BLOCK_N):
-        n_offs = n_chunk + tl.arange(0, BLOCK_N)
-        mn_mask = m_mask[:, None] & (n_offs[None, :] < N)
+        m_mask = m_offs < M
         n_mask = n_offs < N
+        mask = m_mask[:, None] & n_mask[None, :]
 
-        x = tl.load(x_ptr + offsets_base + n_offs[None, :], mask=mn_mask, other=0.0).to(
-            tl.float32
-        )
+        x = tl.load(x_ptr + offs, mask=mask, other=0.0).to(tl.float32)
         w = tl.load(w_ptr + n_offs, mask=n_mask, other=0.0).to(tl.float32)
 
-        out = (1.0 + w[None, :]) * x * rrms[:, None]
-        tl.store(out_ptr + offsets_base + n_offs[None, :], out, mask=mn_mask)
-
-
-def get_gemma_rmsnorm_may_2d_no_splitn_configs():
-    configs = []
-    for block_m in [1, 4, 8, 16]:
-        for num_warps in [1, 2, 4, 8, 16]:
-            configs.append(
-                triton.Config(
-                    {"BLOCK_M": block_m},
-                    num_warps=num_warps,
-                    num_stages=2,
-                )
-            )
-    return configs
-
-
-@triton.autotune(
-    configs=get_gemma_rmsnorm_may_2d_no_splitn_configs(),
-    key=["M", "N"],
-)
-@triton.jit
-def gemma_rmsnorm_may_2d_no_splitn_kernel(
-    x_ptr,
-    w_ptr,
-    out_ptr,
-    M,
-    N,
-    eps: float,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-):
-    if BLOCK_M == 1:
+        inv_rms = 1.0 / tl.sqrt(tl.sum(x * x, axis=1) / N + eps)
+        y = x * inv_rms[:, None] * (1.0 + w[None, :])
+        tl.store(out_ptr + offs, y, mask=mask)
+    else:
         m = tl.program_id(0)
         n_offs = tl.arange(0, BLOCK_N)
+        offs = m * N + n_offs[None, :]
+
         n_mask = n_offs < N
-        x = tl.load(x_ptr + m * N + n_offs, mask=n_mask, other=0.0).to(tl.float32)
+        x = tl.load(x_ptr + offs, mask=n_mask, other=0.0).to(tl.float32)
         w = tl.load(w_ptr + n_offs, mask=n_mask, other=0.0).to(tl.float32)
-        xq = x * x
-        xq_mean = tl.sum(xq, axis=-1, keep_dims=True) / N  # tensor<1xf32>
-        rrms = tl.rsqrt(xq_mean + eps)
-        out = (1 + w) * x * rrms
-        tl.store(out_ptr + m * N + n_offs, out, mask=n_mask)
-    else:
-        m_block_id = tl.program_id(0)
-        m = m_block_id * BLOCK_M
-        n_offs = tl.arange(0, BLOCK_N)
-        m_offs = m + tl.arange(0, BLOCK_M)
-        n_mask = n_offs < N
-        m_mask = m_offs < M
-        mn_mask = n_mask[None, :] & m_mask[:, None]
-        x = tl.load(
-            x_ptr + m_offs[:, None] * N + n_offs[None, :], mask=mn_mask, other=0.0
-        ).to(tl.float32)
-        w = tl.load(w_ptr + n_offs, mask=n_mask, other=0.0).to(tl.float32)
-        xq = x * x
-        xq_mean = tl.sum(xq, axis=-1, keep_dims=True) / N  # tensor<BLOCK_Mx1xf32>
-        rrms = tl.rsqrt(xq_mean + eps)
-        out = (1 + w) * x * rrms
-        tl.store(out_ptr + m_offs[:, None] * N + n_offs[None, :], out, mask=mn_mask)
+
+        inv_rms = 1.0 / tl.sqrt(tl.sum(x * x, axis=1) / N + eps)
+        y = x * inv_rms * (1.0 + w)
+        tl.store(out_ptr + offs, y, mask=n_mask)
 
 
 def gemma_rmsnorm(x: torch.Tensor, w: torch.Tensor, eps: float) -> torch.Tensor:
@@ -177,17 +79,7 @@ def gemma_rmsnorm(x: torch.Tensor, w: torch.Tensor, eps: float) -> torch.Tensor:
     M = x.shape[0]
     out = torch.empty_like(x)
     grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
-    if M == 1:
-        gemma_rmsnorm_may_2d_no_splitn_kernel[grid](
-            x, w, out, M, N, eps, BLOCK_N=triton.next_power_of_2(N)
-        )
-    else:
-        gemma_rmsnorm_may_2d_splitn_kernel[grid](
-            x,
-            w,
-            out,
-            M,
-            N,
-            eps,
-        )
+    _gemma_rmsnorm_may_2d_kernel[grid](
+        x, w, out, M, N, eps, BLOCK_N=triton.next_power_of_2(N)
+    )
     return out.reshape(orig_shape)

--- a/tests/test_gemma_rmsnorm.py
+++ b/tests/test_gemma_rmsnorm.py
@@ -1,0 +1,58 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import random
+from itertools import product
+
+import pytest
+import torch
+
+import flaggems_vllm
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+os.environ["FLAGTREE_ABBS"] = "0"
+
+# Shapes aligned to powers of two and the hidden dimensions of the Gemma‑series models
+_gemma_rmsnorm_ns = [128, 256, 1024] + [1152, 2048, 2560, 3072, 3584, 3840, 4608, 5376]
+# Batch size
+_gemma_rmsnorm_ms = [1, 64, 256, 1024, 4096]
+_gemma_rmsnorm_shapes = list(product(_gemma_rmsnorm_ms, _gemma_rmsnorm_ns))
+if cfg.QUICK_MODE:
+    _gemma_rmsnorm_shapes = random.sample(_gemma_rmsnorm_shapes, 8)
+
+
+@pytest.mark.gemma_rms_norm
+@pytest.mark.parametrize("shape", _gemma_rmsnorm_shapes)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_add_rms_norm(shape, dtype):
+    N = shape[-1]
+    x = torch.randn(shape, dtype=dtype, device=flaggems_vllm.device)
+    w = torch.randn((N), dtype=dtype, device=flaggems_vllm.device)
+    eps = 1e-5
+
+    def _torch_gemma_rmsnorm(x, w, eps):
+        x = x.to(dtype=torch.float32)
+        w = w.to(dtype=torch.float32)
+        rrms = 1 / ((x**2).mean(dim=-1, keepdim=True) + eps).sqrt()
+        return (1 + w) * x * rrms
+
+    ref_out = _torch_gemma_rmsnorm(x, w, eps)
+
+    with flaggems_vllm.use_gems():
+        res_out = flaggems_vllm.gemma_rmsnorm(x, w, eps)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
<!--
 Copyright 2026 FlagOS Contributors

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator 
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Add `gemma_rmsnorm` operator.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
On 5060Ti
```bash
benchmark/test_gemma_rmsnorm.py::test_gemma_rmsnorm 
Operator: gemma_rmsnorm  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.004352            0.004384               0.993          [torch.Size([1, 128]), torch.Size([128]), 1e-05]
SUCCESS               0.004352            0.004384               0.993          [torch.Size([1, 256]), torch.Size([256]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 1024]), torch.Size([1024]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 1152]), torch.Size([1152]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 2048]), torch.Size([2048]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 2560]), torch.Size([2560]), 1e-05]
SUCCESS               0.004464            0.006400               0.698          [torch.Size([1, 3072]), torch.Size([3072]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 3584]), torch.Size([3584]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 3840]), torch.Size([3840]), 1e-05]
SUCCESS               0.004384            0.008448               0.519          [torch.Size([1, 4608]), torch.Size([4608]), 1e-05]
SUCCESS               0.006016            0.008448               0.712          [torch.Size([1, 5376]), torch.Size([5376]), 1e-05]
SUCCESS               0.004352            0.004384               0.993          [torch.Size([256, 128]), torch.Size([128]), 1e-05]
SUCCESS               0.006336            0.006368               0.995          [torch.Size([256, 256]), torch.Size([256]), 1e-05]
SUCCESS               0.006400            0.006400               1.000          [torch.Size([256, 1024]), torch.Size([1024]), 1e-05]
SUCCESS               0.006400            0.006400               1.000          [torch.Size([256, 1152]), torch.Size([1152]), 1e-05]
SUCCESS               0.008448            0.008448               1.000          [torch.Size([256, 2048]), torch.Size([2048]), 1e-05]
SUCCESS               0.010464            0.010528               0.994          [torch.Size([256, 2560]), torch.Size([2560]), 1e-05]
SUCCESS               0.010560            0.010944               0.965          [torch.Size([256, 3072]), torch.Size([3072]), 1e-05]
SUCCESS               0.012544            0.012576               0.997          [torch.Size([256, 3584]), torch.Size([3584]), 1e-05]
SUCCESS               0.012544            0.014096               0.890          [torch.Size([256, 3840]), torch.Size([3840]), 1e-05]
SUCCESS               0.014672            0.018656               0.786          [torch.Size([256, 4608]), torch.Size([4608]), 1e-05]
SUCCESS               0.016640            0.018688               0.890          [torch.Size([256, 5376]), torch.Size([5376]), 1e-05]
SUCCESS               0.006384            0.006400               0.998          [torch.Size([1024, 128]), torch.Size([128]), 1e-05]
SUCCESS               0.006400            0.006400               1.000          [torch.Size([1024, 256]), torch.Size([256]), 1e-05]
SUCCESS               0.012544            0.012576               0.997          [torch.Size([1024, 1024]), torch.Size([1024]), 1e-05]
SUCCESS               0.014592            0.014592               1.000          [torch.Size([1024, 1152]), torch.Size([1152]), 1e-05]
SUCCESS               0.024704            0.024704               1.000          [torch.Size([1024, 2048]), torch.Size([2048]), 1e-05]
SUCCESS               0.030848            0.032832               0.940          [torch.Size([1024, 2560]), torch.Size([2560]), 1e-05]
SUCCESS               0.035120            0.036864               0.953          [torch.Size([1024, 3072]), torch.Size([3072]), 1e-05]
SUCCESS               0.040960            0.041504               0.987          [torch.Size([1024, 3584]), torch.Size([3584]), 1e-05]
SUCCESS               0.043456            0.045248               0.960          [torch.Size([1024, 3840]), torch.Size([3840]), 1e-05]
SUCCESS               0.051328            0.053392               0.961          [torch.Size([1024, 4608]), torch.Size([4608]), 1e-05]
SUCCESS               0.059520            0.061600               0.966          [torch.Size([1024, 5376]), torch.Size([5376]), 1e-05]
SUCCESS               0.006368            0.006400               0.995          [torch.Size([2048, 128]), torch.Size([128]), 1e-05]
SUCCESS               0.008384            0.008448               0.992          [torch.Size([2048, 256]), torch.Size([256]), 1e-05]
SUCCESS               0.024704            0.024704               1.000          [torch.Size([2048, 1024]), torch.Size([1024]), 1e-05]
SUCCESS               0.026736            0.028800               0.928          [torch.Size([2048, 1152]), torch.Size([1152]), 1e-05]
SUCCESS               0.047200            0.047792               0.988          [torch.Size([2048, 2048]), torch.Size([2048]), 1e-05]
SUCCESS               0.057472            0.059520               0.966          [torch.Size([2048, 2560]), torch.Size([2560]), 1e-05]
SUCCESS               0.067712            0.069760               0.971          [torch.Size([2048, 3072]), torch.Size([3072]), 1e-05]
SUCCESS               0.078016            0.080000               0.975          [torch.Size([2048, 3584]), torch.Size([3584]), 1e-05]
SUCCESS               0.084064            0.084096               1.000          [torch.Size([2048, 3840]), torch.Size([3840]), 1e-05]
SUCCESS               0.100480            0.102528               0.980          [torch.Size([2048, 4608]), torch.Size([4608]), 1e-05]
SUCCESS               0.116864            0.118912               0.983          [torch.Size([2048, 5376]), torch.Size([5376]), 1e-05]
SUCCESS               0.008416            0.008448               0.996          [torch.Size([4096, 128]), torch.Size([128]), 1e-05]
SUCCESS               0.012544            0.012544               1.000          [torch.Size([4096, 256]), torch.Size([256]), 1e-05]
SUCCESS               0.045152            0.047232               0.956          [torch.Size([4096, 1024]), torch.Size([1024]), 1e-05]
SUCCESS               0.051456            0.054896               0.937          [torch.Size([4096, 1152]), torch.Size([1152]), 1e-05]
SUCCESS               0.088544            0.090240               0.981          [torch.Size([4096, 2048]), torch.Size([2048]), 1e-05]
SUCCESS               0.110720            0.112768               0.982          [torch.Size([4096, 2560]), torch.Size([2560]), 1e-05]
SUCCESS               0.132688            0.133248               0.996          [torch.Size([4096, 3072]), torch.Size([3072]), 1e-05]
SUCCESS               0.153728            0.157072               0.979          [torch.Size([4096, 3584]), torch.Size([3584]), 1e-05]
SUCCESS               0.165936            0.166032               0.999          [torch.Size([4096, 3840]), torch.Size([3840]), 1e-05]
SUCCESS               0.198784            0.200832               0.990          [torch.Size([4096, 4608]), torch.Size([4608]), 1e-05]
SUCCESS               0.231072            0.233600               0.989          [torch.Size([4096, 5376]), torch.Size([5376]), 1e-05]


Operator: gemma_rmsnorm  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.004352            0.006368               0.683          [torch.Size([1, 128]), torch.Size([128]), 1e-05]
SUCCESS               0.004352            0.006336               0.687          [torch.Size([1, 256]), torch.Size([256]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 1024]), torch.Size([1024]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 1152]), torch.Size([1152]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 2048]), torch.Size([2048]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 2560]), torch.Size([2560]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 3072]), torch.Size([3072]), 1e-05]
SUCCESS               0.006400            0.006448               0.993          [torch.Size([1, 3584]), torch.Size([3584]), 1e-05]
SUCCESS               0.006400            0.006432               0.995          [torch.Size([1, 3840]), torch.Size([3840]), 1e-05]
SUCCESS               0.006400            0.008448               0.758          [torch.Size([1, 4608]), torch.Size([4608]), 1e-05]
SUCCESS               0.006400            0.008448               0.758          [torch.Size([1, 5376]), torch.Size([5376]), 1e-05]
SUCCESS               0.006368            0.006400               0.995          [torch.Size([256, 128]), torch.Size([128]), 1e-05]
SUCCESS               0.006400            0.006400               1.000          [torch.Size([256, 256]), torch.Size([256]), 1e-05]
SUCCESS               0.008448            0.008448               1.000          [torch.Size([256, 1024]), torch.Size([1024]), 1e-05]
SUCCESS               0.010496            0.010176               1.031          [torch.Size([256, 1152]), torch.Size([1152]), 1e-05]
SUCCESS               0.012544            0.012544               1.000          [torch.Size([256, 2048]), torch.Size([2048]), 1e-05]
SUCCESS               0.016640            0.016896               0.985          [torch.Size([256, 2560]), torch.Size([2560]), 1e-05]
SUCCESS               0.018704            0.020608               0.908          [torch.Size([256, 3072]), torch.Size([3072]), 1e-05]
SUCCESS               0.022656            0.022656               1.000          [torch.Size([256, 3584]), torch.Size([3584]), 1e-05]
SUCCESS               0.024704            0.024736               0.999          [torch.Size([256, 3840]), torch.Size([3840]), 1e-05]
SUCCESS               0.028192            0.030848               0.914          [torch.Size([256, 4608]), torch.Size([4608]), 1e-05]
SUCCESS               0.030848            0.034880               0.884          [torch.Size([256, 5376]), torch.Size([5376]), 1e-05]
SUCCESS               0.006400            0.006400               1.000          [torch.Size([1024, 128]), torch.Size([128]), 1e-05]
SUCCESS               0.008448            0.008448               1.000          [torch.Size([1024, 256]), torch.Size([256]), 1e-05]
SUCCESS               0.024512            0.024864               0.986          [torch.Size([1024, 1024]), torch.Size([1024]), 1e-05]
SUCCESS               0.028816            0.026912               1.071          [torch.Size([1024, 1152]), torch.Size([1152]), 1e-05]
SUCCESS               0.047200            0.047232               0.999          [torch.Size([1024, 2048]), torch.Size([2048]), 1e-05]
SUCCESS               0.057472            0.059488               0.966          [torch.Size([1024, 2560]), torch.Size([2560]), 1e-05]
SUCCESS               0.067712            0.069760               0.971          [torch.Size([1024, 3072]), torch.Size([3072]), 1e-05]
SUCCESS               0.079680            0.080000               0.996          [torch.Size([1024, 3584]), torch.Size([3584]), 1e-05]
SUCCESS               0.084064            0.086144               0.976          [torch.Size([1024, 3840]), torch.Size([3840]), 1e-05]
SUCCESS               0.100528            0.102896               0.977          [torch.Size([1024, 4608]), torch.Size([4608]), 1e-05]
SUCCESS               0.116832            0.120960               0.966          [torch.Size([1024, 5376]), torch.Size([5376]), 1e-05]
SUCCESS               0.008448            0.008448               1.000          [torch.Size([2048, 128]), torch.Size([128]), 1e-05]
SUCCESS               0.012544            0.012704               0.987          [torch.Size([2048, 256]), torch.Size([256]), 1e-05]
SUCCESS               0.045088            0.045184               0.998          [torch.Size([2048, 1024]), torch.Size([1024]), 1e-05]
SUCCESS               0.053376            0.053408               0.999          [torch.Size([2048, 1152]), torch.Size([1152]), 1e-05]
SUCCESS               0.088192            0.090240               0.977          [torch.Size([2048, 2048]), torch.Size([2048]), 1e-05]
SUCCESS               0.111104            0.112768               0.985          [torch.Size([2048, 2560]), torch.Size([2560]), 1e-05]
SUCCESS               0.133216            0.134752               0.989          [torch.Size([2048, 3072]), torch.Size([3072]), 1e-05]
SUCCESS               0.154144            0.155776               0.990          [torch.Size([2048, 3584]), torch.Size([3584]), 1e-05]
SUCCESS               0.166016            0.168064               0.988          [torch.Size([2048, 3840]), torch.Size([3840]), 1e-05]
SUCCESS               0.198784            0.201152               0.988          [torch.Size([2048, 4608]), torch.Size([4608]), 1e-05]
SUCCESS               0.231488            0.235200               0.984          [torch.Size([2048, 5376]), torch.Size([5376]), 1e-05]
SUCCESS               0.012544            0.012544               1.000          [torch.Size([4096, 128]), torch.Size([128]), 1e-05]
SUCCESS               0.026784            0.026720               1.002          [torch.Size([4096, 256]), torch.Size([256]), 1e-05]
SUCCESS               0.088192            0.089696               0.983          [torch.Size([4096, 1024]), torch.Size([1024]), 1e-05]
SUCCESS               0.100864            0.102528               0.984          [torch.Size([4096, 1152]), torch.Size([1152]), 1e-05]
SUCCESS               0.176256            0.178272               0.989          [torch.Size([4096, 2048]), torch.Size([2048]), 1e-05]
SUCCESS               0.220272            0.223408               0.986          [torch.Size([4096, 2560]), torch.Size([2560]), 1e-05]
SUCCESS               0.266304            0.268416               0.992          [torch.Size([4096, 3072]), torch.Size([3072]), 1e-05]
SUCCESS               0.307296            0.311424               0.987          [torch.Size([4096, 3584]), torch.Size([3584]), 1e-05]
SUCCESS               0.329936            0.333952               0.988          [torch.Size([4096, 3840]), torch.Size([3840]), 1e-05]
SUCCESS               0.395360            0.398432               0.992          [torch.Size([4096, 4608]), torch.Size([4608]), 1e-05]
SUCCESS               0.460800            0.465024               0.991          [torch.Size([4096, 5376]), torch.Size([5376]), 1e-05]


Operator: gemma_rmsnorm  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.004352            0.004384               0.993          [torch.Size([1, 128]), torch.Size([128]), 1e-05]
SUCCESS               0.004352            0.006128               0.710          [torch.Size([1, 256]), torch.Size([256]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 1024]), torch.Size([1024]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 1152]), torch.Size([1152]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 2048]), torch.Size([2048]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 2560]), torch.Size([2560]), 1e-05]
SUCCESS               0.006400            0.006400               1.000          [torch.Size([1, 3072]), torch.Size([3072]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 3584]), torch.Size([3584]), 1e-05]
SUCCESS               0.004352            0.006400               0.680          [torch.Size([1, 3840]), torch.Size([3840]), 1e-05]
SUCCESS               0.004400            0.008416               0.523          [torch.Size([1, 4608]), torch.Size([4608]), 1e-05]
SUCCESS               0.004416            0.008448               0.523          [torch.Size([1, 5376]), torch.Size([5376]), 1e-05]
SUCCESS               0.004352            0.004416               0.986          [torch.Size([256, 128]), torch.Size([128]), 1e-05]
SUCCESS               0.006400            0.006400               1.000          [torch.Size([256, 256]), torch.Size([256]), 1e-05]
SUCCESS               0.006400            0.006400               1.000          [torch.Size([256, 1024]), torch.Size([1024]), 1e-05]
SUCCESS               0.006400            0.006400               1.000          [torch.Size([256, 1152]), torch.Size([1152]), 1e-05]
SUCCESS               0.008448            0.008448               1.000          [torch.Size([256, 2048]), torch.Size([2048]), 1e-05]
SUCCESS               0.010496            0.011440               0.917          [torch.Size([256, 2560]), torch.Size([2560]), 1e-05]
SUCCESS               0.010528            0.011904               0.884          [torch.Size([256, 3072]), torch.Size([3072]), 1e-05]
SUCCESS               0.012544            0.012544               1.000          [torch.Size([256, 3584]), torch.Size([3584]), 1e-05]
SUCCESS               0.012544            0.014320               0.876          [torch.Size([256, 3840]), torch.Size([3840]), 1e-05]
SUCCESS               0.014656            0.016928               0.866          [torch.Size([256, 4608]), torch.Size([4608]), 1e-05]
SUCCESS               0.016640            0.018688               0.890          [torch.Size([256, 5376]), torch.Size([5376]), 1e-05]
SUCCESS               0.006400            0.006400               1.000          [torch.Size([1024, 128]), torch.Size([128]), 1e-05]
SUCCESS               0.006400            0.006400               1.000          [torch.Size([1024, 256]), torch.Size([256]), 1e-05]
SUCCESS               0.012512            0.012544               0.997          [torch.Size([1024, 1024]), torch.Size([1024]), 1e-05]
SUCCESS               0.014592            0.015232               0.958          [torch.Size([1024, 1152]), torch.Size([1152]), 1e-05]
SUCCESS               0.024704            0.024704               1.000          [torch.Size([1024, 2048]), torch.Size([2048]), 1e-05]
SUCCESS               0.030848            0.032896               0.938          [torch.Size([1024, 2560]), torch.Size([2560]), 1e-05]
SUCCESS               0.036960            0.036960               1.000          [torch.Size([1024, 3072]), torch.Size([3072]), 1e-05]
SUCCESS               0.041024            0.041216               0.995          [torch.Size([1024, 3584]), torch.Size([3584]), 1e-05]
SUCCESS               0.043184            0.046656               0.926          [torch.Size([1024, 3840]), torch.Size([3840]), 1e-05]
SUCCESS               0.051328            0.053376               0.962          [torch.Size([1024, 4608]), torch.Size([4608]), 1e-05]
SUCCESS               0.059520            0.061568               0.967          [torch.Size([1024, 5376]), torch.Size([5376]), 1e-05]
SUCCESS               0.006400            0.006400               1.000          [torch.Size([2048, 128]), torch.Size([128]), 1e-05]
SUCCESS               0.008448            0.008448               1.000          [torch.Size([2048, 256]), torch.Size([256]), 1e-05]
SUCCESS               0.024704            0.024704               1.000          [torch.Size([2048, 1024]), torch.Size([1024]), 1e-05]
SUCCESS               0.026752            0.028800               0.929          [torch.Size([2048, 1152]), torch.Size([1152]), 1e-05]
SUCCESS               0.047232            0.047232               1.000          [torch.Size([2048, 2048]), torch.Size([2048]), 1e-05]
SUCCESS               0.058496            0.059504               0.983          [torch.Size([2048, 2560]), torch.Size([2560]), 1e-05]
SUCCESS               0.067712            0.069760               0.971          [torch.Size([2048, 3072]), torch.Size([3072]), 1e-05]
SUCCESS               0.079680            0.080000               0.996          [torch.Size([2048, 3584]), torch.Size([3584]), 1e-05]
SUCCESS               0.082048            0.085536               0.959          [torch.Size([2048, 3840]), torch.Size([3840]), 1e-05]
SUCCESS               0.100448            0.102528               0.980          [torch.Size([2048, 4608]), torch.Size([4608]), 1e-05]
SUCCESS               0.116832            0.118912               0.983          [torch.Size([2048, 5376]), torch.Size([5376]), 1e-05]
SUCCESS               0.008416            0.008448               0.996          [torch.Size([4096, 128]), torch.Size([128]), 1e-05]
SUCCESS               0.012544            0.012544               1.000          [torch.Size([4096, 256]), torch.Size([256]), 1e-05]
SUCCESS               0.045184            0.047232               0.957          [torch.Size([4096, 1024]), torch.Size([1024]), 1e-05]
SUCCESS               0.052688            0.054608               0.965          [torch.Size([4096, 1152]), torch.Size([1152]), 1e-05]
SUCCESS               0.088256            0.090240               0.978          [torch.Size([4096, 2048]), torch.Size([2048]), 1e-05]
SUCCESS               0.110688            0.112768               0.982          [torch.Size([4096, 2560]), torch.Size([2560]), 1e-05]
SUCCESS               0.132976            0.133696               0.995          [torch.Size([4096, 3072]), torch.Size([3072]), 1e-05]
SUCCESS               0.153728            0.155776               0.987          [torch.Size([4096, 3584]), torch.Size([3584]), 1e-05]
SUCCESS               0.165552            0.167008               0.991          [torch.Size([4096, 3840]), torch.Size([3840]), 1e-05]
SUCCESS               0.198784            0.200800               0.990          [torch.Size([4096, 4608]), torch.Size([4608]), 1e-05]
SUCCESS               0.231104            0.234624               0.985          [torch.Size([4096, 5376]), torch.Size([5376]), 1e-05]
```
The bad case will be improved latter.