### PR TITLE
[KMCompiler] Make combine_topk_swa_indices tests/benchmark runnable on non-NVIDIA platforms

### DIFF
--- a/benchmark/test_deepseek_v4_attention_combine_topk_swa_indices.py
+++ b/benchmark/test_deepseek_v4_attention_combine_topk_swa_indices.py
@@ -15,9 +15,7 @@
 import pytest
 import torch
 
-from flaggems_vllm.ops.deepseek_v4_attention_combine_topk_swa_indices import (
-    combine_topk_swa_indices,
-)
+import flaggems_vllm
 
 try:
     from vllm.v1.attention.ops.deepseek_v4_ops import (
@@ -31,12 +29,94 @@ except Exception:
 
 from . import base
 
+# Bind through the top-level entry rather than the ops submodule: when a vendor
+# ships a specialized implementation, the runtime rebinds it on the package at
+# import time, so importing from flaggems_vllm.ops.<module> would bypass vendor
+# dispatch (same reasoning as persistent_topk).
+combine_topk_swa_indices = flaggems_vllm.combine_topk_swa_indices
+
+# Device-agnostic entry point: "cuda" on NVIDIA / MetaX / Hygon / T-Head,
+# "musa" on MThreads, "npu" on Ascend. Never hard-code "cuda" below.
+device = flaggems_vllm.device
+_device_module = getattr(torch, device, None)
+_HAS_DEVICE = _device_module is not None and _device_module.is_available()
+
+# Keep in sync with _SPARSE_PREFILL_TOPK_ALIGNMENT in the operator module.
+_TOPK_ALIGNMENT = 128
+
+
+def _torch_combine_topk_swa_indices(
+    topk_indices,
+    query_start_loc,
+    seq_lens,
+    gather_lens,
+    window_size,
+    compress_ratio,
+    topk,
+    M,
+    N,
+):
+    """Vectorized PyTorch baseline.
+
+    The vLLM op is CUDA-only, so it is unavailable on every non-NVIDIA backend.
+    This reference keeps the benchmark runnable there; it is built from plain
+    PyTorch ops so it lowers on any vendor backend. Note that when this
+    fallback is in use the reported speedup is against PyTorch, not vLLM.
+    """
+    dev = topk_indices.device
+    num_tokens = topk_indices.shape[0]
+    num_reqs = seq_lens.shape[0]
+    combined_topk = (
+        (topk + window_size + _TOPK_ALIGNMENT - 1) // _TOPK_ALIGNMENT * _TOPK_ALIGNMENT
+    )
+
+    base_off = query_start_loc[0].to(torch.int64)
+    starts = query_start_loc[:-1].to(torch.int64) - base_off
+    ends = query_start_loc[1:].to(torch.int64) - base_off
+    query_lens = ends - starts
+
+    batch_id = torch.repeat_interleave(
+        torch.arange(num_reqs, device=dev, dtype=torch.int64), query_lens
+    )
+    seq = seq_lens.to(torch.int64)[batch_id]
+    gat = gather_lens.to(torch.int64)[batch_id]
+    token_idx = torch.arange(num_tokens, device=dev, dtype=torch.int64)
+    pos = (seq - query_lens[batch_id]) + (token_idx - starts[batch_id])
+    gather_start = seq - gat
+
+    topk_len = torch.clamp((pos + 1) // compress_ratio, max=topk)
+    swa_len = torch.clamp(pos + 1, max=window_size)
+    row_off = M * batch_id
+
+    combined = torch.full(
+        (num_tokens, combined_topk), -1, device=dev, dtype=torch.int32
+    )
+    cols_k = torch.arange(topk, device=dev, dtype=torch.int64).unsqueeze(0)
+    combined[:, :topk] = torch.where(
+        cols_k < topk_len.unsqueeze(1),
+        (topk_indices.to(torch.int64) + row_off.unsqueeze(1)).to(torch.int32),
+        combined[:, :topk],
+    )
+    cols = torch.arange(combined_topk, device=dev, dtype=torch.int64).unsqueeze(0)
+    off = cols - topk_len.unsqueeze(1)
+    swa_base = row_off + N + pos - swa_len + 1 - gather_start
+    combined = torch.where(
+        (off >= 0) & (off < swa_len.unsqueeze(1)),
+        (swa_base.unsqueeze(1) + off).to(torch.int32),
+        combined,
+    )
+    return combined, (topk_len + swa_len).to(torch.int32)
+
 
 class CombineTopkSwaIndicesBenchmark(base.Benchmark):
     def __init__(self):
         super().__init__(
             "combine_topk_swa_indices",
-            vllm_combine_topk_swa_indices,
+            (
+                vllm_combine_topk_swa_indices
+                if _HAS_VLLM_COMBINE_TOPK_SWA_INDICES
+                else _torch_combine_topk_swa_indices
+            ),
             [torch.int32],
             gems_op=combine_topk_swa_indices,
         )
@@ -79,18 +159,18 @@ class CombineTopkSwaIndicesBenchmark(base.Benchmark):
                 -1,
                 max(N, 1),
                 (num_tokens, topk),
-                device="cuda",
+                device=device,
                 dtype=torch.int32,
             )
             query_start_values = [0]
             for query_len in query_lens:
                 query_start_values.append(query_start_values[-1] + query_len)
             query_start_loc = torch.tensor(
-                query_start_values, device="cuda", dtype=torch.int32
+                query_start_values, device=device, dtype=torch.int32
             )
-            seq_lens = torch.tensor(seq_lens_values, device="cuda", dtype=torch.int32)
+            seq_lens = torch.tensor(seq_lens_values, device=device, dtype=torch.int32)
             gather_lens = torch.tensor(
-                gather_lens_values, device="cuda", dtype=torch.int32
+                gather_lens_values, device=device, dtype=torch.int32
             )
             yield (
                 topk_indices,
@@ -106,9 +186,6 @@ class CombineTopkSwaIndicesBenchmark(base.Benchmark):
 
 
 @pytest.mark.combine_topk_swa_indices
-@pytest.mark.skipif(
-    (not torch.cuda.is_available()) or (not _HAS_VLLM_COMBINE_TOPK_SWA_INDICES),
-    reason="requires cuda and vllm deepseek_v4_ops.combine_topk_swa_indices",
-)
+@pytest.mark.skipif(not _HAS_DEVICE, reason=f"requires an available {device} device")
 def test_combine_topk_swa_indices_benchmark():
     CombineTopkSwaIndicesBenchmark().run()

--- a/tests/test_deepseek_v4_attention_combine_topk_swa_indices.py
+++ b/tests/test_deepseek_v4_attention_combine_topk_swa_indices.py
@@ -15,12 +15,23 @@
 import pytest
 import torch
 
+import flaggems_vllm
 import flaggems_vllm.testing as fg_testing
-from flaggems_vllm.ops.deepseek_v4_attention_combine_topk_swa_indices import (
-    combine_topk_swa_indices,
-)
+
+# Bind through the top-level entry rather than the ops submodule: when a vendor
+# ships a specialized implementation, the runtime rebinds it on the package at
+# import time, so importing from flaggems_vllm.ops.<module> would bypass vendor
+# dispatch (same reasoning as persistent_topk).
+combine_topk_swa_indices = flaggems_vllm.combine_topk_swa_indices
 
 pytestmark = pytest.mark.combine_topk_swa_indices
+
+# Device-agnostic entry point: the runtime resolves the vendor device name --
+# "cuda" on NVIDIA / MetaX / Hygon / T-Head, "musa" on MThreads, "npu" on
+# Ascend. Never hard-code "cuda" here.
+device = flaggems_vllm.device
+_device_module = getattr(torch, device, None)
+_HAS_DEVICE = _device_module is not None and _device_module.is_available()
 
 try:
     from vllm.v1.attention.ops.deepseek_v4_ops import (
@@ -76,7 +87,7 @@ except Exception:
         ),
     ],
 )
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda")
+@pytest.mark.skipif(not _HAS_DEVICE, reason=f"requires an available {device} device")
 def test_combine_topk_swa_indices_accuracy(
     topk_values,
     query_start_values,
@@ -88,7 +99,6 @@ def test_combine_topk_swa_indices_accuracy(
     M,
     N,
 ):
-    device = "cuda"
     topk_indices = torch.tensor(topk_values, device=device, dtype=torch.int32)
     query_start_loc = torch.tensor(query_start_values, device=device, dtype=torch.int32)
     seq_lens = torch.tensor(seq_len_values, device=device, dtype=torch.int32)
@@ -136,11 +146,11 @@ def test_combine_topk_swa_indices_accuracy(
 
 
 @pytest.mark.skipif(
-    (not torch.cuda.is_available()) or (not _HAS_VLLM_COMBINE_TOPK_SWA_INDICES),
-    reason="requires cuda and vllm deepseek_v4_ops.combine_topk_swa_indices",
+    (not _HAS_DEVICE) or (not _HAS_VLLM_COMBINE_TOPK_SWA_INDICES),
+    reason="requires an available device and "
+    "vllm deepseek_v4_ops.combine_topk_swa_indices",
 )
 def test_combine_topk_swa_indices_vllm_accuracy():
-    device = "cuda"
     topk_indices = torch.tensor(
         [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
         device=device,


### PR DESCRIPTION
### PR Category

[ OP Test | Benchmark ]

### Type of Change

[ Refactor ]

### Description

The generic functional test and benchmark for `combine_topk_swa_indices` currently
assume an NVIDIA/vLLM platform: both are gated on `torch.cuda.is_available()`, both
hard-code `device="cuda"` when building inputs, and the benchmark uses vLLM's
`deepseek_v4_ops.combine_topk_swa_indices` as its only baseline, so it is skipped
entirely where vLLM is absent. The result is that both files are skipped rather than
run on MetaX, MThreads, Hygon, T-Head and Ascend alike — including MetaX / Hygon /
T-Head, whose `device_name` already resolves to `"cuda"` and which would otherwise
pass. This PR makes both files runnable on those platforms while keeping
NVIDIA/vLLM-platform behavior unchanged:

1. **Call through the top-level `flaggems_vllm.combine_topk_swa_indices` entry**: the
   repo's vendor-dispatch mechanism replaces same-named top-level implementations at
   import time by vendor (same mechanism as moe's `fused_experts_impl`). Both files
   previously imported `from flaggems_vllm.ops.deepseek_v4_attention_combine_topk_swa_indices
   import combine_topk_swa_indices` directly, bypassing dispatch. No vendor overrides
   this operator today, so behavior is unchanged for now; binding the top-level entry
   means a platform that later ships a specialized implementation exercises it
   automatically, while NVIDIA still gets the generic one.
2. **Resolve the device through the runtime**: `device = flaggems_vllm.device`
   (`"cuda"` on NVIDIA / MetaX / Hygon / T-Head, `"musa"` on MThreads, `"npu"` on
   Ascend), replacing the six hard-coded `device="cuda"` sites (2 in the test, 4 in
   the benchmark). No `"cuda"` literal remains in either file.
3. **Gate on the resolved device instead of CUDA**: `torch.cuda.is_available()` is
   False on MThreads and Ascend, so both files skipped outright there. The skip now
   tests that device's own `is_available()` (`torch.cuda` / `torch.musa` /
   `torch.npu` uniformly). `test_combine_topk_swa_indices_vllm_accuracy` stays gated
   on the vLLM op, which it genuinely requires; only its skip reason was corrected.
4. **Dual-path benchmark baseline**: when the vLLM op is importable it is kept as the
   baseline (NVIDIA CI behavior unchanged); otherwise the baseline falls back to a
   **vectorized PyTorch reference** built from plain tensor ops so it lowers on any
   vendor backend. `base.Benchmark` compares the baseline against the gems output, so
   the fallback has to be numerically exact: it was verified element-for-element
   against the loop reference in `tests/` over all 7 benchmark shapes plus 6 edge
   cases (`topk_len == 0`, non-power-of-2 `window`/`topk`, `gather_len << seq_len`,
   and shapes where `combined_topk` is mostly alignment padding), 13/13 exact. It is
   vectorized rather than reusing the `tests/` loop because that loop takes ~1 s at
   4096 tokens and would inflate the measured torch latency. Note that while the
   fallback is in use the reported speedup is against PyTorch, not vLLM.

### Issue

N/A (no related issue)

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

No operator kernels are touched — only test/benchmark runnability and the baseline
methodology change, so there is no performance-regression risk.

Benchmark on **MetaX C550** (`--mode kernel`, dtype `torch.int32`,
torch 2.8.0+metax3.7.1.4, triton 3.6.0, single run). **Baseline: vLLM's
`deepseek_v4_ops.combine_topk_swa_indices`**.

| Torch Latency (ms) | Gems Latency (ms) | Gems Speedup | Size Detail |
|---:|---:|---:|---|
| 0.027904 | 0.026112 | 1.069 | `[torch.Size([5, 4]), torch.Size([3]), torch.Size([2]), torch.Size([2]), 4, 2, 4, 20, 8]` |
| 0.028672 | 0.026112 | 1.098 | `[torch.Size([128, 32]), torch.Size([2]), torch.Size([1]), torch.Size([1]), 128, 4, 32, 42240, 40960]` |
| 0.032000 | 0.029440 | 1.087 | `[torch.Size([768, 64]), torch.Size([3]), torch.Size([2]), torch.Size([2]), 256, 4, 64, 45056, 40960]` |
| 0.050944 | 0.047360 | 1.076 | `[torch.Size([4096, 128]), torch.Size([2]), torch.Size([1]), torch.Size([1]), 256, 4, 128, 45056, 40960]` |
| 0.036608 | 0.034048 | 1.075 | `[torch.Size([2048, 128]), torch.Size([3]), torch.Size([2]), torch.Size([2]), 256, 4, 128, 45056, 40960]` |
| 0.028928 | 0.026112 | 1.108 | `[torch.Size([128, 32]), torch.Size([2]), torch.Size([1]), torch.Size([1]), 256, 128, 32, 5632, 1280]` |
| 0.049664 | 0.046848 | 1.060 | `[torch.Size([4096, 128]), torch.Size([2]), torch.Size([1]), torch.Size([1]), 256, 128, 128, 8448, 1280]` |

**Arithmetic mean speedup: 1.082x** (vs vLLM). All 7 shapes report SUCCESS.
