### PR TITLE
[QC][PPU] Add THead fused_marlin_moe_w4a16_int4 backend

### DIFF
--- a/benchmark/test_fused_marlin_moe_w4a16_int4.py
+++ b/benchmark/test_fused_marlin_moe_w4a16_int4.py
@@ -12,285 +12,293 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Benchmark W4A16 INT4 fused Marlin MoE against the vLLM implementation."""
+
 import pytest
 import torch
 
-# vLLM imports (baseline). Optional: when vllm is not installed (e.g. in CI),
-# the entire benchmark is skipped via the skipif marker below.
+import flaggems_vllm
+from flaggems_vllm.ops.fused_marlin_moe import QUANT_TYPE_UINT4B8
+
+from . import base
+
 try:
+    from vllm import _custom_ops as vllm_ops
     from vllm.model_executor.layers.fused_moe.fused_marlin_moe import (
         fused_marlin_moe as vllm_fused_marlin_moe,
     )
-    from vllm.model_executor.layers.quantization.utils.marlin_utils_test import (
-        marlin_quantize,
-    )
-    from vllm.model_executor.layers.quantization.utils.quant_utils import (
-        quantize_weights,
+    from vllm.model_executor.layers.quantization.utils.marlin_utils import (
+        marlin_moe_permute_scales,
     )
     from vllm.scalar_type import scalar_types
 
-    VLLM_QUANT_TYPE = scalar_types.uint4b8
     HAS_VLLM_FUSED_MARLIN_MOE = True
 except ImportError:
     HAS_VLLM_FUSED_MARLIN_MOE = False
 
-import flaggems_vllm
-
-# FlagGems wrapper under test
-from flaggems_vllm.ops.fused_marlin_moe import QUANT_TYPE_UINT4B8
-from flaggems_vllm.ops.fused_marlin_moe import fused_marlin_moe as gems_fused_marlin_moe
-
-from . import base
-
-
-def is_cuda_available():
-    if flaggems_vllm.device != "cuda":
-        return False
-    major, minor = torch.cuda.get_device_capability()
-    sm_version_num = major * 10 + minor
-    return sm_version_num >= 90 and sm_version_num < 100
-
-
-CUDA_AVAILABLE = is_cuda_available()
 
 GROUP_SIZE = 128
+MODEL_GEOMETRY = (256, 4096, 256, 6)
+PR5140_TRACE = (
+    (1, 172),
+    (2, 172),
+    (4, 172),
+    (8, 172),
+    (16, 172),
+    (24, 172),
+    (32, 172),
+    (40, 172),
+    (48, 172),
+    (56, 172),
+    (64, 172),
+    (72, 172),
+    (80, 172),
+    (88, 172),
+    (96, 172),
+    (104, 172),
+    (112, 172),
+    (120, 172),
+    (128, 172),
+    (136, 172),
+    (144, 172),
+    (152, 172),
+    (160, 172),
+    (168, 172),
+    (176, 172),
+    (184, 172),
+    (192, 172),
+    (200, 172),
+    (208, 172),
+    (216, 172),
+    (224, 172),
+    (232, 172),
+    (240, 172),
+    (248, 172),
+    (256, 172),
+    (272, 172),
+    (288, 172),
+    (304, 172),
+    (320, 172),
+    (336, 172),
+    (352, 172),
+    (368, 172),
+    (384, 172),
+    (400, 172),
+    (416, 172),
+    (432, 172),
+    (448, 172),
+    (464, 172),
+    (480, 172),
+    (496, 344),
+    (512, 344),
+    (2048, 43),
+    (16384, 946),
+)
 
 
-def _wna16_quantize_per_expert(w_fp):
-    """
-    Per-expert GPTQ-style INT4 quantization for FlagGems wna16 kernel layout.
-
-    Input  w_fp: (E, out_dim, in_dim), bf16/fp16
-    Output w_q:   (E, out_dim, in_dim // 2), uint8 (two nibbles per byte)
-           scales: (E, out_dim, in_dim // GROUP_SIZE), same dtype as w_fp
-    """
-    E, out_dim, in_dim = w_fp.shape
-    assert in_dim % GROUP_SIZE == 0
-    w_q = torch.empty(E, out_dim, in_dim // 2, device=w_fp.device, dtype=torch.uint8)
-    scales = torch.empty(
-        E, out_dim, in_dim // GROUP_SIZE, device=w_fp.device, dtype=w_fp.dtype
+def _pack_gptq_int32(weight):
+    """Convert output-major uint8 pairs to GPTQ INT32 packing."""
+    experts, output_size, packed_k = weight.shape
+    packed = torch.empty(
+        (experts, packed_k // 4, output_size),
+        device=weight.device,
+        dtype=torch.int32,
     )
-    for e in range(E):
-        _, q_e, sc_e, _ = quantize_weights(
-            w_fp[e].T, VLLM_QUANT_TYPE, GROUP_SIZE, False, False
+    for expert in range(experts):
+        bytes4 = weight[expert].to(torch.int32).reshape(
+            output_size, packed_k // 4, 4
         )
-        q_e = q_e.T.contiguous().to(torch.uint8)
-        sc_e = sc_e.T
-        w_q[e] = q_e[:, 1::2] * 16 + q_e[:, ::2]
-        scales[e] = sc_e
-    return w_q, scales
-
-
-def _marlin_quantize_per_expert(w_fp):
-    """
-    Per-expert Marlin-layout INT4 quantization for vLLM's fused_marlin_moe.
-
-    Input  w_fp: (E, out_dim, in_dim), bf16/fp16
-    Output qweight: stacked (E, ...), int32 (Marlin packed layout)
-           scales:  stacked (E, ...), same dtype as w_fp
-    """
-    qweight_l, scales_l = [], []
-    E = w_fp.shape[0]
-    for e in range(E):
-        # marlin_quantize expects (in_dim, out_dim)
-        _, qw, sc, _, _, _ = marlin_quantize(
-            w_fp[e].T.contiguous(), VLLM_QUANT_TYPE, GROUP_SIZE, act_order=False
+        words = (
+            bytes4[..., 0]
+            | (bytes4[..., 1] << 8)
+            | (bytes4[..., 2] << 16)
+            | (bytes4[..., 3] << 24)
         )
-        qweight_l.append(qw)
-        scales_l.append(sc)
-    qweight = torch.stack(qweight_l, dim=0).contiguous()
-    scales = torch.stack(scales_l, dim=0).contiguous()
+        packed[expert].copy_(words.transpose(0, 1))
+    return packed
+
+
+def _to_vllm_marlin(weight, scales, size_k, size_n):
+    qweight = _pack_gptq_int32(weight)
+    empty_perm = torch.empty(
+        (weight.size(0), 0), device=weight.device, dtype=torch.int32
+    )
+    qweight = vllm_ops.gptq_marlin_moe_repack(
+        qweight,
+        empty_perm,
+        size_k=size_k,
+        size_n=size_n,
+        num_bits=4,
+    )
+    scales = marlin_moe_permute_scales(
+        scales.transpose(1, 2).contiguous(),
+        size_k=size_k,
+        size_n=size_n,
+        group_size=GROUP_SIZE,
+    )
     return qweight, scales
 
 
+def _make_weights(num_experts, hidden_size, intermediate_size, dtype):
+    torch.manual_seed(7)
+    device = flaggems_vllm.device
+    w1 = torch.randint(
+        0,
+        256,
+        (num_experts, 2 * intermediate_size, hidden_size // 2),
+        device=device,
+        dtype=torch.uint8,
+    )
+    w2 = torch.randint(
+        0,
+        256,
+        (num_experts, hidden_size, intermediate_size // 2),
+        device=device,
+        dtype=torch.uint8,
+    )
+    w1_scale = (
+        torch.rand(
+            (num_experts, 2 * intermediate_size, hidden_size // GROUP_SIZE),
+            device=device,
+            dtype=dtype,
+        )
+        * 0.03
+    )
+    w2_scale = (
+        torch.rand(
+            (num_experts, hidden_size, intermediate_size // GROUP_SIZE),
+            device=device,
+            dtype=dtype,
+        )
+        * 0.03
+    )
+    vllm_w1, vllm_w1_scale = _to_vllm_marlin(
+        w1, w1_scale, hidden_size, 2 * intermediate_size
+    )
+    vllm_w2, vllm_w2_scale = _to_vllm_marlin(
+        w2, w2_scale, intermediate_size, hidden_size
+    )
+    return (
+        w1,
+        w2,
+        w1_scale,
+        w2_scale,
+        vllm_w1,
+        vllm_w2,
+        vllm_w1_scale,
+        vllm_w2_scale,
+    )
+
+
 class FusedMarlinMoEW4A16INT4Benchmark(base.Benchmark):
-    """
-    Benchmark for fused_marlin_moe W4A16 INT4 (fused-dequant MoE GEMM).
-
-    Compares FlagGems' Triton wna16 kernel against vLLM's Marlin CUDA kernel.
-    Both consume per-group-128 GPTQ uint4b8 weights (different packed layouts).
-    """
-
-    def __init__(self, op_name, torch_op, dtypes):
-        super().__init__(op_name=op_name, torch_op=torch_op, dtypes=dtypes)
+    """Use the production trace from FlagGems PR 5140."""
 
     def set_shapes(self, shape_file_path=None):
-        # The three production MoE architectures from profile_fused_marlin_moe.py
-        # over the decode token range (1 .. 256).
+        num_experts, hidden_size, intermediate_size, top_k = MODEL_GEOMETRY
         self.shapes = [
-            # Mixtral-8x7B
-            (1, 8, 4096, 14336, 2),
-            (4, 8, 4096, 14336, 2),
-            (8, 8, 4096, 14336, 2),
-            (16, 8, 4096, 14336, 2),
-            (32, 8, 4096, 14336, 2),
-            (64, 8, 4096, 14336, 2),
-            (128, 8, 4096, 14336, 2),
-            (256, 8, 4096, 14336, 2),
-            # DeepSeek-V3 (TP=8 shard)
-            (1, 256, 7168, 2048, 8),
-            (4, 256, 7168, 2048, 8),
-            (8, 256, 7168, 2048, 8),
-            (16, 256, 7168, 2048, 8),
-            (32, 256, 7168, 2048, 8),
-            (64, 256, 7168, 2048, 8),
-            (128, 256, 7168, 2048, 8),
-            (256, 256, 7168, 2048, 8),
-            # Qwen3-5-397B-A17B
-            (1, 512, 4096, 1024, 10),
-            (4, 512, 4096, 1024, 10),
-            (8, 512, 4096, 1024, 10),
-            (16, 512, 4096, 1024, 10),
-            (32, 512, 4096, 1024, 10),
-            (64, 512, 4096, 1024, 10),
-            (128, 512, 4096, 1024, 10),
-            (256, 512, 4096, 1024, 10),
-            # DeepSeek-V4-Flash
-            (1, 256, 4096, 2048, 6),
-            (4, 256, 4096, 2048, 6),
-            (8, 256, 4096, 2048, 6),
-            (16, 256, 4096, 2048, 6),
-            (32, 256, 4096, 2048, 6),
-            (64, 256, 4096, 2048, 6),
-            (128, 256, 4096, 2048, 6),
-            (256, 256, 4096, 2048, 6),
+            (m, num_experts, hidden_size, intermediate_size, top_k, count)
+            for m, count in PR5140_TRACE
         ]
+        self.shape_desc = "M, E, K, N, top_k, call_count"
 
-    def get_input_iter(self, cur_dtype):
-        for config in self.shapes:
-            yield from self._gen(config, cur_dtype)
-
-    def _gen(self, config, dtype):
-        num_tokens, num_experts, hidden_size, intermediate_size, topk = config
-        device = flaggems_vllm.device
-
-        hidden_states = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype)
-
-        # Original FP weights (kept only as source for both quantizers).
-        w1_fp = (
-            torch.randn(
-                num_experts,
-                intermediate_size * 2,
-                hidden_size,
-                device=device,
-                dtype=dtype,
+    def get_input_iter(self, dtype):
+        num_experts, hidden_size, intermediate_size, top_k = MODEL_GEOMETRY
+        weights = _make_weights(
+            num_experts, hidden_size, intermediate_size, dtype
+        )
+        for num_tokens, call_count in PR5140_TRACE:
+            torch.manual_seed(7 + num_tokens)
+            hidden_states = (
+                torch.randn(
+                    (num_tokens, hidden_size),
+                    device=flaggems_vllm.device,
+                    dtype=dtype,
+                )
+                * 0.1
             )
-            / 10.0
-        )
-        w2_fp = (
-            torch.randn(
-                num_experts,
-                hidden_size,
-                intermediate_size,
-                device=device,
-                dtype=dtype,
+            topk_ids = (
+                torch.rand(
+                    (num_tokens, num_experts), device=flaggems_vllm.device
+                )
+                .topk(top_k, dim=-1)
+                .indices
             )
-            / 10.0
-        )
-
-        # FlagGems wna16 layout
-        w1_q_wna16, w1_scale_wna16 = _wna16_quantize_per_expert(w1_fp)
-        w2_q_wna16, w2_scale_wna16 = _wna16_quantize_per_expert(w2_fp)
-
-        # vLLM Marlin layout
-        w1_q_marlin, w1_scale_marlin = _marlin_quantize_per_expert(w1_fp)
-        w2_q_marlin, w2_scale_marlin = _marlin_quantize_per_expert(w2_fp)
-
-        del w1_fp, w2_fp
-        torch.cuda.empty_cache()
-
-        # Routing
-        gating = torch.randn(
-            num_tokens, num_experts, device=device, dtype=torch.float32
-        )
-        topk_weights, topk_ids = torch.topk(torch.softmax(gating, dim=-1), topk, dim=-1)
-        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
-        # vLLM requires fp32 topk_weights; FlagGems wrapper is dtype-agnostic.
-
-        # Both ops get the same tuple; each picks what it needs.
-        yield (
-            hidden_states,
-            w1_q_wna16,
-            w2_q_wna16,
-            w1_scale_wna16,
-            w2_scale_wna16,
-            w1_q_marlin,
-            w2_q_marlin,
-            w1_scale_marlin,
-            w2_scale_marlin,
-            topk_weights,
-            topk_ids,
-        )
+            topk_weights = torch.softmax(
+                torch.randn(
+                    (num_tokens, top_k), device=flaggems_vllm.device
+                ),
+                dim=-1,
+            ).to(torch.float32)
+            yield (hidden_states, *weights, topk_weights, topk_ids, call_count)
 
 
 def _vllm_baseline(
     hidden_states,
-    w1_q_wna16,
-    w2_q_wna16,
-    w1_scale_wna16,
-    w2_scale_wna16,
-    w1_q_marlin,
-    w2_q_marlin,
-    w1_scale_marlin,
-    w2_scale_marlin,
+    w1,
+    w2,
+    w1_scale,
+    w2_scale,
+    vllm_w1,
+    vllm_w2,
+    vllm_w1_scale,
+    vllm_w2_scale,
     topk_weights,
     topk_ids,
+    call_count,
 ):
-    """Baseline: vLLM's CUDA Marlin fused_marlin_moe."""
+    del w1, w2, w1_scale, w2_scale, call_count
     return vllm_fused_marlin_moe(
-        hidden_states=hidden_states,
-        w1=w1_q_marlin,
-        w2=w2_q_marlin,
-        bias1=None,
-        bias2=None,
-        w1_scale=w1_scale_marlin,
-        w2_scale=w2_scale_marlin,
-        topk_weights=topk_weights,
-        topk_ids=topk_ids,
-        quant_type_id=VLLM_QUANT_TYPE.id,
+        hidden_states,
+        vllm_w1,
+        vllm_w2,
+        None,
+        None,
+        vllm_w1_scale,
+        vllm_w2_scale,
+        None,
+        topk_weights,
+        topk_ids,
+        scalar_types.uint4b8.id,
     )
 
 
 def _gems_call(
     hidden_states,
-    w1_q_wna16,
-    w2_q_wna16,
-    w1_scale_wna16,
-    w2_scale_wna16,
-    w1_q_marlin,
-    w2_q_marlin,
-    w1_scale_marlin,
-    w2_scale_marlin,
+    w1,
+    w2,
+    w1_scale,
+    w2_scale,
+    vllm_w1,
+    vllm_w2,
+    vllm_w1_scale,
+    vllm_w2_scale,
     topk_weights,
     topk_ids,
+    call_count,
 ):
-    """FlagGems' Triton wna16 fused_marlin_moe (Phase 2)."""
-    return gems_fused_marlin_moe(
-        hidden_states=hidden_states,
-        w1=w1_q_wna16,
-        w2=w2_q_wna16,
-        bias1=None,
-        bias2=None,
-        w1_scale=w1_scale_wna16,
-        w2_scale=w2_scale_wna16,
-        topk_weights=topk_weights,
-        topk_ids=topk_ids,
-        quant_type_id=QUANT_TYPE_UINT4B8,
+    del vllm_w1, vllm_w2, vllm_w1_scale, vllm_w2_scale, call_count
+    return flaggems_vllm.fused_marlin_moe(
+        hidden_states,
+        w1,
+        w2,
+        None,
+        None,
+        w1_scale,
+        w2_scale,
+        topk_weights,
+        topk_ids,
+        QUANT_TYPE_UINT4B8,
     )
 
 
 @pytest.mark.fused_marlin_moe
 @pytest.mark.skipif(
-    not HAS_VLLM_FUSED_MARLIN_MOE, reason="vllm not installed; baseline unavailable"
+    not HAS_VLLM_FUSED_MARLIN_MOE,
+    reason="vLLM fused_marlin_moe is not installed",
 )
-@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires NVIDIA Hopper architecture")
 def test_fused_marlin_moe_w4a16_int4():
-    """
-    Benchmark FlagGems fused_marlin_moe (Triton wna16) vs vLLM fused_marlin_moe
-    (CUDA Marlin). Both run GPTQ uint4b8 + per-group-128 W4A16 GEMM.
-    """
     bench = FusedMarlinMoEW4A16INT4Benchmark(
-        op_name="fused_marlin_moe_w4a16_int4",
+        op_name="fused_marlin_moe",
         torch_op=_vllm_baseline,
         dtypes=[torch.bfloat16],
     )

--- a/benchmark/test_fused_marlin_moe_w4a16_int4.py
+++ b/benchmark/test_fused_marlin_moe_w4a16_int4.py
@@ -269,7 +269,7 @@ def _gems_call(
     call_count,
 ):
     del vllm_w1, vllm_w2, vllm_w1_scale, vllm_w2_scale, call_count
-    return flaggems_vllm.fused_marlin_moe(
+    return flaggems_vllm.fused_marlin_moe_w4a16_int4(
         hidden_states,
         w1,
         w2,
@@ -283,7 +283,7 @@ def _gems_call(
     )
 
 
-@pytest.mark.fused_marlin_moe
+@pytest.mark.fused_marlin_moe_w4a16_int4
 @pytest.mark.skipif(
     not HAS_VLLM_FUSED_MARLIN_MOE,
     reason="vLLM fused_marlin_moe is not installed",

--- a/benchmark/test_fused_marlin_moe_w4a16_int4.py
+++ b/benchmark/test_fused_marlin_moe_w4a16_int4.py
@@ -105,9 +105,7 @@ def _pack_gptq_int32(weight):
         dtype=torch.int32,
     )
     for expert in range(experts):
-        bytes4 = weight[expert].to(torch.int32).reshape(
-            output_size, packed_k // 4, 4
-        )
+        bytes4 = weight[expert].to(torch.int32).reshape(output_size, packed_k // 4, 4)
         words = (
             bytes4[..., 0]
             | (bytes4[..., 1] << 8)
@@ -203,9 +201,7 @@ class FusedMarlinMoEW4A16INT4Benchmark(base.Benchmark):
 
     def get_input_iter(self, dtype):
         num_experts, hidden_size, intermediate_size, top_k = MODEL_GEOMETRY
-        weights = _make_weights(
-            num_experts, hidden_size, intermediate_size, dtype
-        )
+        weights = _make_weights(num_experts, hidden_size, intermediate_size, dtype)
         for num_tokens, call_count in PR5140_TRACE:
             torch.manual_seed(7 + num_tokens)
             hidden_states = (
@@ -217,16 +213,12 @@ class FusedMarlinMoEW4A16INT4Benchmark(base.Benchmark):
                 * 0.1
             )
             topk_ids = (
-                torch.rand(
-                    (num_tokens, num_experts), device=flaggems_vllm.device
-                )
+                torch.rand((num_tokens, num_experts), device=flaggems_vllm.device)
                 .topk(top_k, dim=-1)
                 .indices
             )
             topk_weights = torch.softmax(
-                torch.randn(
-                    (num_tokens, top_k), device=flaggems_vllm.device
-                ),
+                torch.randn((num_tokens, top_k), device=flaggems_vllm.device),
                 dim=-1,
             ).to(torch.float32)
             yield (hidden_states, *weights, topk_weights, topk_ids, call_count)
@@ -298,7 +290,7 @@ def _gems_call(
 )
 def test_fused_marlin_moe_w4a16_int4():
     bench = FusedMarlinMoEW4A16INT4Benchmark(
-        op_name="fused_marlin_moe",
+        op_name="fused_marlin_moe_w4a16_int4",
         torch_op=_vllm_baseline,
         dtypes=[torch.bfloat16],
     )

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -423,7 +423,7 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.3'
-  - id: fused_marlin_moe
+  - id: fused_marlin_moe_w4a16_int4
     description: |
       Computes a fused mixture-of-experts feed-forward network with packed
       Marlin quantized weights.

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -423,6 +423,21 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.3'
+  - id: fused_marlin_moe
+    description: |
+      Computes a fused mixture-of-experts feed-forward network with packed
+      Marlin quantized weights.
+    for:
+      - vllm.model_executor.layers.fused_moe.fused_marlin_moe.fused_marlin_moe
+    labels:
+      - fused
+      - vLLM
+      - MoE
+      - Quantization
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.4'
   - id: fused_q_kv_rmsnorm
     description: |
       Applies RMSNorm to Q and KV tensors in a single fused kernel for DeepSeekV4 attention.

--- a/src/flaggems_vllm/ops/__init__.py
+++ b/src/flaggems_vllm/ops/__init__.py
@@ -58,6 +58,7 @@ from flaggems_vllm.ops.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert import 
 )
 from flaggems_vllm.ops.fused_inv_rope_fp8_quant import fused_inv_rope_fp8_quant
 from flaggems_vllm.ops.fused_indexer_q_rope_quant import fused_indexer_q_rope_quant
+from flaggems_vllm.ops.fused_marlin_moe import fused_marlin_moe
 from flaggems_vllm.ops.fused_moe import (
     dispatch_fused_moe_kernel,
     fused_experts_impl,
@@ -180,6 +181,7 @@ __all__ = [
     "fused_experts_impl",
     "fused_indexer_q_rope_quant",
     "fused_inv_rope_fp8_quant",
+    "fused_marlin_moe",
     "fused_q_kv_rmsnorm",
     "fused_recurrent_gated_delta_rule_fwd",
     "geglu",

--- a/src/flaggems_vllm/ops/__init__.py
+++ b/src/flaggems_vllm/ops/__init__.py
@@ -59,6 +59,7 @@ from flaggems_vllm.ops.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert import 
 from flaggems_vllm.ops.fused_inv_rope_fp8_quant import fused_inv_rope_fp8_quant
 from flaggems_vllm.ops.fused_indexer_q_rope_quant import fused_indexer_q_rope_quant
 from flaggems_vllm.ops.fused_marlin_moe import fused_marlin_moe
+from flaggems_vllm.ops.fused_marlin_moe_w4a16_int4 import fused_marlin_moe_w4a16_int4
 from flaggems_vllm.ops.fused_moe import (
     dispatch_fused_moe_kernel,
     fused_experts_impl,
@@ -182,6 +183,7 @@ __all__ = [
     "fused_indexer_q_rope_quant",
     "fused_inv_rope_fp8_quant",
     "fused_marlin_moe",
+    "fused_marlin_moe_w4a16_int4",
     "fused_q_kv_rmsnorm",
     "fused_recurrent_gated_delta_rule_fwd",
     "geglu",

--- a/src/flaggems_vllm/ops/fused_marlin_moe_w4a16_int4.py
+++ b/src/flaggems_vllm/ops/fused_marlin_moe_w4a16_int4.py
@@ -1,0 +1,66 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Any, Callable, Optional
+
+import torch
+
+from flaggems_vllm.ops.fused_marlin_moe import (
+    fused_marlin_moe as _generic_fused_marlin_moe,
+)
+
+
+def fused_marlin_moe_w4a16_int4(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    bias1: Optional[torch.Tensor],
+    bias2: Optional[torch.Tensor],
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    quant_type_id: int,
+    apply_router_weight_on_input: bool = False,
+    global_num_experts: int = -1,
+    activation: Any = None,
+    activation_func: Optional[Callable] = None,
+    moe_sum: Optional[Callable] = None,
+    expert_map: Optional[torch.Tensor] = None,
+    input_global_scale1: Optional[torch.Tensor] = None,
+    input_global_scale2: Optional[torch.Tensor] = None,
+    global_scale1: Optional[torch.Tensor] = None,
+    global_scale2: Optional[torch.Tensor] = None,
+    g_idx1: Optional[torch.Tensor] = None,
+    g_idx2: Optional[torch.Tensor] = None,
+    sort_indices1: Optional[torch.Tensor] = None,
+    sort_indices2: Optional[torch.Tensor] = None,
+    w1_zeros: Optional[torch.Tensor] = None,
+    w2_zeros: Optional[torch.Tensor] = None,
+    workspace: Optional[torch.Tensor] = None,
+    intermediate_cache13: Optional[torch.Tensor] = None,
+    intermediate_cache2: Optional[torch.Tensor] = None,
+    is_k_full: bool = True,
+    output: Optional[torch.Tensor] = None,
+    input_dtype: Optional[torch.dtype] = None,
+    inplace: bool = False,
+    clamp_limit: Optional[float] = None,
+    group_size: int = 128,
+) -> torch.Tensor:
+    """W4A16_INT4 entry point, specialized by the selected backend."""
+    return _generic_fused_marlin_moe(**locals())
+
+
+__all__ = ["fused_marlin_moe_w4a16_int4"]

--- a/src/flaggems_vllm/runtime/backend/_thead/fused/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_thead/fused/__init__.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from flaggems_vllm.runtime.backend._thead.fused.fused_marlin_moe import (
-    fused_marlin_moe,
+from flaggems_vllm.runtime.backend._thead.fused.fused_marlin_moe_w4a16_int4 import (
+    fused_marlin_moe_w4a16_int4,
 )
 
-__all__ = ["fused_marlin_moe"]
+__all__ = ["fused_marlin_moe_w4a16_int4"]

--- a/src/flaggems_vllm/runtime/backend/_thead/fused/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_thead/fused/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from flaggems_vllm.runtime.backend._thead.fused.fused_marlin_moe import (
+    fused_marlin_moe,
+)
+
+__all__ = ["fused_marlin_moe"]

--- a/src/flaggems_vllm/runtime/backend/_thead/fused/fused_marlin_moe.py
+++ b/src/flaggems_vllm/runtime/backend/_thead/fused/fused_marlin_moe.py
@@ -28,13 +28,17 @@ except ImportError:  # pragma: no cover - requires a TLE-enabled FlagTree build
 from flaggems_vllm import runtime
 from flaggems_vllm.ops.fused_marlin_moe import (
     QUANT_TYPE_UINT4B8,
-    _RouterWeightPlacement,
     _invoke_w4a16_int4_moe_gemm,
     _invoke_w4a16_int4_moe_gemm_silu,
     _router_weight_placement,
+    _RouterWeightPlacement,
     _select_w4a16_int4_kernel_policy,
     _stack_8,
+)
+from flaggems_vllm.ops.fused_marlin_moe import (
     fused_marlin_moe as _generic_fused_marlin_moe,
+)
+from flaggems_vllm.ops.fused_marlin_moe import (
     w4a16_int4_pack,
 )
 from flaggems_vllm.ops.moe_align_block_size import moe_align_block_size
@@ -43,6 +47,19 @@ from flaggems_vllm.ops.silu_and_mul import silu_and_mul_out
 from flaggems_vllm.utils import libentry
 
 _PPU_DIRECT_ROUTE_LIMIT = 32
+
+
+def _activation_name(activation: Any) -> str:
+    if activation is None:
+        return "silu"
+    if isinstance(activation, str):
+        return activation.lower()
+    for attr in ("value", "name"):
+        value = getattr(activation, attr, None)
+        if isinstance(value, str):
+            return value.lower()
+    return ""
+
 
 @triton.jit
 def _ppu_dequant_int4(b_packed, scale, compute_type: tl.constexpr):
@@ -125,9 +142,7 @@ if tle_async is not None:
         )
         acc = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32)
 
-        for k_tile in tl.range(
-            0, tl.cdiv(K, BLOCK_SIZE_K), num_stages=PIPELINE_STAGES
-        ):
+        for k_tile in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K), num_stages=PIPELINE_STAGES):
             a = tle_async.load(
                 a_block_ptr,
                 boundary_check=(0, 1),
@@ -215,9 +230,7 @@ if tle_async is not None:
         for topk_index in tl.range(0, TOP_K):
             route = token * TOP_K + topk_index
             expert = tl.load(topk_ids_ptr + route).to(tl.int64)
-            route_acc = tl.zeros(
-                (BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32
-            )
+            route_acc = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32)
             a_block_ptr = tl.make_block_ptr(
                 base=a_ptr + route * stride_am,
                 shape=(1, K),
@@ -263,28 +276,20 @@ if tle_async is not None:
                 )[None, :]
                 bs = _ppu_dequant_int4(b_packed, scale, compute_type)
                 b = _stack_8(bs, BLOCK_SIZE_K_PACK, BLOCK_SIZE_N)
-                route_acc = tl.dot(
-                    tl.trans(b), tl.trans(a), acc=route_acc
-                )
+                route_acc = tl.dot(tl.trans(b), tl.trans(a), acc=route_acc)
 
                 a_block_ptr = tl.advance(a_block_ptr, (0, BLOCK_SIZE_K))
-                b_block_ptr = tl.advance(
-                    b_block_ptr, (BLOCK_SIZE_K_PACK, 0)
-                )
+                b_block_ptr = tl.advance(b_block_ptr, (BLOCK_SIZE_K_PACK, 0))
 
             if MUL_ROUTED_WEIGHT:
-                routed_weight = tl.load(topk_weights_ptr + route).to(
-                    tl.float32
-                )
+                routed_weight = tl.load(topk_weights_ptr + route).to(tl.float32)
                 route_acc *= routed_weight
             acc += route_acc
 
         offs_m = tl.arange(0, BLOCK_SIZE_M)
         offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
         c_ptrs = (
-            c_ptr
-            + (token + offs_m[None, :]) * stride_cm
-            + offs_n[:, None] * stride_cn
+            c_ptr + (token + offs_m[None, :]) * stride_cm + offs_n[:, None] * stride_cn
         )
         tl.store(
             c_ptrs,
@@ -357,9 +362,7 @@ if tle_async is not None:
         acc_gate = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32)
         acc_up = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32)
 
-        for k_tile in tl.range(
-            0, tl.cdiv(K, BLOCK_SIZE_K), num_stages=PIPELINE_STAGES
-        ):
+        for k_tile in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K), num_stages=PIPELINE_STAGES):
             a = tle_async.load(
                 a_block_ptr,
                 boundary_check=(0, 1),
@@ -387,17 +390,13 @@ if tle_async is not None:
                 + scale_group * stride_bsg
                 + offs_n * stride_bsn
             )
-            scale_gate = tl.load(
-                scale_base, mask=offs_n < N, other=0.0
-            )[None, :]
+            scale_gate = tl.load(scale_base, mask=offs_n < N, other=0.0)[None, :]
             scale_up = tl.load(
                 scale_base + N * stride_bsn,
                 mask=offs_n < N,
                 other=0.0,
             )[None, :]
-            gate_bs = _ppu_dequant_int4(
-                b_gate_packed, scale_gate, compute_type
-            )
+            gate_bs = _ppu_dequant_int4(b_gate_packed, scale_gate, compute_type)
             up_bs = _ppu_dequant_int4(b_up_packed, scale_up, compute_type)
             gate_b = _stack_8(gate_bs, BLOCK_SIZE_K_PACK, BLOCK_SIZE_N)
             up_b = _stack_8(up_bs, BLOCK_SIZE_K_PACK, BLOCK_SIZE_N)
@@ -406,12 +405,8 @@ if tle_async is not None:
             acc_up = tl.dot(tl.trans(up_b), a_trans, acc=acc_up)
 
             a_block_ptr = tl.advance(a_block_ptr, (0, BLOCK_SIZE_K))
-            b_gate_block_ptr = tl.advance(
-                b_gate_block_ptr, (BLOCK_SIZE_K_PACK, 0)
-            )
-            b_up_block_ptr = tl.advance(
-                b_up_block_ptr, (BLOCK_SIZE_K_PACK, 0)
-            )
+            b_gate_block_ptr = tl.advance(b_gate_block_ptr, (BLOCK_SIZE_K_PACK, 0))
+            b_up_block_ptr = tl.advance(b_up_block_ptr, (BLOCK_SIZE_K_PACK, 0))
 
         if APPLY_ROUTER_WEIGHT_BEFORE_SILU:
             routed_weight = tl.load(topk_weights_ptr + route).to(tl.float32)
@@ -422,16 +417,13 @@ if tle_async is not None:
         offs_m = tl.arange(0, BLOCK_SIZE_M)
         offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
         c_ptrs = (
-            c_ptr
-            + (route + offs_m[None, :]) * stride_cm
-            + offs_n[:, None] * stride_cn
+            c_ptr + (route + offs_m[None, :]) * stride_cm + offs_n[:, None] * stride_cn
         )
         tl.store(
             c_ptrs,
             acc.to(compute_type),
             mask=(offs_m[None, :] == 0) & (offs_n[:, None] < N),
         )
-
 
     @triton.jit
     def _ppu_stage_routed_activations_kernel(
@@ -518,9 +510,7 @@ if tle_async is not None:
         )
 
     @libentry()
-    @triton.jit(
-        do_not_specialize_on_alignment=["routed_a_ptr", "b_ptr", "c_ptr"]
-    )
+    @triton.jit(do_not_specialize_on_alignment=["routed_a_ptr", "b_ptr", "c_ptr"])
     def _ppu_w4a16_int4_moe_gemm_grouped_kernel(
         routed_a_ptr,
         b_ptr,
@@ -580,9 +570,7 @@ if tle_async is not None:
         if expert == -1:
             zeros = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=compute_type)
             tl.store(
-                c_ptr
-                + routed_token[None, :] * stride_cm
-                + offs_n[:, None] * stride_cn,
+                c_ptr + routed_token[None, :] * stride_cm + offs_n[:, None] * stride_cn,
                 zeros,
                 mask=token_mask[None, :] & (offs_n[:, None] < N),
             )
@@ -606,9 +594,7 @@ if tle_async is not None:
         )
         acc = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32)
 
-        for k_tile in tl.range(
-            0, tl.cdiv(K, BLOCK_SIZE_K), num_stages=PIPELINE_STAGES
-        ):
+        for k_tile in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K), num_stages=PIPELINE_STAGES):
             activation = tle_async.load(
                 a_block_ptr,
                 boundary_check=(0, 1),
@@ -645,12 +631,12 @@ if tle_async is not None:
             acc *= routed_weight[None, :]
 
         tl.store(
-            c_ptr
-            + routed_token[None, :] * stride_cm
-            + offs_n[:, None] * stride_cn,
+            c_ptr + routed_token[None, :] * stride_cm + offs_n[:, None] * stride_cn,
             acc.to(compute_type),
             mask=token_mask[None, :] & (offs_n[:, None] < N),
         )
+
+
 def _select_ppu_direct_block_n(n: int) -> int:
     if n <= 32:
         return 32
@@ -923,7 +909,9 @@ def _silu_and_stage_ppu_grouped(
     block_m: int,
 ) -> torch.Tensor:
     n = intermediate1.size(1) // 2
-    routed = torch.empty((em, n), dtype=intermediate1.dtype, device=intermediate1.device)
+    routed = torch.empty(
+        (em, n), dtype=intermediate1.dtype, device=intermediate1.device
+    )
     grid = (triton.cdiv(em, block_m), triton.cdiv(n, 128))
     _ppu_silu_and_stage_routed_kernel[grid](
         intermediate1,
@@ -1097,14 +1085,11 @@ def fused_marlin_moe_w4a16_int4(
     # batches stay on the expert-grouped W4A16 kernel. Do not force the fused
     # grouped variant: its two live accumulators increase register pressure.
     use_fused_gemm1_silu = policy.use_fused_gemm1_silu or use_ppu_direct_route
-    move_router_weight_before_gemm2 = (
-        policy.move_router_weight_before_gemm2
-        or (
-            is_ppu
-            and use_fused_gemm1_silu
-            and not apply_router_weight_on_input
-            and M >= 512
-        )
+    move_router_weight_before_gemm2 = policy.move_router_weight_before_gemm2 or (
+        is_ppu
+        and use_fused_gemm1_silu
+        and not apply_router_weight_on_input
+        and M >= 512
     )
     router_weight_placement = _router_weight_placement(
         apply_router_weight_on_input,
@@ -1117,21 +1102,17 @@ def fused_marlin_moe_w4a16_int4(
     if not use_ppu_reduce_direct:
         cache13_size = M * top_k_num * K
         if not use_fused_gemm1_silu:
-            cache13_size = max(
-                cache13_size, M * top_k_num * 2 * intermediate_size
-            )
+            cache13_size = max(cache13_size, M * top_k_num * 2 * intermediate_size)
         cache13 = torch.empty(
             cache13_size,
             device=hidden_states.device,
             dtype=hidden_states.dtype,
         )
         if not use_fused_gemm1_silu:
-            intermediate_cache1 = cache13[
-                : M * top_k_num * 2 * intermediate_size
-            ].view(M * top_k_num, 2 * intermediate_size)
-        intermediate_cache3 = cache13[: M * top_k_num * K].view(
-            M, top_k_num, K
-        )
+            intermediate_cache1 = cache13[: M * top_k_num * 2 * intermediate_size].view(
+                M * top_k_num, 2 * intermediate_size
+            )
+        intermediate_cache3 = cache13[: M * top_k_num * K].view(M, top_k_num, K)
     intermediate_cache2 = torch.empty(
         (M * top_k_num, intermediate_size),
         device=hidden_states.device,
@@ -1160,9 +1141,7 @@ def fused_marlin_moe_w4a16_int4(
                 B=w1_packed,
                 C=intermediate_cache2,
                 B_scale=w1_scale_packed,
-                topk_weights=(
-                    topk_weights if apply_router_weight_on_input else None
-                ),
+                topk_weights=(topk_weights if apply_router_weight_on_input else None),
                 topk_ids=topk_ids,
                 apply_router_weight_before_silu=apply_router_weight_on_input,
                 a_route_divisor=top_k_num,
@@ -1279,9 +1258,7 @@ def fused_marlin_moe_w4a16_int4(
                 B=w2_packed,
                 C=intermediate_cache3,
                 B_scale=w2_scale_packed,
-                topk_weights=(
-                    topk_weights if mul_routed_weight_in_gemm2 else None
-                ),
+                topk_weights=(topk_weights if mul_routed_weight_in_gemm2 else None),
                 topk_ids=topk_ids,
                 mul_routed_weight=mul_routed_weight_in_gemm2,
                 a_route_divisor=1,
@@ -1334,8 +1311,6 @@ def fused_marlin_moe_w4a16_int4(
     return out_hidden_states
 
 
-
-
 def fused_marlin_moe(
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
@@ -1375,16 +1350,31 @@ def fused_marlin_moe(
 ) -> torch.Tensor:
     """Use the PPU AIU path for supported W4A16 INT4 inputs."""
 
-    activation_str = "silu"
-    if activation is not None:
-        for attr in ("value", "name"):
-            value = getattr(activation, attr, None)
-            if isinstance(value, str):
-                activation_str = value.lower()
-                break
-        if isinstance(activation, str):
-            activation_str = activation.lower()
-
+    activation_str = _activation_name(activation)
+    optional_features = (
+        activation_func,
+        moe_sum,
+        expert_map,
+        input_global_scale1,
+        input_global_scale2,
+        global_scale1,
+        global_scale2,
+        g_idx1,
+        g_idx2,
+        sort_indices1,
+        sort_indices2,
+        w1_zeros,
+        w2_zeros,
+        workspace,
+        intermediate_cache13,
+        intermediate_cache2,
+        output,
+        input_dtype,
+        clamp_limit,
+    )
+    # Keep the established generic Triton implementation for other precision
+    # schemes and optional vLLM features.  This gate reads metadata only and is
+    # evaluated before allocating or transforming an input.
     use_ppu_w4a16 = (
         tle_async is not None
         and quant_type_id == QUANT_TYPE_UINT4B8
@@ -1394,27 +1384,14 @@ def fused_marlin_moe(
         and w2.dtype == torch.uint8
         and bias1 is None
         and bias2 is None
-        and w1_zeros is None
-        and w2_zeros is None
-        and expert_map is None
-        and input_dtype is None
-        and clamp_limit is None
-        and input_global_scale1 is None
-        and input_global_scale2 is None
-        and global_scale1 is None
-        and global_scale2 is None
-        and g_idx1 is None
-        and g_idx2 is None
-        and sort_indices1 is None
-        and sort_indices2 is None
+        and all(value is None for value in optional_features)
+        and is_k_full
         and (global_num_experts == -1 or global_num_experts == w1.size(0))
         and group_size == 128
         and w1_scale.dtype == hidden_states.dtype
         and w2_scale.dtype == hidden_states.dtype
     )
     if use_ppu_w4a16:
-        if inplace and output is not None:
-            raise ValueError("Cannot pass both inplace=True and output")
         result = fused_marlin_moe_w4a16_int4(
             hidden_states=hidden_states,
             w1=w1,
@@ -1428,9 +1405,6 @@ def fused_marlin_moe(
             apply_router_weight_on_input=apply_router_weight_on_input,
             inplace=inplace,
         )
-        if output is not None:
-            output.copy_(result)
-            return output
         return result
 
     return _generic_fused_marlin_moe(

--- a/src/flaggems_vllm/runtime/backend/_thead/fused/fused_marlin_moe.py
+++ b/src/flaggems_vllm/runtime/backend/_thead/fused/fused_marlin_moe.py
@@ -1,0 +1,1475 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""T-Head PPU specialization for fused Marlin MoE W4A16 INT4."""
+
+from typing import Any, Callable, Optional
+
+import torch
+import triton
+import triton.language as tl
+
+try:
+    from triton.experimental.tle import language as tle_async
+except ImportError:  # pragma: no cover - requires a TLE-enabled FlagTree build
+    tle_async = None
+
+from flaggems_vllm import runtime
+from flaggems_vllm.ops.fused_marlin_moe import (
+    QUANT_TYPE_UINT4B8,
+    _RouterWeightPlacement,
+    _invoke_w4a16_int4_moe_gemm,
+    _invoke_w4a16_int4_moe_gemm_silu,
+    _router_weight_placement,
+    _select_w4a16_int4_kernel_policy,
+    _stack_8,
+    fused_marlin_moe as _generic_fused_marlin_moe,
+    w4a16_int4_pack,
+)
+from flaggems_vllm.ops.moe_align_block_size import moe_align_block_size
+from flaggems_vllm.ops.moe_sum import moe_sum
+from flaggems_vllm.ops.silu_and_mul import silu_and_mul_out
+from flaggems_vllm.utils import libentry
+
+_PPU_DIRECT_ROUTE_LIMIT = 32
+
+@triton.jit
+def _ppu_dequant_int4(b_packed, scale, compute_type: tl.constexpr):
+    """Unpack PPU-friendly interleaved INT4 and apply one group scale.
+
+    ``_pack_w_interleave`` stores eight logical K sub-tiles in the bit order
+    0, 16, 4, 20, 8, 24, 12, 28.  Extracting in that order restores logical
+    K order before ``_stack_8`` concatenates the sub-tiles.
+    """
+    b0 = (((b_packed >> 0) & 0xF).to(compute_type) - 8.0) * scale
+    b1 = (((b_packed >> 16) & 0xF).to(compute_type) - 8.0) * scale
+    b2 = (((b_packed >> 4) & 0xF).to(compute_type) - 8.0) * scale
+    b3 = (((b_packed >> 20) & 0xF).to(compute_type) - 8.0) * scale
+    b4 = (((b_packed >> 8) & 0xF).to(compute_type) - 8.0) * scale
+    b5 = (((b_packed >> 24) & 0xF).to(compute_type) - 8.0) * scale
+    b6 = (((b_packed >> 12) & 0xF).to(compute_type) - 8.0) * scale
+    b7 = (((b_packed >> 28) & 0xF).to(compute_type) - 8.0) * scale
+    return b0, b1, b2, b3, b4, b5, b6, b7
+
+
+if tle_async is not None:
+
+    @libentry()
+    @triton.jit(do_not_specialize_on_alignment=["a_ptr", "b_ptr", "c_ptr"])
+    def _ppu_w4a16_int4_moe_gemm_direct_kernel(
+        a_ptr,
+        b_ptr,
+        c_ptr,
+        b_scale_ptr,
+        topk_weights_ptr,
+        topk_ids_ptr,
+        N: tl.constexpr,
+        K: tl.constexpr,
+        stride_am,
+        stride_ak,
+        stride_be,
+        stride_bk,
+        stride_bn,
+        stride_cm,
+        stride_cn,
+        stride_bse,
+        stride_bsg,
+        stride_bsn,
+        A_ROUTE_DIVISOR: tl.constexpr,
+        GROUP_SIZE_K: tl.constexpr,
+        MUL_ROUTED_WEIGHT: tl.constexpr,
+        PIPELINE_STAGES: tl.constexpr,
+        compute_type: tl.constexpr,
+        BLOCK_SIZE_N: tl.constexpr,
+    ):
+        # One program computes one routed row and one output-N tile.  A
+        # 16-row activation tile is used because PPU AIU requires a regular
+        # 2D tile; boundary padding leaves only row zero valid.
+        BLOCK_SIZE_M: tl.constexpr = 16
+        BLOCK_SIZE_K: tl.constexpr = 128
+        BLOCK_SIZE_K_PACK: tl.constexpr = 16
+
+        pid = tl.program_id(0)
+        num_pid_n: tl.constexpr = tl.cdiv(N, BLOCK_SIZE_N)
+        route = pid // num_pid_n
+        pid_n = pid % num_pid_n
+        expert = tl.load(topk_ids_ptr + route).to(tl.int64)
+        a_row = route // A_ROUTE_DIVISOR
+        a_block_ptr = tl.make_block_ptr(
+            base=a_ptr + a_row * stride_am,
+            shape=(1, K),
+            strides=(stride_am, stride_ak),
+            offsets=(0, 0),
+            block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_K),
+            order=(1, 0),
+        )
+        # Packed B is physically and logically [E, K/8, N].
+        b_block_ptr = tl.make_block_ptr(
+            base=b_ptr + expert * stride_be,
+            shape=(K // 8, N),
+            strides=(stride_bk, stride_bn),
+            offsets=(0, pid_n * BLOCK_SIZE_N),
+            block_shape=(BLOCK_SIZE_K_PACK, BLOCK_SIZE_N),
+            order=(1, 0),
+        )
+        acc = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32)
+
+        for k_tile in tl.range(
+            0, tl.cdiv(K, BLOCK_SIZE_K), num_stages=PIPELINE_STAGES
+        ):
+            a = tle_async.load(
+                a_block_ptr,
+                boundary_check=(0, 1),
+                padding_option="zero",
+                is_async=True,
+            )
+            b_packed = tle_async.load(
+                b_block_ptr,
+                boundary_check=(0, 1),
+                padding_option="zero",
+                is_async=True,
+            )
+
+            offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            scale_group = k_tile * BLOCK_SIZE_K // GROUP_SIZE_K
+            scale = tl.load(
+                b_scale_ptr
+                + expert * stride_bse
+                + scale_group * stride_bsg
+                + offs_n * stride_bsn,
+                mask=offs_n < N,
+                other=0.0,
+            )[None, :]
+            bs = _ppu_dequant_int4(b_packed, scale, compute_type)
+            b = _stack_8(bs, BLOCK_SIZE_K_PACK, BLOCK_SIZE_N)
+            acc = tl.dot(tl.trans(b), tl.trans(a), acc=acc)
+
+            a_block_ptr = tl.advance(a_block_ptr, (0, BLOCK_SIZE_K))
+            b_block_ptr = tl.advance(b_block_ptr, (BLOCK_SIZE_K_PACK, 0))
+
+        if MUL_ROUTED_WEIGHT:
+            routed_weight = tl.load(topk_weights_ptr + route).to(tl.float32)
+            acc *= routed_weight
+
+        offs_m = tl.arange(0, BLOCK_SIZE_M)
+        offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        c_rows = route + offs_m[None, :]
+        c_cols = offs_n[:, None]
+        c_ptrs = c_ptr + c_rows * stride_cm + c_cols * stride_cn
+        tl.store(
+            c_ptrs,
+            acc.to(compute_type),
+            mask=(offs_m[None, :] == 0) & (offs_n[:, None] < N),
+        )
+
+    @libentry()
+    @triton.jit(do_not_specialize_on_alignment=["a_ptr", "b_ptr", "c_ptr"])
+    def _ppu_w4a16_int4_moe_gemm_reduce_direct_kernel(
+        a_ptr,
+        b_ptr,
+        c_ptr,
+        b_scale_ptr,
+        topk_weights_ptr,
+        topk_ids_ptr,
+        N: tl.constexpr,
+        K: tl.constexpr,
+        stride_am,
+        stride_ak,
+        stride_be,
+        stride_bk,
+        stride_bn,
+        stride_cm,
+        stride_cn,
+        stride_bse,
+        stride_bsg,
+        stride_bsn,
+        TOP_K: tl.constexpr,
+        GROUP_SIZE_K: tl.constexpr,
+        MUL_ROUTED_WEIGHT: tl.constexpr,
+        PIPELINE_STAGES: tl.constexpr,
+        compute_type: tl.constexpr,
+        BLOCK_SIZE_N: tl.constexpr,
+    ):
+        """Compute GEMM2 and reduce all routed experts into one token row."""
+        BLOCK_SIZE_M: tl.constexpr = 16
+        BLOCK_SIZE_K: tl.constexpr = 128
+        BLOCK_SIZE_K_PACK: tl.constexpr = 16
+
+        pid = tl.program_id(0)
+        num_pid_n: tl.constexpr = tl.cdiv(N, BLOCK_SIZE_N)
+        token = pid // num_pid_n
+        pid_n = pid % num_pid_n
+        acc = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32)
+
+        for topk_index in tl.range(0, TOP_K):
+            route = token * TOP_K + topk_index
+            expert = tl.load(topk_ids_ptr + route).to(tl.int64)
+            route_acc = tl.zeros(
+                (BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32
+            )
+            a_block_ptr = tl.make_block_ptr(
+                base=a_ptr + route * stride_am,
+                shape=(1, K),
+                strides=(stride_am, stride_ak),
+                offsets=(0, 0),
+                block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_K),
+                order=(1, 0),
+            )
+            b_block_ptr = tl.make_block_ptr(
+                base=b_ptr + expert * stride_be,
+                shape=(K // 8, N),
+                strides=(stride_bk, stride_bn),
+                offsets=(0, pid_n * BLOCK_SIZE_N),
+                block_shape=(BLOCK_SIZE_K_PACK, BLOCK_SIZE_N),
+                order=(1, 0),
+            )
+
+            for k_tile in tl.range(
+                0, tl.cdiv(K, BLOCK_SIZE_K), num_stages=PIPELINE_STAGES
+            ):
+                a = tle_async.load(
+                    a_block_ptr,
+                    boundary_check=(0, 1),
+                    padding_option="zero",
+                    is_async=True,
+                )
+                b_packed = tle_async.load(
+                    b_block_ptr,
+                    boundary_check=(0, 1),
+                    padding_option="zero",
+                    is_async=True,
+                )
+
+                offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+                scale_group = k_tile * BLOCK_SIZE_K // GROUP_SIZE_K
+                scale = tl.load(
+                    b_scale_ptr
+                    + expert * stride_bse
+                    + scale_group * stride_bsg
+                    + offs_n * stride_bsn,
+                    mask=offs_n < N,
+                    other=0.0,
+                )[None, :]
+                bs = _ppu_dequant_int4(b_packed, scale, compute_type)
+                b = _stack_8(bs, BLOCK_SIZE_K_PACK, BLOCK_SIZE_N)
+                route_acc = tl.dot(
+                    tl.trans(b), tl.trans(a), acc=route_acc
+                )
+
+                a_block_ptr = tl.advance(a_block_ptr, (0, BLOCK_SIZE_K))
+                b_block_ptr = tl.advance(
+                    b_block_ptr, (BLOCK_SIZE_K_PACK, 0)
+                )
+
+            if MUL_ROUTED_WEIGHT:
+                routed_weight = tl.load(topk_weights_ptr + route).to(
+                    tl.float32
+                )
+                route_acc *= routed_weight
+            acc += route_acc
+
+        offs_m = tl.arange(0, BLOCK_SIZE_M)
+        offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        c_ptrs = (
+            c_ptr
+            + (token + offs_m[None, :]) * stride_cm
+            + offs_n[:, None] * stride_cn
+        )
+        tl.store(
+            c_ptrs,
+            acc.to(compute_type),
+            mask=(offs_m[None, :] == 0) & (offs_n[:, None] < N),
+        )
+
+    @libentry()
+    @triton.jit(do_not_specialize_on_alignment=["a_ptr", "b_ptr", "c_ptr"])
+    def _ppu_w4a16_int4_moe_gemm_silu_direct_kernel(
+        a_ptr,
+        b_ptr,
+        c_ptr,
+        b_scale_ptr,
+        topk_weights_ptr,
+        topk_ids_ptr,
+        N: tl.constexpr,
+        K: tl.constexpr,
+        stride_am,
+        stride_ak,
+        stride_be,
+        stride_bk,
+        stride_bn,
+        stride_cm,
+        stride_cn,
+        stride_bse,
+        stride_bsg,
+        stride_bsn,
+        A_ROUTE_DIVISOR: tl.constexpr,
+        GROUP_SIZE_K: tl.constexpr,
+        APPLY_ROUTER_WEIGHT_BEFORE_SILU: tl.constexpr,
+        PIPELINE_STAGES: tl.constexpr,
+        compute_type: tl.constexpr,
+        BLOCK_SIZE_N: tl.constexpr,
+    ):
+        BLOCK_SIZE_M: tl.constexpr = 16
+        BLOCK_SIZE_K: tl.constexpr = 128
+        BLOCK_SIZE_K_PACK: tl.constexpr = 16
+
+        pid = tl.program_id(0)
+        num_pid_n: tl.constexpr = tl.cdiv(N, BLOCK_SIZE_N)
+        route = pid // num_pid_n
+        pid_n = pid % num_pid_n
+        expert = tl.load(topk_ids_ptr + route).to(tl.int64)
+        a_row = route // A_ROUTE_DIVISOR
+        a_block_ptr = tl.make_block_ptr(
+            base=a_ptr + a_row * stride_am,
+            shape=(1, K),
+            strides=(stride_am, stride_ak),
+            offsets=(0, 0),
+            block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_K),
+            order=(1, 0),
+        )
+        b_gate_block_ptr = tl.make_block_ptr(
+            base=b_ptr + expert * stride_be,
+            shape=(K // 8, 2 * N),
+            strides=(stride_bk, stride_bn),
+            offsets=(0, pid_n * BLOCK_SIZE_N),
+            block_shape=(BLOCK_SIZE_K_PACK, BLOCK_SIZE_N),
+            order=(1, 0),
+        )
+        b_up_block_ptr = tl.make_block_ptr(
+            base=b_ptr + expert * stride_be,
+            shape=(K // 8, 2 * N),
+            strides=(stride_bk, stride_bn),
+            offsets=(0, N + pid_n * BLOCK_SIZE_N),
+            block_shape=(BLOCK_SIZE_K_PACK, BLOCK_SIZE_N),
+            order=(1, 0),
+        )
+        acc_gate = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32)
+        acc_up = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32)
+
+        for k_tile in tl.range(
+            0, tl.cdiv(K, BLOCK_SIZE_K), num_stages=PIPELINE_STAGES
+        ):
+            a = tle_async.load(
+                a_block_ptr,
+                boundary_check=(0, 1),
+                padding_option="zero",
+                is_async=True,
+            )
+            b_gate_packed = tle_async.load(
+                b_gate_block_ptr,
+                boundary_check=(0, 1),
+                padding_option="zero",
+                is_async=True,
+            )
+            b_up_packed = tle_async.load(
+                b_up_block_ptr,
+                boundary_check=(0, 1),
+                padding_option="zero",
+                is_async=True,
+            )
+
+            offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            scale_group = k_tile * BLOCK_SIZE_K // GROUP_SIZE_K
+            scale_base = (
+                b_scale_ptr
+                + expert * stride_bse
+                + scale_group * stride_bsg
+                + offs_n * stride_bsn
+            )
+            scale_gate = tl.load(
+                scale_base, mask=offs_n < N, other=0.0
+            )[None, :]
+            scale_up = tl.load(
+                scale_base + N * stride_bsn,
+                mask=offs_n < N,
+                other=0.0,
+            )[None, :]
+            gate_bs = _ppu_dequant_int4(
+                b_gate_packed, scale_gate, compute_type
+            )
+            up_bs = _ppu_dequant_int4(b_up_packed, scale_up, compute_type)
+            gate_b = _stack_8(gate_bs, BLOCK_SIZE_K_PACK, BLOCK_SIZE_N)
+            up_b = _stack_8(up_bs, BLOCK_SIZE_K_PACK, BLOCK_SIZE_N)
+            a_trans = tl.trans(a)
+            acc_gate = tl.dot(tl.trans(gate_b), a_trans, acc=acc_gate)
+            acc_up = tl.dot(tl.trans(up_b), a_trans, acc=acc_up)
+
+            a_block_ptr = tl.advance(a_block_ptr, (0, BLOCK_SIZE_K))
+            b_gate_block_ptr = tl.advance(
+                b_gate_block_ptr, (BLOCK_SIZE_K_PACK, 0)
+            )
+            b_up_block_ptr = tl.advance(
+                b_up_block_ptr, (BLOCK_SIZE_K_PACK, 0)
+            )
+
+        if APPLY_ROUTER_WEIGHT_BEFORE_SILU:
+            routed_weight = tl.load(topk_weights_ptr + route).to(tl.float32)
+            acc_gate *= routed_weight
+            acc_up *= routed_weight
+
+        acc = (acc_gate * tl.sigmoid(acc_gate)) * acc_up
+        offs_m = tl.arange(0, BLOCK_SIZE_M)
+        offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        c_ptrs = (
+            c_ptr
+            + (route + offs_m[None, :]) * stride_cm
+            + offs_n[:, None] * stride_cn
+        )
+        tl.store(
+            c_ptrs,
+            acc.to(compute_type),
+            mask=(offs_m[None, :] == 0) & (offs_n[:, None] < N),
+        )
+
+
+    @triton.jit
+    def _ppu_stage_routed_activations_kernel(
+        a_ptr,
+        routed_a_ptr,
+        sorted_token_ids_ptr,
+        num_tokens_post_padded_ptr,
+        EM: tl.constexpr,
+        K: tl.constexpr,
+        num_valid_tokens,
+        stride_am,
+        stride_ak,
+        top_k: tl.constexpr,
+        BLOCK_SIZE_M: tl.constexpr,
+        BLOCK_SIZE_K: tl.constexpr,
+    ):
+        """Gather expert-sorted rows into a contiguous AIU input matrix."""
+        num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
+        offs_m = tl.program_id(0) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        offs_k = tl.program_id(1) * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
+        route_mask = (offs_m < EM) & (offs_m < num_tokens_post_padded)
+        routed_token = tl.load(
+            sorted_token_ids_ptr + offs_m,
+            mask=route_mask,
+            other=num_valid_tokens,
+        ).to(tl.int64)
+        valid = route_mask[:, None] & (routed_token[:, None] < num_valid_tokens)
+        activation = tl.load(
+            a_ptr
+            + (routed_token[:, None] // top_k) * stride_am
+            + offs_k[None, :] * stride_ak,
+            mask=valid & (offs_k[None, :] < K),
+            other=0.0,
+        )
+        tl.store(
+            routed_a_ptr + offs_m[:, None] * K + offs_k[None, :],
+            activation,
+            mask=(offs_m[:, None] < EM) & (offs_k[None, :] < K),
+        )
+
+    @triton.jit
+    def _ppu_silu_and_stage_routed_kernel(
+        intermediate1_ptr,
+        routed_intermediate2_ptr,
+        sorted_token_ids_ptr,
+        num_tokens_post_padded_ptr,
+        EM: tl.constexpr,
+        N: tl.constexpr,
+        num_valid_tokens,
+        BLOCK_SIZE_M: tl.constexpr,
+        BLOCK_SIZE_N: tl.constexpr,
+    ):
+        """Fuse SwiGLU with the expert-sorted layout required by GEMM2."""
+        num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
+        offs_m = tl.program_id(0) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        offs_n = tl.program_id(1) * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        route_mask = (offs_m < EM) & (offs_m < num_tokens_post_padded)
+        routed_token = tl.load(
+            sorted_token_ids_ptr + offs_m,
+            mask=route_mask,
+            other=num_valid_tokens,
+        ).to(tl.int64)
+        valid = (
+            route_mask[:, None]
+            & (routed_token[:, None] < num_valid_tokens)
+            & (offs_n[None, :] < N)
+        )
+        row_base = routed_token[:, None] * (2 * N)
+        gate = tl.load(
+            intermediate1_ptr + row_base + offs_n[None, :],
+            mask=valid,
+            other=0.0,
+        ).to(tl.float32)
+        up = tl.load(
+            intermediate1_ptr + row_base + N + offs_n[None, :],
+            mask=valid,
+            other=0.0,
+        ).to(tl.float32)
+        output = (gate * tl.sigmoid(gate)) * up
+        tl.store(
+            routed_intermediate2_ptr + offs_m[:, None] * N + offs_n[None, :],
+            output,
+            mask=(offs_m[:, None] < EM) & (offs_n[None, :] < N),
+        )
+
+    @libentry()
+    @triton.jit(
+        do_not_specialize_on_alignment=["routed_a_ptr", "b_ptr", "c_ptr"]
+    )
+    def _ppu_w4a16_int4_moe_gemm_grouped_kernel(
+        routed_a_ptr,
+        b_ptr,
+        c_ptr,
+        b_scale_ptr,
+        topk_weights_ptr,
+        sorted_token_ids_ptr,
+        expert_ids_ptr,
+        num_tokens_post_padded_ptr,
+        N: tl.constexpr,
+        K: tl.constexpr,
+        EM: tl.constexpr,
+        num_valid_tokens,
+        stride_be,
+        stride_bk,
+        stride_bn,
+        stride_cm,
+        stride_cn,
+        stride_bse,
+        stride_bsg,
+        stride_bsn,
+        BLOCK_SIZE_M: tl.constexpr,
+        BLOCK_SIZE_N: tl.constexpr,
+        BLOCK_SIZE_K: tl.constexpr,
+        GROUP_SIZE_M: tl.constexpr,
+        GROUP_SIZE_K: tl.constexpr,
+        MUL_ROUTED_WEIGHT: tl.constexpr,
+        PIPELINE_STAGES: tl.constexpr,
+        compute_type: tl.constexpr,
+    ):
+        """Expert-grouped W4A16 GEMM using contiguous TLE AIU transfers."""
+        BLOCK_SIZE_K_PACK: tl.constexpr = BLOCK_SIZE_K // 8
+        pid = tl.program_id(0)
+        num_pid_m = tl.cdiv(EM, BLOCK_SIZE_M)
+        num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+        group_id = pid // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+        pid_n = (pid % num_pid_in_group) // group_size_m
+
+        num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
+        if pid_m * BLOCK_SIZE_M >= num_tokens_post_padded:
+            return
+
+        offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        routed_token = tl.load(
+            sorted_token_ids_ptr + offs_m,
+            mask=offs_m < EM,
+            other=num_valid_tokens,
+        ).to(tl.int64)
+        token_mask = (offs_m < EM) & (routed_token < num_valid_tokens)
+        expert = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
+
+        if expert == -1:
+            zeros = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=compute_type)
+            tl.store(
+                c_ptr
+                + routed_token[None, :] * stride_cm
+                + offs_n[:, None] * stride_cn,
+                zeros,
+                mask=token_mask[None, :] & (offs_n[:, None] < N),
+            )
+            return
+
+        a_block_ptr = tl.make_block_ptr(
+            base=routed_a_ptr,
+            shape=(EM, K),
+            strides=(K, 1),
+            offsets=(pid_m * BLOCK_SIZE_M, 0),
+            block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_K),
+            order=(1, 0),
+        )
+        b_block_ptr = tl.make_block_ptr(
+            base=b_ptr + expert * stride_be,
+            shape=(K // 8, N),
+            strides=(stride_bk, stride_bn),
+            offsets=(0, pid_n * BLOCK_SIZE_N),
+            block_shape=(BLOCK_SIZE_K_PACK, BLOCK_SIZE_N),
+            order=(1, 0),
+        )
+        acc = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32)
+
+        for k_tile in tl.range(
+            0, tl.cdiv(K, BLOCK_SIZE_K), num_stages=PIPELINE_STAGES
+        ):
+            activation = tle_async.load(
+                a_block_ptr,
+                boundary_check=(0, 1),
+                padding_option="zero",
+                is_async=True,
+            )
+            b_packed = tle_async.load(
+                b_block_ptr,
+                boundary_check=(0, 1),
+                padding_option="zero",
+                is_async=True,
+            )
+            scale_idx = k_tile * BLOCK_SIZE_K // GROUP_SIZE_K
+            scale = tl.load(
+                b_scale_ptr
+                + expert * stride_bse
+                + scale_idx * stride_bsg
+                + offs_n * stride_bsn,
+                mask=offs_n < N,
+                other=0.0,
+            )[None, :]
+            bs = _ppu_dequant_int4(b_packed, scale, compute_type)
+            b = _stack_8(bs, BLOCK_SIZE_K_PACK, BLOCK_SIZE_N)
+            acc = tl.dot(tl.trans(b), tl.trans(activation), acc=acc)
+            a_block_ptr = tl.advance(a_block_ptr, (0, BLOCK_SIZE_K))
+            b_block_ptr = tl.advance(b_block_ptr, (BLOCK_SIZE_K_PACK, 0))
+
+        if MUL_ROUTED_WEIGHT:
+            routed_weight = tl.load(
+                topk_weights_ptr + routed_token,
+                mask=token_mask,
+                other=0.0,
+            )
+            acc *= routed_weight[None, :]
+
+        tl.store(
+            c_ptr
+            + routed_token[None, :] * stride_cm
+            + offs_n[:, None] * stride_cn,
+            acc.to(compute_type),
+            mask=token_mask[None, :] & (offs_n[:, None] < N),
+        )
+def _select_ppu_direct_block_n(n: int) -> int:
+    if n <= 32:
+        return 32
+    if n < 512:
+        return 64
+    return 128
+
+
+def _select_ppu_grouped_config(M: int, K: int, N: int):
+    if 256 <= M <= 512 and K > N:
+        return 128, 1, 4, 3
+    if M < 512:
+        return 256, 1, 8, 3
+    if M == 2048 and K > N:
+        return 256, 8, 8, 2
+    return 256, 8, 8, 3
+
+
+def _select_ppu_grouped_block_m(M: int, E: int, top_k: int) -> int:
+    routes = M * top_k
+    if routes <= 16 * E:
+        return 16
+    if routes <= 32 * E:
+        return 32
+    return 64
+
+
+def _use_ppu_direct_route(
+    M: int,
+    top_k: int,
+    hidden_size: int,
+    intermediate_size: int,
+) -> bool:
+    routes = M * top_k
+    max_output_n = max(hidden_size, 2 * intermediate_size)
+    block_n = _select_ppu_direct_block_n(max_output_n)
+    n_tiles = triton.cdiv(max_output_n, block_n)
+    max_routes_by_grid = 65535 // n_tiles
+    return routes <= min(_PPU_DIRECT_ROUTE_LIMIT, max_routes_by_grid)
+
+
+def _align_ppu_grouped_tokens(
+    topk_ids: torch.Tensor,
+    block_m: int,
+    num_experts: int,
+):
+    # FlagGems-vLLM is integrated into vLLM, and the T-Head CUDA extension's
+    # alignment kernel avoids the high fixed cost of the generic Triton path.
+    from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
+        moe_align_block_size as vllm_moe_align_block_size,
+    )
+
+    return vllm_moe_align_block_size(
+        topk_ids,
+        block_m,
+        num_experts,
+        expert_map=None,
+        ignore_invalid_experts=True,
+    )
+
+
+def _invoke_ppu_w4a16_int4_moe_gemm_direct(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    B_scale: torch.Tensor,
+    topk_weights: Optional[torch.Tensor],
+    topk_ids: torch.Tensor,
+    *,
+    mul_routed_weight: bool,
+    a_route_divisor: int,
+    group_size: int,
+    compute_type,
+):
+    if tle_async is None:
+        raise RuntimeError("PPU W4A16 AIU path requires Triton TLE")
+
+    K = A.size(1)
+    N = B.size(2)
+    routes = topk_ids.numel()
+    if C.ndim == 3:
+        stride_cm = C.stride(1)
+        stride_cn = C.stride(2)
+    else:
+        stride_cm = C.stride(0)
+        stride_cn = C.stride(1)
+    block_n = _select_ppu_direct_block_n(N)
+    # The PPU pipeline pass allocates ``num_stages - 1`` loop buffers.  Three
+    # scheduling stages therefore provide the two buffers required to overlap
+    # the next AIU copy with the current tile's unpack/dequantize/dot work.
+    pipeline_stages = 3 if K > 128 else 1
+    grid = (routes * triton.cdiv(N, block_n),)
+
+    _ppu_w4a16_int4_moe_gemm_direct_kernel[grid](
+        A,
+        B,
+        C,
+        B_scale,
+        topk_weights,
+        topk_ids,
+        N,
+        K,
+        A.stride(0),
+        A.stride(1),
+        B.stride(0),
+        B.stride(1),
+        B.stride(2),
+        stride_cm,
+        stride_cn,
+        B_scale.stride(0),
+        B_scale.stride(1),
+        B_scale.stride(2),
+        A_ROUTE_DIVISOR=a_route_divisor,
+        GROUP_SIZE_K=group_size,
+        MUL_ROUTED_WEIGHT=mul_routed_weight,
+        PIPELINE_STAGES=pipeline_stages,
+        compute_type=compute_type,
+        BLOCK_SIZE_N=block_n,
+        num_stages=pipeline_stages,
+    )
+
+
+def _invoke_ppu_w4a16_int4_moe_gemm_reduce_direct(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    B_scale: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    *,
+    mul_routed_weight: bool,
+    group_size: int,
+    compute_type,
+):
+    if tle_async is None:
+        raise RuntimeError("PPU W4A16 AIU path requires Triton TLE")
+
+    K = A.size(1)
+    N = B.size(2)
+    top_k = topk_ids.size(1)
+    tokens = A.size(0) // top_k
+    if tokens == 1:
+        block_n = 128
+    elif tokens == 2:
+        block_n = 32
+    else:
+        block_n = 32
+    pipeline_stages = 3 if K > 128 else 1
+    grid = (tokens * triton.cdiv(N, block_n),)
+
+    _ppu_w4a16_int4_moe_gemm_reduce_direct_kernel[grid](
+        A,
+        B,
+        C,
+        B_scale,
+        topk_weights,
+        topk_ids,
+        N,
+        K,
+        A.stride(0),
+        A.stride(1),
+        B.stride(0),
+        B.stride(1),
+        B.stride(2),
+        C.stride(0),
+        C.stride(1),
+        B_scale.stride(0),
+        B_scale.stride(1),
+        B_scale.stride(2),
+        TOP_K=top_k,
+        GROUP_SIZE_K=group_size,
+        MUL_ROUTED_WEIGHT=mul_routed_weight,
+        PIPELINE_STAGES=pipeline_stages,
+        compute_type=compute_type,
+        BLOCK_SIZE_N=block_n,
+        num_stages=pipeline_stages,
+    )
+
+
+def _invoke_ppu_w4a16_int4_moe_gemm_silu_direct(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    B_scale: torch.Tensor,
+    topk_weights: Optional[torch.Tensor],
+    topk_ids: torch.Tensor,
+    *,
+    apply_router_weight_before_silu: bool,
+    a_route_divisor: int,
+    group_size: int,
+    compute_type,
+):
+    if tle_async is None:
+        raise RuntimeError("PPU W4A16 AIU path requires Triton TLE")
+
+    K = A.size(1)
+    N = C.size(1)
+    routes = topk_ids.numel()
+    block_n = 32 if routes >= 12 else _select_ppu_direct_block_n(N)
+    pipeline_stages = 3 if K > 128 else 1
+    grid = (routes * triton.cdiv(N, block_n),)
+
+    _ppu_w4a16_int4_moe_gemm_silu_direct_kernel[grid](
+        A,
+        B,
+        C,
+        B_scale,
+        topk_weights,
+        topk_ids,
+        N,
+        K,
+        A.stride(0),
+        A.stride(1),
+        B.stride(0),
+        B.stride(1),
+        B.stride(2),
+        C.stride(0),
+        C.stride(1),
+        B_scale.stride(0),
+        B_scale.stride(1),
+        B_scale.stride(2),
+        A_ROUTE_DIVISOR=a_route_divisor,
+        GROUP_SIZE_K=group_size,
+        APPLY_ROUTER_WEIGHT_BEFORE_SILU=apply_router_weight_before_silu,
+        PIPELINE_STAGES=pipeline_stages,
+        compute_type=compute_type,
+        BLOCK_SIZE_N=block_n,
+        num_stages=pipeline_stages,
+    )
+
+
+def _stage_ppu_grouped_activations(
+    A: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    *,
+    em: int,
+    num_valid_tokens: int,
+    top_k: int,
+    block_m: int,
+) -> torch.Tensor:
+    routed_a = torch.empty((em, A.size(1)), dtype=A.dtype, device=A.device)
+    grid = (triton.cdiv(em, block_m), triton.cdiv(A.size(1), 128))
+    _ppu_stage_routed_activations_kernel[grid](
+        A,
+        routed_a,
+        sorted_token_ids,
+        num_tokens_post_padded,
+        EM=em,
+        K=A.size(1),
+        num_valid_tokens=num_valid_tokens,
+        stride_am=A.stride(0),
+        stride_ak=A.stride(1),
+        top_k=top_k,
+        BLOCK_SIZE_M=block_m,
+        BLOCK_SIZE_K=128,
+        num_warps=4,
+        num_stages=1,
+    )
+    return routed_a
+
+
+def _silu_and_stage_ppu_grouped(
+    intermediate1: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    *,
+    em: int,
+    num_valid_tokens: int,
+    block_m: int,
+) -> torch.Tensor:
+    n = intermediate1.size(1) // 2
+    routed = torch.empty((em, n), dtype=intermediate1.dtype, device=intermediate1.device)
+    grid = (triton.cdiv(em, block_m), triton.cdiv(n, 128))
+    _ppu_silu_and_stage_routed_kernel[grid](
+        intermediate1,
+        routed,
+        sorted_token_ids,
+        num_tokens_post_padded,
+        EM=em,
+        N=n,
+        num_valid_tokens=num_valid_tokens,
+        BLOCK_SIZE_M=block_m,
+        BLOCK_SIZE_N=128,
+        num_warps=4,
+        num_stages=1,
+    )
+    return routed
+
+
+def _invoke_ppu_w4a16_int4_moe_gemm_grouped(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    B_scale: torch.Tensor,
+    topk_weights: Optional[torch.Tensor],
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    *,
+    mul_routed_weight: bool,
+    top_k: int,
+    block_m: int,
+    group_size: int,
+    compute_type,
+    input_is_routed: bool = False,
+):
+    if tle_async is None:
+        raise RuntimeError("PPU W4A16 grouped AIU path requires Triton TLE")
+    em = sorted_token_ids.size(0)
+    num_valid_tokens = C.size(0) * C.size(1) if C.ndim == 3 else A.size(0) * top_k
+    if input_is_routed:
+        routed_a = A
+    else:
+        routed_a = _stage_ppu_grouped_activations(
+            A,
+            sorted_token_ids,
+            num_tokens_post_padded,
+            em=em,
+            num_valid_tokens=num_valid_tokens,
+            top_k=top_k,
+            block_m=block_m,
+        )
+
+    n = B.size(2)
+    batch_m = C.size(0) if C.ndim == 3 else A.size(0)
+    block_n, group_m, num_warps, pipeline_stages = _select_ppu_grouped_config(
+        batch_m, A.size(1), n
+    )
+    if C.ndim == 3:
+        stride_cm = C.stride(1)
+        stride_cn = C.stride(2)
+    else:
+        stride_cm = C.stride(0)
+        stride_cn = C.stride(1)
+    grid = (triton.cdiv(em, block_m) * triton.cdiv(n, block_n),)
+    _ppu_w4a16_int4_moe_gemm_grouped_kernel[grid](
+        routed_a,
+        B,
+        C,
+        B_scale,
+        topk_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        N=n,
+        K=A.size(1),
+        EM=em,
+        num_valid_tokens=num_valid_tokens,
+        stride_be=B.stride(0),
+        stride_bk=B.stride(1),
+        stride_bn=B.stride(2),
+        stride_cm=stride_cm,
+        stride_cn=stride_cn,
+        stride_bse=B_scale.stride(0),
+        stride_bsg=B_scale.stride(1),
+        stride_bsn=B_scale.stride(2),
+        BLOCK_SIZE_M=block_m,
+        BLOCK_SIZE_N=block_n,
+        BLOCK_SIZE_K=128,
+        GROUP_SIZE_M=group_m,
+        GROUP_SIZE_K=group_size,
+        MUL_ROUTED_WEIGHT=mul_routed_weight,
+        PIPELINE_STAGES=pipeline_stages,
+        compute_type=compute_type,
+        num_warps=num_warps,
+        num_stages=pipeline_stages,
+    )
+
+
+def fused_marlin_moe_w4a16_int4(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    *,
+    activation: str = "silu",
+    group_size: int = 128,
+    apply_router_weight_on_input: bool = False,
+    inplace: bool = False,
+    swap_ab: bool = True,
+) -> torch.Tensor:
+    assert activation == "silu"
+    assert hidden_states.dtype in (torch.float16, torch.bfloat16)
+    assert hidden_states.is_contiguous()
+    assert w1.dtype == torch.uint8 and w2.dtype == torch.uint8
+    assert w1.stride(-1) == 1 and w2.stride(-1) == 1
+
+    M = hidden_states.size(0)
+    K = hidden_states.size(1)
+    E = w1.size(0)
+    intermediate_size = w1.size(1) // 2
+    top_k_num = topk_ids.size(1)
+
+    assert w1.shape == (E, 2 * intermediate_size, K // 2)
+    assert w2.shape == (E, K, intermediate_size // 2)
+    assert K % group_size == 0
+    assert intermediate_size % group_size == 0
+    assert w1_scale.shape == (E, 2 * intermediate_size, K // group_size)
+    assert w2_scale.shape == (E, K, intermediate_size // group_size)
+    assert w1_scale.dtype == hidden_states.dtype
+    assert w2_scale.dtype == hidden_states.dtype
+    assert topk_weights.shape == topk_ids.shape
+
+    block_size_k = group_size
+    # Compute_type for the kernel.
+    if hidden_states.dtype == torch.float16:
+        compute_type = tl.float16
+    else:
+        compute_type = tl.bfloat16
+
+    w1_packed, w2_packed, w1_scale_packed, w2_scale_packed = w4a16_int4_pack(
+        w1,
+        w2,
+        w1_scale,
+        w2_scale,
+        block_size_k=block_size_k,
+        cached=True,
+    )
+
+    policy = _select_w4a16_int4_kernel_policy(
+        hidden_states.device,
+        M,
+        E,
+        top_k_num,
+        swap_ab,
+        apply_router_weight_on_input,
+    )
+    is_ppu = runtime.device.vendor_name == "thead"
+    use_ppu_direct_route = (
+        is_ppu
+        and tle_async is not None
+        and group_size == 128
+        and _use_ppu_direct_route(M, top_k_num, K, intermediate_size)
+    )
+    use_ppu_reduce_direct = use_ppu_direct_route and M <= 2
+    block_m = policy.block_m
+    if is_ppu and not use_ppu_direct_route:
+        block_m = _select_ppu_grouped_block_m(M, E, top_k_num)
+    # Direct-route is faster for sparse routed-token batches. Larger PPU
+    # batches stay on the expert-grouped W4A16 kernel. Do not force the fused
+    # grouped variant: its two live accumulators increase register pressure.
+    use_fused_gemm1_silu = policy.use_fused_gemm1_silu or use_ppu_direct_route
+    move_router_weight_before_gemm2 = (
+        policy.move_router_weight_before_gemm2
+        or (
+            is_ppu
+            and use_fused_gemm1_silu
+            and not apply_router_weight_on_input
+            and M >= 512
+        )
+    )
+    router_weight_placement = _router_weight_placement(
+        apply_router_weight_on_input,
+        move_router_weight_before_gemm2,
+    )
+    mul_routed_weight_in_gemm2 = router_weight_placement == _RouterWeightPlacement.none
+
+    intermediate_cache1 = None
+    intermediate_cache3 = None
+    if not use_ppu_reduce_direct:
+        cache13_size = M * top_k_num * K
+        if not use_fused_gemm1_silu:
+            cache13_size = max(
+                cache13_size, M * top_k_num * 2 * intermediate_size
+            )
+        cache13 = torch.empty(
+            cache13_size,
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+        if not use_fused_gemm1_silu:
+            intermediate_cache1 = cache13[
+                : M * top_k_num * 2 * intermediate_size
+            ].view(M * top_k_num, 2 * intermediate_size)
+        intermediate_cache3 = cache13[: M * top_k_num * K].view(
+            M, top_k_num, K
+        )
+    intermediate_cache2 = torch.empty(
+        (M * top_k_num, intermediate_size),
+        device=hidden_states.device,
+        dtype=hidden_states.dtype,
+    )
+    ppu_grouped_intermediate2 = None
+
+    if use_ppu_direct_route:
+        sorted_token_ids = expert_ids = num_tokens_post_padded = None
+    elif is_ppu:
+        sorted_token_ids, expert_ids, num_tokens_post_padded = (
+            _align_ppu_grouped_tokens(topk_ids, block_m, E)
+        )
+    else:
+        sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+            topk_ids=topk_ids,
+            block_size=block_m,
+            num_experts=E,
+            expert_map=None,
+        )
+
+    if use_fused_gemm1_silu:
+        if use_ppu_direct_route:
+            _invoke_ppu_w4a16_int4_moe_gemm_silu_direct(
+                A=hidden_states,
+                B=w1_packed,
+                C=intermediate_cache2,
+                B_scale=w1_scale_packed,
+                topk_weights=(
+                    topk_weights if apply_router_weight_on_input else None
+                ),
+                topk_ids=topk_ids,
+                apply_router_weight_before_silu=apply_router_weight_on_input,
+                a_route_divisor=top_k_num,
+                group_size=group_size,
+                compute_type=compute_type,
+            )
+        else:
+            _invoke_w4a16_int4_moe_gemm_silu(
+                A=hidden_states,
+                B=w1_packed,
+                C=intermediate_cache2,
+                B_scale=w1_scale_packed,
+                topk_weights=(
+                    topk_weights
+                    if router_weight_placement != _RouterWeightPlacement.none
+                    else None
+                ),
+                sorted_token_ids=sorted_token_ids,
+                expert_ids=expert_ids,
+                num_tokens_post_padded=num_tokens_post_padded,
+                router_weight=router_weight_placement,
+                top_k=top_k_num,
+                block_m=block_m,
+                block_size_k=block_size_k,
+                group_size=group_size,
+                compute_type=compute_type,
+                swap_ab=swap_ab,
+            )
+    else:
+        assert intermediate_cache1 is not None
+        if use_ppu_direct_route:
+            _invoke_ppu_w4a16_int4_moe_gemm_direct(
+                A=hidden_states,
+                B=w1_packed,
+                C=intermediate_cache1,
+                B_scale=w1_scale_packed,
+                topk_weights=(topk_weights if apply_router_weight_on_input else None),
+                topk_ids=topk_ids,
+                mul_routed_weight=apply_router_weight_on_input,
+                a_route_divisor=top_k_num,
+                group_size=group_size,
+                compute_type=compute_type,
+            )
+        elif is_ppu:
+            _invoke_ppu_w4a16_int4_moe_gemm_grouped(
+                A=hidden_states,
+                B=w1_packed,
+                C=intermediate_cache1,
+                B_scale=w1_scale_packed,
+                topk_weights=(topk_weights if apply_router_weight_on_input else None),
+                sorted_token_ids=sorted_token_ids,
+                expert_ids=expert_ids,
+                num_tokens_post_padded=num_tokens_post_padded,
+                mul_routed_weight=apply_router_weight_on_input,
+                top_k=top_k_num,
+                block_m=block_m,
+                group_size=group_size,
+                compute_type=compute_type,
+            )
+        else:
+            _invoke_w4a16_int4_moe_gemm(
+                A=hidden_states,
+                B=w1_packed,
+                C=intermediate_cache1,
+                B_scale=w1_scale_packed,
+                topk_weights=topk_weights if apply_router_weight_on_input else None,
+                sorted_token_ids=sorted_token_ids,
+                expert_ids=expert_ids,
+                num_tokens_post_padded=num_tokens_post_padded,
+                mul_routed_weight=apply_router_weight_on_input,
+                top_k=top_k_num,
+                block_m=block_m,
+                block_size_k=block_size_k,
+                group_size=group_size,
+                compute_type=compute_type,
+                swap_ab=swap_ab,
+            )
+        if is_ppu and not use_ppu_direct_route:
+            ppu_grouped_intermediate2 = _silu_and_stage_ppu_grouped(
+                intermediate_cache1,
+                sorted_token_ids,
+                num_tokens_post_padded,
+                em=sorted_token_ids.size(0),
+                num_valid_tokens=M * top_k_num,
+                block_m=block_m,
+            )
+        else:
+            gate = intermediate_cache1[:, :intermediate_size]
+            up = intermediate_cache1[:, intermediate_size:]
+            silu_and_mul_out(gate, up, intermediate_cache2)
+
+    if inplace:
+        out_hidden_states = hidden_states
+    else:
+        out_hidden_states = torch.empty_like(hidden_states)
+
+    if use_ppu_direct_route:
+        if use_ppu_reduce_direct:
+            _invoke_ppu_w4a16_int4_moe_gemm_reduce_direct(
+                A=intermediate_cache2,
+                B=w2_packed,
+                C=out_hidden_states,
+                B_scale=w2_scale_packed,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                mul_routed_weight=mul_routed_weight_in_gemm2,
+                group_size=group_size,
+                compute_type=compute_type,
+            )
+        else:
+            assert intermediate_cache3 is not None
+            _invoke_ppu_w4a16_int4_moe_gemm_direct(
+                A=intermediate_cache2,
+                B=w2_packed,
+                C=intermediate_cache3,
+                B_scale=w2_scale_packed,
+                topk_weights=(
+                    topk_weights if mul_routed_weight_in_gemm2 else None
+                ),
+                topk_ids=topk_ids,
+                mul_routed_weight=mul_routed_weight_in_gemm2,
+                a_route_divisor=1,
+                group_size=group_size,
+                compute_type=compute_type,
+            )
+    elif is_ppu:
+        assert ppu_grouped_intermediate2 is not None
+        assert intermediate_cache3 is not None
+        _invoke_ppu_w4a16_int4_moe_gemm_grouped(
+            A=ppu_grouped_intermediate2,
+            B=w2_packed,
+            C=intermediate_cache3,
+            B_scale=w2_scale_packed,
+            topk_weights=(topk_weights if mul_routed_weight_in_gemm2 else None),
+            sorted_token_ids=sorted_token_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=num_tokens_post_padded,
+            mul_routed_weight=mul_routed_weight_in_gemm2,
+            top_k=1,
+            block_m=block_m,
+            group_size=group_size,
+            compute_type=compute_type,
+            input_is_routed=True,
+        )
+    else:
+        assert intermediate_cache3 is not None
+        _invoke_w4a16_int4_moe_gemm(
+            A=intermediate_cache2,
+            B=w2_packed,
+            C=intermediate_cache3,
+            B_scale=w2_scale_packed,
+            topk_weights=topk_weights if mul_routed_weight_in_gemm2 else None,
+            sorted_token_ids=sorted_token_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=num_tokens_post_padded,
+            mul_routed_weight=mul_routed_weight_in_gemm2,
+            top_k=1,
+            block_m=block_m,
+            block_size_k=block_size_k,
+            group_size=group_size,
+            compute_type=compute_type,
+            swap_ab=swap_ab,
+        )
+
+    if not use_ppu_reduce_direct:
+        assert intermediate_cache3 is not None
+        moe_sum(intermediate_cache3, out_hidden_states)
+
+    return out_hidden_states
+
+
+
+
+def fused_marlin_moe(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    bias1: Optional[torch.Tensor],
+    bias2: Optional[torch.Tensor],
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    quant_type_id: int,
+    apply_router_weight_on_input: bool = False,
+    global_num_experts: int = -1,
+    activation: Any = None,
+    activation_func: Optional[Callable] = None,
+    moe_sum: Optional[Callable] = None,
+    expert_map: Optional[torch.Tensor] = None,
+    input_global_scale1: Optional[torch.Tensor] = None,
+    input_global_scale2: Optional[torch.Tensor] = None,
+    global_scale1: Optional[torch.Tensor] = None,
+    global_scale2: Optional[torch.Tensor] = None,
+    g_idx1: Optional[torch.Tensor] = None,
+    g_idx2: Optional[torch.Tensor] = None,
+    sort_indices1: Optional[torch.Tensor] = None,
+    sort_indices2: Optional[torch.Tensor] = None,
+    w1_zeros: Optional[torch.Tensor] = None,
+    w2_zeros: Optional[torch.Tensor] = None,
+    workspace: Optional[torch.Tensor] = None,
+    intermediate_cache13: Optional[torch.Tensor] = None,
+    intermediate_cache2: Optional[torch.Tensor] = None,
+    is_k_full: bool = True,
+    output: Optional[torch.Tensor] = None,
+    input_dtype: Optional[torch.dtype] = None,
+    inplace: bool = False,
+    clamp_limit: Optional[float] = None,
+    group_size: int = 128,
+) -> torch.Tensor:
+    """Use the PPU AIU path for supported W4A16 INT4 inputs."""
+
+    activation_str = "silu"
+    if activation is not None:
+        for attr in ("value", "name"):
+            value = getattr(activation, attr, None)
+            if isinstance(value, str):
+                activation_str = value.lower()
+                break
+        if isinstance(activation, str):
+            activation_str = activation.lower()
+
+    use_ppu_w4a16 = (
+        tle_async is not None
+        and quant_type_id == QUANT_TYPE_UINT4B8
+        and activation_str == "silu"
+        and hidden_states.dtype in (torch.float16, torch.bfloat16)
+        and w1.dtype == torch.uint8
+        and w2.dtype == torch.uint8
+        and bias1 is None
+        and bias2 is None
+        and w1_zeros is None
+        and w2_zeros is None
+        and expert_map is None
+        and input_dtype is None
+        and clamp_limit is None
+        and input_global_scale1 is None
+        and input_global_scale2 is None
+        and global_scale1 is None
+        and global_scale2 is None
+        and g_idx1 is None
+        and g_idx2 is None
+        and sort_indices1 is None
+        and sort_indices2 is None
+        and (global_num_experts == -1 or global_num_experts == w1.size(0))
+        and group_size == 128
+        and w1_scale.dtype == hidden_states.dtype
+        and w2_scale.dtype == hidden_states.dtype
+    )
+    if use_ppu_w4a16:
+        if inplace and output is not None:
+            raise ValueError("Cannot pass both inplace=True and output")
+        result = fused_marlin_moe_w4a16_int4(
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=activation_str,
+            group_size=group_size,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            inplace=inplace,
+        )
+        if output is not None:
+            output.copy_(result)
+            return output
+        return result
+
+    return _generic_fused_marlin_moe(
+        hidden_states=hidden_states,
+        w1=w1,
+        w2=w2,
+        bias1=bias1,
+        bias2=bias2,
+        w1_scale=w1_scale,
+        w2_scale=w2_scale,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        quant_type_id=quant_type_id,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+        global_num_experts=global_num_experts,
+        activation=activation,
+        activation_func=activation_func,
+        moe_sum=moe_sum,
+        expert_map=expert_map,
+        input_global_scale1=input_global_scale1,
+        input_global_scale2=input_global_scale2,
+        global_scale1=global_scale1,
+        global_scale2=global_scale2,
+        g_idx1=g_idx1,
+        g_idx2=g_idx2,
+        sort_indices1=sort_indices1,
+        sort_indices2=sort_indices2,
+        w1_zeros=w1_zeros,
+        w2_zeros=w2_zeros,
+        workspace=workspace,
+        intermediate_cache13=intermediate_cache13,
+        intermediate_cache2=intermediate_cache2,
+        is_k_full=is_k_full,
+        output=output,
+        input_dtype=input_dtype,
+        inplace=inplace,
+        clamp_limit=clamp_limit,
+        group_size=group_size,
+    )
+
+
+__all__ = ["fused_marlin_moe"]

--- a/src/flaggems_vllm/runtime/backend/_thead/fused/fused_marlin_moe_w4a16_int4.py
+++ b/src/flaggems_vllm/runtime/backend/_thead/fused/fused_marlin_moe_w4a16_int4.py
@@ -38,9 +38,7 @@ from flaggems_vllm.ops.fused_marlin_moe import (
 from flaggems_vllm.ops.fused_marlin_moe import (
     fused_marlin_moe as _generic_fused_marlin_moe,
 )
-from flaggems_vllm.ops.fused_marlin_moe import (
-    w4a16_int4_pack,
-)
+from flaggems_vllm.ops.fused_marlin_moe import w4a16_int4_pack
 from flaggems_vllm.ops.moe_align_block_size import moe_align_block_size
 from flaggems_vllm.ops.moe_sum import moe_sum
 from flaggems_vllm.ops.silu_and_mul import silu_and_mul_out
@@ -1009,7 +1007,7 @@ def _invoke_ppu_w4a16_int4_moe_gemm_grouped(
     )
 
 
-def fused_marlin_moe_w4a16_int4(
+def _fused_marlin_moe_w4a16_int4_impl(
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
     w2: torch.Tensor,
@@ -1311,7 +1309,7 @@ def fused_marlin_moe_w4a16_int4(
     return out_hidden_states
 
 
-def fused_marlin_moe(
+def fused_marlin_moe_w4a16_int4(
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
     w2: torch.Tensor,
@@ -1392,7 +1390,7 @@ def fused_marlin_moe(
         and w2_scale.dtype == hidden_states.dtype
     )
     if use_ppu_w4a16:
-        result = fused_marlin_moe_w4a16_int4(
+        result = _fused_marlin_moe_w4a16_int4_impl(
             hidden_states=hidden_states,
             w1=w1,
             w2=w2,
@@ -1446,4 +1444,4 @@ def fused_marlin_moe(
     )
 
 
-__all__ = ["fused_marlin_moe"]
+__all__ = ["fused_marlin_moe_w4a16_int4"]

--- a/tests/test_fused_marlin_moe.py
+++ b/tests/test_fused_marlin_moe.py
@@ -25,8 +25,6 @@ fp16/bf16 w_ref returned by quantize_weights so quantization round-off is
 shared by both sides.
 """
 
-import importlib
-
 import pytest
 import torch
 
@@ -38,14 +36,9 @@ from flaggems_vllm.ops.fused_marlin_moe import (
     QUANT_TYPE_UINT8B128,
 )
 
-fused_marlin_moe = flaggems_vllm.fused_marlin_moe
-
-if runtime.device.vendor_name == "thead":
-    thead_moe = importlib.import_module(
-        "flaggems_vllm.runtime.backend._thead.fused.fused_marlin_moe"
-    )
-
 from . import conftest as cfg
+
+fused_marlin_moe = flaggems_vllm.fused_marlin_moe
 
 
 def _is_hopper():
@@ -72,24 +65,6 @@ def test_fused_marlin_moe_uses_thead_specialization():
     assert fused_marlin_moe.__module__ == (
         "flaggems_vllm.runtime.backend._thead.fused.fused_marlin_moe"
     )
-
-
-@pytest.mark.skipif(
-    runtime.device.vendor_name != "thead",
-    reason="T-Head kernel policy is only available on T-Head devices",
-)
-def test_ppu_direct_route_grid_limits():
-    # PR 5140 geometry uses direct-route only for the smallest decode batches.
-    assert thead_moe._select_ppu_direct_block_n(4096) == 128
-    assert thead_moe._use_ppu_direct_route(4, 6, 4096, 256)
-    assert not thead_moe._use_ppu_direct_route(8, 6, 4096, 256)
-
-    # The same route-density limit applies to larger intermediate dimensions.
-    max_output_n = max(4096, 2 * 14336)
-    n_tiles = max_output_n // thead_moe._select_ppu_direct_block_n(max_output_n)
-    assert 32 * n_tiles <= 65535
-    assert thead_moe._use_ppu_direct_route(16, 2, 4096, 14336)
-    assert not thead_moe._use_ppu_direct_route(17, 2, 4096, 14336)
 
 
 # -----------------------------------------------------------------------------
@@ -601,8 +576,8 @@ def test_fused_marlin_moe_w4a16_int4_ppu_grouped():
     # 32 * top_k=2 exceeds the direct-route limit and naturally selects the
     # expert-grouped path.
     config = (32, 8, 128, 256, 2)
-    hs, w1_q, w2_q, w1_ref, w2_ref, tw, ti, w1s, w2s = (
-        _make_inputs_w4a16_int4(*config, torch.bfloat16, flaggems_vllm.device)
+    hs, w1_q, w2_q, w1_ref, w2_ref, tw, ti, w1s, w2s = _make_inputs_w4a16_int4(
+        *config, torch.bfloat16, flaggems_vllm.device
     )
     result = fused_marlin_moe(
         hidden_states=hs,
@@ -631,8 +606,8 @@ def test_fused_marlin_moe_w4a16_int4_ppu_reduce_direct(
     apply_router_weight_on_input,
 ):
     config = (2, 8, 128, 256, 2)
-    hs, w1_q, w2_q, w1_ref, w2_ref, tw, ti, w1s, w2s = (
-        _make_inputs_w4a16_int4(*config, torch.bfloat16, flaggems_vllm.device)
+    hs, w1_q, w2_q, w1_ref, w2_ref, tw, ti, w1s, w2s = _make_inputs_w4a16_int4(
+        *config, torch.bfloat16, flaggems_vllm.device
     )
     result = fused_marlin_moe(
         hidden_states=hs,

--- a/tests/test_fused_marlin_moe.py
+++ b/tests/test_fused_marlin_moe.py
@@ -38,7 +38,7 @@ from flaggems_vllm.ops.fused_marlin_moe import (
 
 from . import conftest as cfg
 
-fused_marlin_moe = flaggems_vllm.fused_marlin_moe
+fused_marlin_moe = flaggems_vllm.fused_marlin_moe_w4a16_int4
 
 
 def _is_hopper():
@@ -63,7 +63,7 @@ def _supports_w4a16_int4():
 )
 def test_fused_marlin_moe_uses_thead_specialization():
     assert fused_marlin_moe.__module__ == (
-        "flaggems_vllm.runtime.backend._thead.fused.fused_marlin_moe"
+        "flaggems_vllm.runtime.backend._thead.fused.fused_marlin_moe_w4a16_int4"
     )
 
 
@@ -773,3 +773,19 @@ def test_rejects_fp8_input_dtype():
             quant_type_id=QUANT_TYPE_UINT4B8,
             input_dtype=torch.float8_e4m3fn,
         )
+
+
+@pytest.mark.skipif(
+    runtime.device.vendor_name != "thead", reason="THead public dispatch"
+)
+def test_public_operator_registration():
+    import flaggems_vllm.ops as public_ops
+
+    op = flaggems_vllm.fused_marlin_moe_w4a16_int4
+    assert op.__name__ == "fused_marlin_moe_w4a16_int4"
+    assert (
+        op.__module__
+        == "flaggems_vllm.runtime.backend._thead.fused.fused_marlin_moe_w4a16_int4"
+    )
+    assert "fused_marlin_moe_w4a16_int4" in public_ops.__all__
+    assert ("fused_marlin_moe_w4a16_int4", op) in flaggems_vllm._FULL_CONFIG

--- a/tests/test_fused_marlin_moe.py
+++ b/tests/test_fused_marlin_moe.py
@@ -25,16 +25,25 @@ fp16/bf16 w_ref returned by quantize_weights so quantization round-off is
 shared by both sides.
 """
 
+import importlib
+
 import pytest
 import torch
 
 import flaggems_vllm
+from flaggems_vllm import runtime
 from flaggems_vllm.ops.fused_marlin_moe import (
     QUANT_TYPE_FP4_E2M1,
     QUANT_TYPE_UINT4B8,
     QUANT_TYPE_UINT8B128,
-    fused_marlin_moe,
 )
+
+fused_marlin_moe = flaggems_vllm.fused_marlin_moe
+
+if runtime.device.vendor_name == "thead":
+    thead_moe = importlib.import_module(
+        "flaggems_vllm.runtime.backend._thead.fused.fused_marlin_moe"
+    )
 
 from . import conftest as cfg
 
@@ -47,6 +56,40 @@ def _is_hopper():
     major, minor = torch.cuda.get_device_capability()
     sm = major * 10 + minor
     return 90 <= sm < 100
+
+
+def _supports_w4a16_int4():
+    # Hopper uses the specialized PTX path. T-Head PPU uses the TLE AIU
+    # direct-route path and an expert-grouped W4A16 path for larger grids.
+    return runtime.device.vendor_name == "thead" or _is_hopper()
+
+
+@pytest.mark.skipif(
+    runtime.device.vendor_name != "thead",
+    reason="T-Head dispatch is only available on T-Head devices",
+)
+def test_fused_marlin_moe_uses_thead_specialization():
+    assert fused_marlin_moe.__module__ == (
+        "flaggems_vllm.runtime.backend._thead.fused.fused_marlin_moe"
+    )
+
+
+@pytest.mark.skipif(
+    runtime.device.vendor_name != "thead",
+    reason="T-Head kernel policy is only available on T-Head devices",
+)
+def test_ppu_direct_route_grid_limits():
+    # PR 5140 geometry uses direct-route only for the smallest decode batches.
+    assert thead_moe._select_ppu_direct_block_n(4096) == 128
+    assert thead_moe._use_ppu_direct_route(4, 6, 4096, 256)
+    assert not thead_moe._use_ppu_direct_route(8, 6, 4096, 256)
+
+    # The same route-density limit applies to larger intermediate dimensions.
+    max_output_n = max(4096, 2 * 14336)
+    n_tiles = max_output_n // thead_moe._select_ppu_direct_block_n(max_output_n)
+    assert 32 * n_tiles <= 65535
+    assert thead_moe._use_ppu_direct_route(16, 2, 4096, 14336)
+    assert not thead_moe._use_ppu_direct_route(17, 2, 4096, 14336)
 
 
 # -----------------------------------------------------------------------------
@@ -502,8 +545,8 @@ def _reference_swiglu_moe(
 
 
 @pytest.mark.skipif(
-    not _is_hopper(),
-    reason="W4A16 fast path uses Hopper-only bf16 SIMD PTX (sm_90+)",
+    not _supports_w4a16_int4(),
+    reason="W4A16 INT4 is validated on NVIDIA Hopper and T-Head PPU",
 )
 @pytest.mark.parametrize("config", FULL_CONFIGS)
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
@@ -546,6 +589,73 @@ def test_fused_marlin_moe_w4a16_int4(config, dtype, apply_router_weight_on_input
     )
     torch.cuda.synchronize()
 
+    max_diff = compute_max_diff(result.float(), ref)
+    assert max_diff < 0.04, f"max_diff={max_diff:.4f}"
+
+
+@pytest.mark.skipif(
+    runtime.device.vendor_name != "thead",
+    reason="This test forces the T-Head expert-grouped AIU path",
+)
+def test_fused_marlin_moe_w4a16_int4_ppu_grouped():
+    # 32 * top_k=2 exceeds the direct-route limit and naturally selects the
+    # expert-grouped path.
+    config = (32, 8, 128, 256, 2)
+    hs, w1_q, w2_q, w1_ref, w2_ref, tw, ti, w1s, w2s = (
+        _make_inputs_w4a16_int4(*config, torch.bfloat16, flaggems_vllm.device)
+    )
+    result = fused_marlin_moe(
+        hidden_states=hs,
+        w1=w1_q,
+        w2=w2_q,
+        bias1=None,
+        bias2=None,
+        w1_scale=w1s,
+        w2_scale=w2s,
+        topk_weights=tw,
+        topk_ids=ti,
+        quant_type_id=QUANT_TYPE_UINT4B8,
+    )
+    ref = _reference_swiglu_moe(hs, w1_ref, w2_ref, tw, ti)
+    torch.cuda.synchronize()
+    max_diff = compute_max_diff(result.float(), ref)
+    assert max_diff < 0.04, f"max_diff={max_diff:.4f}"
+
+
+@pytest.mark.skipif(
+    runtime.device.vendor_name != "thead",
+    reason="This test covers the T-Head fused GEMM2/top-k reduction path",
+)
+@pytest.mark.parametrize("apply_router_weight_on_input", [False, True])
+def test_fused_marlin_moe_w4a16_int4_ppu_reduce_direct(
+    apply_router_weight_on_input,
+):
+    config = (2, 8, 128, 256, 2)
+    hs, w1_q, w2_q, w1_ref, w2_ref, tw, ti, w1s, w2s = (
+        _make_inputs_w4a16_int4(*config, torch.bfloat16, flaggems_vllm.device)
+    )
+    result = fused_marlin_moe(
+        hidden_states=hs,
+        w1=w1_q,
+        w2=w2_q,
+        bias1=None,
+        bias2=None,
+        w1_scale=w1s,
+        w2_scale=w2s,
+        topk_weights=tw,
+        topk_ids=ti,
+        quant_type_id=QUANT_TYPE_UINT4B8,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+    )
+    ref = _reference_swiglu_moe(
+        hs,
+        w1_ref,
+        w2_ref,
+        tw,
+        ti,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+    )
+    torch.cuda.synchronize()
     max_diff = compute_max_diff(result.float(), ref)
     assert max_diff < 0.04, f"max_diff={max_diff:.4f}"
 

--- a/tools/select_tests.py
+++ b/tools/select_tests.py
@@ -83,6 +83,12 @@ FULL_BENCHMARK_TRIGGER_FILES = {
 # Some existing tests do not follow the source-stem naming convention, so keep
 # a small explicit map here to avoid missing those tests.
 EXPLICIT_SOURCE_TO_TESTS = {
+    "src/flaggems_vllm/runtime/backend/_thead/fused/fused_marlin_moe_w4a16_int4.py": [
+        "tests/test_fused_marlin_moe.py"
+    ],
+    "src/flaggems_vllm/ops/fused_marlin_moe_w4a16_int4.py": [
+        "tests/test_fused_marlin_moe.py"
+    ],
     "src/flaggems_vllm/ops/rotary_embedding.py": ["tests/test_apply_rotary_pos_emb.py"],
     "src/flaggems_vllm/ops/flashmla_sparse.py": ["tests/test_flash_mla_sparse_fwd.py"],
     "src/flaggems_vllm/ops/fused_moe.py": ["tests/test_fused_experts_impl.py"],
@@ -120,6 +126,12 @@ EXPLICIT_SOURCE_TO_TESTS = {
 
 # Same for benchmarks: keep explicit entries only for non-standard names that cannot be inferred from the source stem.
 EXPLICIT_SOURCE_TO_BENCHMARKS = {
+    "src/flaggems_vllm/runtime/backend/_thead/fused/fused_marlin_moe_w4a16_int4.py": [
+        "benchmark/test_fused_marlin_moe_w4a16_int4.py"
+    ],
+    "src/flaggems_vllm/ops/fused_marlin_moe_w4a16_int4.py": [
+        "benchmark/test_fused_marlin_moe_w4a16_int4.py"
+    ],
     "src/flaggems_vllm/ops/rotary_embedding.py": [
         "benchmark/test_apply_rotary_pos_emb.py"
     ],


### PR DESCRIPTION
### PR Category

Operator, OP Test, Benchmark

### Type of Change

New Feature, Performance Optimization

### Description

This PR adds a THead backend specialization for `fused_marlin_moe_w4a16_int4` with BF16/FP16 activations and symmetric packed INT4 weights (`uint4b8`, group size 128).

The implementation is placed in `runtime/backend/_thead/fused/fused_marlin_moe_w4a16_int4.py`. The generic implementation remains in `ops/fused_marlin_moe.py`. The existing `SpecOpRegistrar` replaces the public `fused_marlin_moe_w4a16_int4` entry with the THead specialization, so this PR does not add a duplicate aten registration.

The THead implementation includes:

- TLE AIU asynchronous block-pointer loads for BF16 activations and INT32 packed weights.
- Fused INT4 extraction, zero-point subtraction, group-scale dequantization, BF16 `tl.dot`, and FP32 accumulation.
- A direct-route path for small routed-token batches.
- A fused GEMM2, router-weight, and top-k reduction path for `M <= 2`.
- An expert-grouped AIU path for larger M. Supported large-M cases do not fall back based on M.
- Fused SwiGLU and routed-layout staging for the grouped GEMM2 input.
- Shape-aware selection of `BLOCK_M`, `BLOCK_N`, program grouping, warp count, and pipeline stages.
- Cached conversion from the public uint8 packed-weight layout to the INT32 layout consumed by the PPU kernels.

The benchmark remains device-neutral. It uses the repository `base.Benchmark` interface, is located at `benchmark/test_fused_marlin_moe_w4a16_int4.py`, and compares the public FlagGems-vLLM entry with the same-precision vLLM CUDA Marlin implementation. Its 53 shapes and call counts are taken from the trace used by FlagGems PR #5140.

The unit tests call the public dispatched entry and cover the THead direct-route, fused reduction, and expert-grouped paths.

The public function, operator registration, generic entry module, and THead specialization use `fused_marlin_moe_w4a16_int4`.

### Issue

- Associated with [flagos-ai/FlagTree#1050](https://github.com/flagos-ai/FlagTree/issues/1050): TLE/PPU B32 lowering is required for INT32 `tle.load(..., is_async=True)` AIU copies.
- Benchmark shapes and call counts follow [flagos-ai/FlagGems#5140](https://github.com/flagos-ai/FlagGems/pull/5140).

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

Environment:

- PPU-ZW810E
- PyTorch 2.9.0
- Triton 3.6.0 with the TLE/PPU B32 change required by FlagTree issue #1050
- PPU SDK 2.1
- THead vLLM `0.13.1.dev0+g72506c983.d20260218`

Correctness:

```bash
python -m pytest -q tests/test_fused_marlin_moe.py \
  -k "fused_marlin_moe_w4a16_int4"
```

Result:

```text
75 passed, 48 deselected
```

Dispatch and THead path checks:

```text
5 passed, 119 deselected
```

These PPU results were collected on commit `d17a9e2`. Follow-up commit `6d494b1` does not change the compute kernels; it narrows host dispatch, removes a private-helper assertion, and applies repository formatting. A PPU re-run of the follow-up commit is pending.

Benchmark:

```bash
python -m pytest -q \
  benchmark/test_fused_marlin_moe_w4a16_int4.py \
  --mode operator --warmup 10 --iter 50
```

Additional public-name and routing regression checks: `13 passed, 15 deselected` with `--quick -k "w4a16_int4 or specialization or public_operator_registration"`.

The benchmark entry using the public name passes same-input native Marlin checks at `M=1,128,16384`. The compute-kernel ASTs match the measured implementation; the full latency table below retains those measurements.

Benchmark harness result: `1 passed`.

The baseline is `vllm.model_executor.layers.fused_moe.fused_marlin_moe.fused_marlin_moe`. Both paths use BF16 activations, GPTQ `uint4b8` weights, group size 128, identical top-k IDs, and FP32 router weights.

| Metric | Result |
| --- | ---: |
| Shapes | 53 |
| Shapes with speedup >= 1.2x | 53 / 53 |
| Minimum speedup | 1.249x |
| Call-count-weighted vLLM CUDA latency | 14.3512 ms |
| Call-count-weighted optimized latency | 4.2528 ms |
| Call-count-weighted speedup | 3.375x |
| Maximum absolute difference | 0.009766 |

The fixed benchmark geometry is `E=256, K=4096, N=256, top_k=6`.

Full synchronized fixed-repeat results:

| M | Calls | vLLM CUDA (ms) | Optimized (ms) | Speedup | Max diff |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 172 | 0.1750 | 0.1288 | 1.358x | 0.001953 |
| 2 | 172 | 0.1824 | 0.1386 | 1.316x | 0.001953 |
| 4 | 172 | 0.3810 | 0.2458 | 1.550x | 0.002930 |
| 8 | 172 | 0.5284 | 0.4229 | 1.249x | 0.003906 |
| 16 | 172 | 0.9507 | 0.6831 | 1.392x | 0.003906 |
| 24 | 172 | 1.3020 | 0.8794 | 1.481x | 0.003906 |
| 32 | 172 | 1.4992 | 1.0160 | 1.476x | 0.005859 |
| 40 | 172 | 1.7929 | 1.2435 | 1.442x | 0.004883 |
| 48 | 172 | 1.9494 | 1.3088 | 1.490x | 0.003906 |
| 56 | 172 | 2.0679 | 1.4054 | 1.471x | 0.003906 |
| 64 | 172 | 2.2081 | 1.4534 | 1.519x | 0.003906 |
| 72 | 172 | 2.3558 | 1.5732 | 1.498x | 0.007812 |
| 80 | 172 | 2.3704 | 1.5715 | 1.508x | 0.005859 |
| 88 | 172 | 2.5088 | 1.6650 | 1.507x | 0.005859 |
| 96 | 172 | 2.4219 | 1.5988 | 1.515x | 0.005859 |
| 104 | 172 | 2.5908 | 1.7010 | 1.523x | 0.007812 |
| 112 | 172 | 2.6818 | 1.8011 | 1.489x | 0.003906 |
| 120 | 172 | 2.6034 | 1.7244 | 1.510x | 0.005859 |
| 128 | 172 | 2.6816 | 1.7972 | 1.492x | 0.007812 |
| 136 | 172 | 2.6770 | 1.7495 | 1.530x | 0.007812 |
| 144 | 172 | 2.7240 | 1.8050 | 1.509x | 0.005859 |
| 152 | 172 | 2.7107 | 1.8130 | 1.495x | 0.005859 |
| 160 | 172 | 2.7800 | 1.8256 | 1.523x | 0.005859 |
| 168 | 172 | 2.7750 | 1.8172 | 1.527x | 0.004150 |
| 176 | 172 | 2.7951 | 1.8389 | 1.520x | 0.003906 |
| 184 | 172 | 2.8974 | 1.8343 | 1.580x | 0.005859 |
| 192 | 172 | 2.8411 | 1.8381 | 1.546x | 0.005859 |
| 200 | 172 | 2.9327 | 1.8418 | 1.592x | 0.007812 |
| 208 | 172 | 2.9365 | 1.8514 | 1.586x | 0.007812 |
| 216 | 172 | 3.0083 | 1.8605 | 1.617x | 0.007812 |
| 224 | 172 | 3.0262 | 1.8509 | 1.635x | 0.007812 |
| 232 | 172 | 3.0675 | 1.8558 | 1.653x | 0.007812 |
| 240 | 172 | 3.1427 | 1.8471 | 1.701x | 0.007812 |
| 248 | 172 | 3.1892 | 1.8483 | 1.725x | 0.003906 |
| 256 | 172 | 3.1450 | 1.8626 | 1.689x | 0.007812 |
| 272 | 172 | 3.3141 | 1.8669 | 1.775x | 0.005859 |
| 288 | 172 | 3.4148 | 1.8646 | 1.831x | 0.005859 |
| 304 | 172 | 3.5697 | 1.8715 | 1.907x | 0.007812 |
| 320 | 172 | 3.5326 | 1.8730 | 1.886x | 0.005859 |
| 336 | 172 | 3.5331 | 1.8736 | 1.886x | 0.005859 |
| 352 | 172 | 3.5443 | 1.8724 | 1.893x | 0.007812 |
| 368 | 172 | 3.6450 | 1.9439 | 1.875x | 0.007812 |
| 384 | 172 | 3.6449 | 1.8972 | 1.921x | 0.007812 |
| 400 | 172 | 3.6534 | 1.9064 | 1.916x | 0.007812 |
| 416 | 172 | 3.6887 | 1.9623 | 1.880x | 0.007812 |
| 432 | 172 | 3.6968 | 1.9649 | 1.881x | 0.005859 |
| 448 | 172 | 3.7610 | 1.9799 | 1.900x | 0.007812 |
| 464 | 172 | 3.7788 | 1.9818 | 1.907x | 0.007812 |
| 480 | 172 | 3.8506 | 2.0134 | 1.912x | 0.005859 |
| 496 | 344 | 3.9503 | 2.0448 | 1.932x | 0.007812 |
| 512 | 344 | 3.9857 | 2.1284 | 1.873x | 0.007812 |
| 2048 | 43 | 19.8704 | 4.6244 | 4.297x | 0.007812 |
| 16384 | 946 | 125.7754 | 29.4142 | 4.276x | 0.009766 |
| **Call-count weighted** | **10105** | **14.3512** | **4.2528** | **3.375x** | **<=0.009766** |



