### PR TITLE
[KMCompiler] Make persistent_topk tests/benchmark runnable on platforms without the vLLM native op

### DIFF
--- a/benchmark/test_persistent_topk.py
+++ b/benchmark/test_persistent_topk.py
@@ -16,27 +16,34 @@ import pytest
 import torch
 
 import flaggems_vllm
-from flaggems_vllm.ops.persistent_topk import persistent_topk
 
 from . import base
 
+# Bind the top-level entry: on vendor backends with a specialized
+# implementation (e.g. _hygon/fused), flaggems_vllm.persistent_topk is the
+# vendor version (replaced at import time); on NVIDIA it is the generic one.
+persistent_topk = flaggems_vllm.persistent_topk
+
 device = flaggems_vllm.device
 
+# The vLLM native op is used as the baseline where available (NVIDIA); on
+# platforms without torch.ops._C.persistent_topk (e.g. Hygon vllm-hcu) the
+# benchmark falls back to a torch.topk reference below.
 HAS_VLLM = False
 try:
     import vllm._custom_ops  # noqa: F401
 
     # `vllm._custom_ops` may import cleanly even when the compiled C++ extension
     # is missing, in which case the native op raises NotImplementedError at
-    # dispatch time. Probe one tiny call so the benchmark is skipped (rather
-    # than errored) when the kernel is not actually available.
+    # dispatch time. Probe one tiny call so the benchmark falls back (rather
+    # than errors) when the kernel is not actually available.
     _probe_logits = torch.zeros(1, 4102, dtype=torch.float32, device="cuda")
     _probe_lengths = torch.tensor([4102], dtype=torch.int32, device="cuda")
     torch.ops._C.persistent_topk(
         _probe_logits,
         _probe_lengths,
         torch.empty((1, 512), dtype=torch.int32, device="cuda"),
-        torch.empty(1024 * 1024, dtype=torch.uint8, device="cuda"),
+        torch.empty(2 * 1024 * 1024, dtype=torch.uint8, device="cuda"),
         512,
         4102,
     )
@@ -47,11 +54,57 @@ except (ImportError, AttributeError, NotImplementedError, RuntimeError):
 STRIDE = 262144
 K = 512
 
+# CUDA-Graph-safe lengths (torch.topk fallback only): the reference needs
+# host-side seq_lens to decide batched-vs-padded and to slice logits. Reading
+# the device tensor back (seq_lens.tolist()) inside CUDA Graph capture is
+# illegal on HIP, and even a warmed cache does not help: torch.topk's own
+# graph capture (small slices first, then large) leaves its private memory
+# pool reused by a later shape's seq_lens tensor, whose content is then
+# observed as 0/garbage on the first D2H read -> baseline collapses to
+# ~0.0018ms. Fix: precompute the host list once per shape in get_input_iter,
+# keyed by tensor id; _host_lengths only looks up the dict and never reads
+# the device tensor in the measured path.
+_HLEN_CACHE: dict = {}
+
+
+def _host_lengths(seq_lens):
+    return _HLEN_CACHE[id(seq_lens)]
+
 
 def _baseline_persistent_topk(
     logits, lengths, indices, workspace, max_seq_len, seq_lens
 ):
-    torch.ops._C.persistent_topk(logits, lengths, indices, workspace, K, max_seq_len)
+    """torch.topk baseline: vLLM native op where available, else a torch.topk
+    reference.
+
+    Matches persistent_topk semantics: top-k column indices in arbitrary
+    order (sorted=False), -1 padding when seq_len < k.
+
+    The torch.topk fallback is batched when all seq_lens are equal, else a
+    single batched topk over the -inf-padded rows (the heterogeneous rows are
+    -inf-padded to the full stride by get_input_iter, so one batched call
+    returns the per-row top-min(K, seq_len) real entries, and pad slots are
+    masked back to -1 via the returned values). A per-row baseline loop is
+    avoided: its sequential launches inflated the measured latency and made
+    the SpeedUp comparison unreliable.
+    """
+    if HAS_VLLM:
+        torch.ops._C.persistent_topk(
+            logits, lengths, indices, workspace, K, max_seq_len
+        )
+        return indices
+    lens = _host_lengths(seq_lens)
+    first = lens[0]
+    if all(x == first for x in lens):
+        k = min(K, first)
+        if k > 0:
+            _, idx = logits[:, :first].topk(k, dim=-1, sorted=False)
+            indices[:, :k] = idx
+        indices[:, k:] = -1
+        return indices
+    vals, idx = logits.topk(K, dim=-1, sorted=False)
+    real = vals > -1e30
+    indices[:, :] = torch.where(real, idx, -1)
     return indices
 
 
@@ -109,10 +162,19 @@ class PersistentTopKBenchmark(base.Benchmark):
                 (num_rows,), seq_len, dtype=torch.int32, device=self.device
             )
             indices = torch.empty((num_rows, K), dtype=torch.int32, device=self.device)
