### PR TITLE
[KMCompiler] Refactor: register backend moe_align_block_size via fused __init__

### DIFF
--- a/src/flaggems_vllm/runtime/backend/_hygon/fused/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_hygon/fused/__init__.py
@@ -17,9 +17,13 @@ from flaggems_vllm.runtime.backend._hygon.fused.fused_moe import (  # noqa: F401
     inplace_fused_experts,
     outplace_fused_experts,
 )
+from flaggems_vllm.runtime.backend._hygon.fused.moe_align_block_size import (  # noqa: F401
+    moe_align_block_size,
+)
 
 __all__ = [
     "fused_experts_impl",
     "inplace_fused_experts",
     "outplace_fused_experts",
+    "moe_align_block_size",
 ]

--- a/src/flaggems_vllm/runtime/backend/_hygon/fused/fused_moe.py
+++ b/src/flaggems_vllm/runtime/backend/_hygon/fused/fused_moe.py
@@ -22,10 +22,20 @@ import torch.nn.functional as F
 import triton
 import triton.language as tl
 
-from flaggems_vllm.runtime.backend._hygon.fused.moe_align_block_size import (
-    moe_align_block_size,
-)
 from flaggems_vllm.utils import pointwise_dynamic
+
+
+def _moe_align_block_size(topk_ids, block_size, num_experts, expert_map=None):
+    """moe_align_block_size resolved through the top-level dispatch table.
+
+    The vendor ``fused/__init__`` exports this backend's TLE-free
+    implementation, so the SpecOpRegistrar overwrites
+    ``flaggems_vllm.moe_align_block_size`` at import time. Resolve lazily:
+    this module is imported while that patch is being applied.
+    """
+    from flaggems_vllm import moe_align_block_size as _impl
+
+    return _impl(topk_ids, block_size, num_experts, expert_map=expert_map)
 
 
 @triton.jit
@@ -2088,12 +2098,14 @@ def fused_experts_impl(
         )
 
         if not naive_block_assignment:
-            sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
-                curr_topk_ids,
-                base_config["BLOCK_SIZE_M"],
-                global_num_experts,
-                expert_map,
-                # ignore_invalid_experts=True,
+            sorted_token_ids, expert_ids, num_tokens_post_padded = (
+                _moe_align_block_size(
+                    curr_topk_ids,
+                    base_config["BLOCK_SIZE_M"],
+                    global_num_experts,
+                    expert_map,
+                    # ignore_invalid_experts=True,
+                )
             )
         else:
             max_num_tokens_padded = topk_ids.numel() * base_config["BLOCK_SIZE_M"]

--- a/src/flaggems_vllm/runtime/backend/_thead/fused/__init__.py
+++ b/src/flaggems_vllm/runtime/backend/_thead/fused/__init__.py
@@ -17,9 +17,13 @@ from flaggems_vllm.runtime.backend._thead.fused.fused_moe import (
     inplace_fused_experts,
     outplace_fused_experts,
 )
+from flaggems_vllm.runtime.backend._thead.fused.moe_align_block_size import (  # noqa: F401
+    moe_align_block_size,
+)
 
 __all__ = [
     "fused_experts_impl",
     "inplace_fused_experts",
     "outplace_fused_experts",
+    "moe_align_block_size",
 ]

--- a/src/flaggems_vllm/runtime/backend/_thead/fused/fused_moe.py
+++ b/src/flaggems_vllm/runtime/backend/_thead/fused/fused_moe.py
@@ -24,10 +24,21 @@ import triton.language as tl
 
 from flaggems_vllm.ops.moe_sum import moe_sum
 from flaggems_vllm.runtime import device, torch_device_fn
-from flaggems_vllm.runtime.backend._thead.fused.moe_align_block_size import (
-    moe_align_block_size,
-)
 from flaggems_vllm.utils import pointwise_dynamic