-            workspace = torch.empty(1024 * 1024, dtype=torch.uint8, device=self.device)
+            # vLLM native op uses its own layout (1MB suffices); the torch.topk
+            # fallback runs the vendor kernels, which need 2MB headroom.
+            workspace = torch.empty(
+                (1 if HAS_VLLM else 2) * 1024 * 1024,
+                dtype=torch.uint8,
+                device=self.device,
+            )
             seq_lens = torch.full(
                 (num_rows,), seq_len, dtype=torch.int32, device=self.device
             )
+            # precompute host lengths once per shape; _host_lengths only looks
+            # this up (never reads the device tensor in the measured path)
+            _HLEN_CACHE[id(seq_lens)] = [seq_len] * num_rows
 
             yield logits, lengths, indices, workspace, max_seq_len, seq_lens
 
@@ -133,13 +195,17 @@ class PersistentTopKBenchmark(base.Benchmark):
 
             lengths = lengths_values
             indices = torch.empty((num_rows, K), dtype=torch.int32, device=self.device)
-            workspace = torch.empty(1024 * 1024, dtype=torch.uint8, device=self.device)
+            workspace = torch.empty(
+                (1 if HAS_VLLM else 2) * 1024 * 1024,
+                dtype=torch.uint8,
+                device=self.device,
+            )
             seq_lens = lengths_values
+            _HLEN_CACHE[id(seq_lens)] = lengths_values.tolist()
 
             yield logits, lengths, indices, workspace, max_len, seq_lens
 
 
-@pytest.mark.skipif(not HAS_VLLM, reason="vLLM not installed")
 @pytest.mark.persistent_topk
 def test_persistent_topk():
     bench = PersistentTopKBenchmark(

--- a/tests/test_persistent_topk.py
+++ b/tests/test_persistent_topk.py
@@ -19,9 +19,13 @@ import torch
 import triton.language as tl
 
 import flaggems_vllm
-from flaggems_vllm.ops.persistent_topk import persistent_topk
 
 from . import conftest as cfg
+
+# Bind the top-level entry: on vendor backends with a specialized
+# implementation (e.g. _hygon/fused), flaggems_vllm.persistent_topk is the
+# vendor version (replaced at import time); on NVIDIA it is the generic one.
+persistent_topk = flaggems_vllm.persistent_topk
 
 device = flaggems_vllm.device
 
@@ -49,7 +53,7 @@ try:
         num_rows = logits.shape[0]
         lengths = torch.tensor(seq_lens, dtype=torch.int32, device=device)
         indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
-        workspace = torch.empty(1024 * 1024, dtype=torch.uint8, device=device)
+        workspace = torch.empty(2 * 1024 * 1024, dtype=torch.uint8, device=device)
         torch.ops._C.persistent_topk(
             logits, lengths, indices, workspace, top_k, max_seq_len
         )
@@ -155,7 +159,7 @@ def _gems_decode(logits, seq_lens, top_k, max_seq_len=None):
 
 
 @pytest.mark.persistent_topk
-@pytest.mark.skipif(not HAS_VLLM, reason="vLLM not installed")
+@pytest.mark.skipif(not HAS_VLLM, reason="vLLM native op unavailable")
 @pytest.mark.parametrize("num_rows, seq_len, max_seq_len", SHAPES)
 @pytest.mark.parametrize("data_type", DATA_TYPES)
 @torch.inference_mode()
@@ -172,7 +176,6 @@ def test_persistent_topk_cross_agreement(num_rows, seq_len, max_seq_len, data_ty
 
 
 @pytest.mark.persistent_topk
-@pytest.mark.skipif(not HAS_VLLM, reason="vLLM not installed")
 @pytest.mark.parametrize("num_rows, seq_len, max_seq_len", SHAPES)
 @pytest.mark.parametrize("data_type", DATA_TYPES)
 @torch.inference_mode()
@@ -223,7 +226,7 @@ def test_persistent_topk_heterogeneous(max_seq_len, lengths_list, case_id):
     logits, lengths = _make_hetero_logits(lengths_list)
     num_rows = len(lengths_list)
 
-    ws = torch.empty(1024 * 1024, dtype=torch.uint8, device=device)
+    ws = torch.empty(2 * 1024 * 1024, dtype=torch.uint8, device=device)
     indices = torch.empty((num_rows, K), dtype=torch.int32, device=device)
 
     persistent_topk(logits, lengths, indices, ws, k=K, max_seq_len=max_seq_len)
@@ -248,7 +251,7 @@ def test_persistent_topk_k_values(k, lengths_list, max_seq_len):
     logits, lengths = _make_hetero_logits(lengths_list)
     num_rows = len(lengths_list)
 
-    ws = torch.empty(1024 * 1024, dtype=torch.uint8, device=device)
+    ws = torch.empty(2 * 1024 * 1024, dtype=torch.uint8, device=device)
     indices = torch.empty((num_rows, k), dtype=torch.int32, device=device)
 
     persistent_topk(logits, lengths, indices, ws, k=k, max_seq_len=max_seq_len)
@@ -278,7 +281,7 @@ def test_persistent_topk_mtp():
         logits[i, :sl] = torch.randn(sl, device=device)
 
     indices = torch.empty((num_rows, K), dtype=torch.int32, device=device)
-    ws = torch.empty(1024 * 1024, dtype=torch.uint8, device=device)
+    ws = torch.empty(2 * 1024 * 1024, dtype=torch.uint8, device=device)
 
     persistent_topk(logits, lengths_2d, indices, ws, k=K, max_seq_len=32774)
 
@@ -302,7 +305,7 @@ def test_persistent_topk_boundary(lengths_list, max_seq_len, case_id):
     logits, lengths = _make_hetero_logits(lengths_list)
     num_rows = len(lengths_list)
 
-    ws = torch.empty(1024 * 1024, dtype=torch.uint8, device=device)
+    ws = torch.empty(2 * 1024 * 1024, dtype=torch.uint8, device=device)
     indices = torch.empty((num_rows, K), dtype=torch.int32, device=device)
 
     persistent_topk(logits, lengths, indices, ws, k=K, max_seq_len=max_seq_len)
@@ -351,7 +354,7 @@ def test_persistent_topk_random_stress():
             logits[i, :sl] = torch.randn(sl, dtype=torch.float32, device=device)
         lengths = torch.tensor(seq_lens, dtype=torch.int32, device=device)
 
-        ws = torch.empty(1024 * 1024, dtype=torch.uint8, device=device)
+        ws = torch.empty(2 * 1024 * 1024, dtype=torch.uint8, device=device)
         indices = torch.empty((B, K), dtype=torch.int32, device=device)
 
         persistent_topk(logits, lengths, indices, ws, k=K, max_seq_len=max_seq_len)
@@ -377,7 +380,7 @@ def test_persistent_topk_data_distributions(lengths_list, dist):
     logits, lengths = _make_hetero_logits_dist(lengths_list, dist)
     num_rows = len(lengths_list)
 
-    ws = torch.empty(1024 * 1024, dtype=torch.uint8, device=device)
+    ws = torch.empty(2 * 1024 * 1024, dtype=torch.uint8, device=device)
     indices = torch.empty((num_rows, K), dtype=torch.int32, device=device)
 
     persistent_topk(logits, lengths, indices, ws, k=K, max_seq_len=max(lengths_list))


### PR DESCRIPTION
### PR Category

[ OP Test | Benchmark ]

### Type of Change

[ Refactor ]

### Description

The generic functional tests and benchmark for persistent_topk currently assume
vLLM's C++ native op (`torch.ops._C.persistent_topk`) is available: the benchmark
is skipped entirely on platforms without it, and in the functional tests a large
group of cases whose reference is plain `torch.topk` (`test_persistent_topk_vs_torch`,
56 cases) is gated off together with the vLLM comparisons, even though only
`test_persistent_topk_cross_agreement` (56 cases) actually needs the vLLM op.
This PR makes both files runnable on platforms **without** the vLLM native op
(e.g. Hygon vllm-hcu) while keeping NVIDIA/vLLM-platform behavior unchanged:

1. **Call through the top-level `flaggems_vllm.persistent_topk` entry**: the repo's
   vendor-dispatch mechanism for fused operators (vendor backend, e.g.
   `_hygon/fused`) replaces same-named top-level implementations at import time
   by vendor (same mechanism as moe's `fused_experts_impl`). The tests previously
   imported `from flaggems_vllm.ops.persistent_topk import persistent_topk`
   directly, bypassing dispatch. Binding the top-level entry means platforms with
   a specialized implementation exercise it automatically, while NVIDIA still
   gets the generic one.
2. **Un-gate `test_persistent_topk_vs_torch`** (`skipif(not HAS_VLLM)` removed):
   its reference is plain `torch.topk` with no vLLM dependency; the 56 cases now
   run on every platform.
3. **Keep `test_persistent_topk_cross_agreement` gated**, with a more accurate
   skip reason, "vLLM native op unavailable" (it cross-checks against the vLLM
   native implementation and genuinely requires it).
4. **Fixed workspaces bumped 1MB -> 2MB**: vendor kernels (Hygon) need the extra
   headroom to satisfy their workspace assertions (used by `_gems_decode` and the
   heterogeneous/boundary/... cases on non-vLLM platforms).
5. **Dual-path benchmark baseline**: when `HAS_VLLM` is true the vLLM native op
   baseline is kept (NVIDIA CI behavior unchanged); otherwise the baseline falls
   back to a **batched `torch.topk` reference** — batched slice for equal-length
   rows, or for heterogeneous rows (already -inf-padded to the full stride) a
   single batched `logits.topk(K, dim=-1)` call whose pad slots are masked back
   to -1 via the returned values (avoiding the per-row baseline loop whose launch
   storm inflated the torch latency). Host-side lengths are precomputed once per
   shape (`_HLEN_CACHE`) so the measured path performs no device reads, keeping
   CUDA-graph capture safe (the historical HIP issue where torch.topk's graph
   capture pollutes device-side `seq_lens`).

### Issue

N/A (no related issue)

### Progress

- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

No operator kernels are touched — only test/benchmark runnability and the
baseline methodology change, so there is no performance-regression risk.