+
+
+def _moe_align_block_size(topk_ids, block_size, num_experts, expert_map=None):
+    """moe_align_block_size resolved through the top-level dispatch table.
+
+    The vendor ``fused/__init__`` exports this backend's TLE-free
+    implementation, so the SpecOpRegistrar overwrites
+    ``flaggems_vllm.moe_align_block_size`` at import time. Resolve lazily:
+    this module is imported while that patch is being applied.
+    """
+    from flaggems_vllm import moe_align_block_size as _impl
+
+    return _impl(topk_ids, block_size, num_experts, expert_map=expert_map)
+
 
 logger = logging.getLogger(__name__)
 
@@ -1815,12 +1826,14 @@ def fused_experts_impl(
         )
 
         if not naive_block_assignment:
-            sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
-                curr_topk_ids,
-                base_config["BLOCK_SIZE_M"],
-                global_num_experts,
-                expert_map,
-                # ignore_invalid_experts=True,
+            sorted_token_ids, expert_ids, num_tokens_post_padded = (
+                _moe_align_block_size(
+                    curr_topk_ids,
+                    base_config["BLOCK_SIZE_M"],
+                    global_num_experts,
+                    expert_map,
+                    # ignore_invalid_experts=True,
+                )
             )
         else:
             max_num_tokens_padded = topk_ids.numel() * base_config["BLOCK_SIZE_M"]


### PR DESCRIPTION
## PR Category

[ Operator ]

## Type of Change

[ Refactoring | Performance Optimization ]

## Description

Register each vendor's `moe_align_block_size` in its `fused/__init__.py` so the
existing backend registrar (SpecOpRegistrar, same mechanism as
`fused_experts_impl`) replaces the generic implementation on that platform, and
drop the explicit per-vendor import from the vendor `fused_moe` kernels.

### Background

- The generic `flaggems_vllm.moe_align_block_size` prefers a TLE cooperative
  kernel (`moe_align_block_size_tle_atomic_fused_coop`) whose
  `tle.distributed_barrier` cannot be compiled on the Hygon DCU (gfx936) and
  PPU (thead ZW810E) backends; every call pays a failed-JIT attempt
  (~257ms on Hygon, ~30ms on PPU) and dumps an MLIR error to stderr, then
  silently falls back to the non-TLE 4-stage pipeline.
- Both vendors therefore ship their own TLE-free
  `moe_align_block_size` (`_hygon/fused/moe_align_block_size.py`,
  `_thead/fused/moe_align_block_size.py`), but until now they were only
  reachable via an **explicit import** inside each vendor's `fused_moe.py`;
  the public `flaggems_vllm.moe_align_block_size` entry still hit the generic
  TLE-failing path on these platforms.

### Changes

- `_hygon/fused/__init__.py` and `_thead/fused/__init__.py` now also export
  `moe_align_block_size` (added to `__all__`). Because
  `SpecOpRegistrar` collects the functions exposed by the vendor `fused`
  package and overwrites the `flaggems_vllm` top-level globals, the public
  `flaggems_vllm.moe_align_block_size` resolves to the vendor TLE-free
  implementation on Hygon/PPU — same registration pattern as
  `fused_experts_impl`.
- `_hygon/fused/fused_moe.py` and `_thead/fused/fused_moe.py` no longer import
  the platform align module explicitly; they resolve
  `flaggems_vllm.moe_align_block_size` lazily (module import happens while the
  registrar patch is being applied, so a module-level binding would capture the
  not-yet-overridden generic implementation).
- No behavior change on other backends (they expose no vendor align, so the
  top-level symbol keeps resolving to the generic implementation).

### Effect on Hygon / PPU

| entry point | before | after |
|---|---|---|
| `flaggems_vllm.moe_align_block_size` (Hygon) | generic: ~257ms/call TLE failed-JIT + MLIR error spam, then fallback | vendor: ~0.3ms, no errors |
| `flaggems_vllm.moe_align_block_size` (PPU) | generic: ~30ms/call TLE failed-JIT | vendor 4-stage (~70-110us) |
| vendor `fused_moe` kernels | explicit platform import | top-level dispatch (vendor agnostic) |

## Issue

N/A

## Progress

- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.