### PR TITLE
[KMCompiler]Enable cross-backend FP8 tests for pack_seq and unpack_seq

### DIFF
--- a/benchmark/test_pack_seq.py
+++ b/benchmark/test_pack_seq.py
@@ -32,23 +32,27 @@ except ImportError:
     HAS_VLLM = False
 
 # =============================================================================
-# CUDA available check for FP8
+# FP8 availability check
 # =============================================================================
 
 
-def is_cuda_available():
-    if flaggems_vllm.device != "cuda":
+def is_fp8_available():
+    if not hasattr(torch, "float8_e4m3fn"):
         return False
-    if not torch.cuda.is_available():
+
+    try:
+        torch.zeros(1, device=flaggems_vllm.device, dtype=torch.float32).to(
+            torch.float8_e4m3fn
+        )
+    except (RuntimeError, TypeError, NotImplementedError):
         return False
-    major, minor = torch.cuda.get_device_capability()
-    sm_version_num = major * 10 + minor
-    return sm_version_num >= 90 and sm_version_num < 100
+
+    return True
 
 
-CUDA_AVAILABLE = is_cuda_available()
+FP8_AVAILABLE = is_fp8_available()
 
-FP8_DTYPE = torch.float8_e4m3fn if CUDA_AVAILABLE else None
+FP8_DTYPE = torch.float8_e4m3fn if FP8_AVAILABLE else None
 
 # =============================================================================
 # Benchmark shapes: (N, D, B, lengths_list)
@@ -139,8 +143,12 @@ def test_pack_seq():
 
 @pytest.mark.pack_seq_triton
 @pytest.mark.skipif(
-    not (HAS_VLLM and CUDA_AVAILABLE),
-    reason="requires vLLM and NVIDIA Hopper architecture for FP8",
+    not HAS_VLLM,
+    reason="requires vLLM to be installed for reference comparison",
+)
+@pytest.mark.skipif(
+    not FP8_AVAILABLE,
+    reason="FP8 is not supported on the current device",
 )
 def test_pack_seq_fp8():
     bench = PackSeqFP8Benchmark(

--- a/benchmark/test_unpack_seq.py
+++ b/benchmark/test_unpack_seq.py
@@ -33,23 +33,27 @@ except ImportError:
 
 
 # =============================================================================
-# CUDA available check for FP8
+# FP8 availability check
 # =============================================================================
 
 
-def is_cuda_available():
-    if flaggems_vllm.device != "cuda":
+def is_fp8_available():
+    if not hasattr(torch, "float8_e4m3fn"):
         return False
-    if not torch.cuda.is_available():
+
+    try:
+        torch.zeros(1, device=flaggems_vllm.device, dtype=torch.float32).to(
+            torch.float8_e4m3fn
+        )
+    except (RuntimeError, TypeError, NotImplementedError):
         return False
-    major, minor = torch.cuda.get_device_capability()
-    sm_version_num = major * 10 + minor
-    return sm_version_num >= 90 and sm_version_num < 100
+
+    return True
 
 
-CUDA_AVAILABLE = is_cuda_available()
+FP8_AVAILABLE = is_fp8_available()
 
-FP8_DTYPE = torch.float8_e4m3fn if CUDA_AVAILABLE else None
+FP8_DTYPE = torch.float8_e4m3fn if FP8_AVAILABLE else None
 
 # =============================================================================
 # Benchmark shapes: (N, D, B, lengths_list)
@@ -142,8 +146,12 @@ def test_unpack_seq():
 
 @pytest.mark.unpack_seq_triton
 @pytest.mark.skipif(
-    not (HAS_VLLM and CUDA_AVAILABLE),
-    reason="requires vLLM and NVIDIA Hopper architecture for FP8",
+    not HAS_VLLM,
+    reason="requires vLLM to be installed for reference comparison",
+)
+@pytest.mark.skipif(
+    not FP8_AVAILABLE,
+    reason="FP8 is not supported on the current device",
 )
 def test_unpack_seq_fp8():
     bench = UnpackSeqFP8Benchmark(

--- a/tests/test_pack_seq.py
+++ b/tests/test_pack_seq.py
@@ -22,21 +22,25 @@ from . import accuracy_utils as utils
 from . import conftest as cfg
 
 # =============================================================================
-# CUDA / Hopper check for FP8
+# FP8 availability check
 # =============================================================================
 
 
-def is_cuda_available():
-    if flaggems_vllm.device != "cuda":
+def is_fp8_available():
+    if not hasattr(torch, "float8_e4m3fn"):
         return False
-    if not torch.cuda.is_available():
+
+    try:
+        torch.zeros(1, device=flaggems_vllm.device, dtype=torch.float32).to(
+            torch.float8_e4m3fn
+        )
+    except (RuntimeError, TypeError, NotImplementedError):
         return False
-    major, minor = torch.cuda.get_device_capability()
-    sm_version_num = major * 10 + minor
-    return sm_version_num >= 90 and sm_version_num < 100
+
+    return True
 
 
-CUDA_AVAILABLE = is_cuda_available()
+FP8_AVAILABLE = is_fp8_available()
 
 
 def _ref_pack_seq(x, lengths, pad_value=-float("inf")):
@@ -232,8 +236,8 @@ def test_pack_seq_block_sizes(block_t, block_d):
 
 @pytest.mark.pack_seq_triton
 @pytest.mark.skipif(
-    not CUDA_AVAILABLE,
-    reason="requires NVIDIA Hopper architecture for FP8",
+    not FP8_AVAILABLE,
+    reason="FP8 is not supported on the current device",
 )
 @pytest.mark.parametrize(
     "N, H, D, lengths_list",
@@ -259,8 +263,8 @@ def test_pack_seq_fp8_basic(N, H, D, lengths_list):
 
 @pytest.mark.pack_seq_triton
 @pytest.mark.skipif(
-    not CUDA_AVAILABLE,
-    reason="requires NVIDIA Hopper architecture for FP8",
+    not FP8_AVAILABLE,
+    reason="FP8 is not supported on the current device",
 )
 def test_pack_seq_fp8_custom_padding():
     FP8 = torch.float8_e4m3fn
@@ -281,8 +285,8 @@ def test_pack_seq_fp8_custom_padding():
 
 @pytest.mark.pack_seq_triton
 @pytest.mark.skipif(
-    not CUDA_AVAILABLE,
-    reason="requires NVIDIA Hopper architecture for FP8",
+    not FP8_AVAILABLE,
+    reason="FP8 is not supported on the current device",
 )
 def test_pack_seq_fp8_default_inf_padding():
     FP8 = torch.float8_e4m3fn
@@ -297,8 +301,8 @@ def test_pack_seq_fp8_default_inf_padding():
 
 @pytest.mark.pack_seq_triton
 @pytest.mark.skipif(
-    not CUDA_AVAILABLE,
-    reason="requires NVIDIA Hopper architecture for FP8",
+    not FP8_AVAILABLE,
+    reason="FP8 is not supported on the current device",
 )
 @pytest.mark.parametrize("block_t, block_d", [(32, 32), (64, 64), (128, 128)])
 def test_pack_seq_fp8_block_sizes(block_t, block_d):

--- a/tests/test_unpack_seq.py
+++ b/tests/test_unpack_seq.py
@@ -22,21 +22,25 @@ from . import accuracy_utils as utils
 from . import conftest as cfg
 
 # =============================================================================
-# CUDA available check for FP8
+# FP8 availability check
 # =============================================================================
 
 
-def _is_cuda_available():
-    if flaggems_vllm.device != "cuda":
+def is_fp8_available():
+    if not hasattr(torch, "float8_e4m3fn"):
         return False
-    if not torch.cuda.is_available():
+
+    try:
+        torch.zeros(1, device=flaggems_vllm.device, dtype=torch.float32).to(
+            torch.float8_e4m3fn
+        )
+    except (RuntimeError, TypeError, NotImplementedError):
         return False
-    major, minor = torch.cuda.get_device_capability()
-    sm_version_num = major * 10 + minor
-    return sm_version_num >= 90 and sm_version_num < 100
+
+    return True
 
 
-CUDA_AVAILABLE = _is_cuda_available()
+FP8_AVAILABLE = is_fp8_available()
 
 
 def _ref_pack_seq(x, lengths, pad_value=-float("inf")):
@@ -210,8 +214,8 @@ def test_unpack_seq_3d_edge_cases(dtype):
 
 @pytest.mark.unpack_seq_triton
 @pytest.mark.skipif(
-    not CUDA_AVAILABLE,
-    reason="requires NVIDIA Hopper architecture for FP8",
+    not FP8_AVAILABLE,
+    reason="FP8 is not supported on the current device",
 )
 def test_pack_unpack_fp8_roundtrip():
     FP8 = torch.float8_e4m3fn


### PR DESCRIPTION
## Summary

Enable FP8 correctness tests and benchmarks for `pack_seq` and `unpack_seq`
on any backend that provides runtime FP8 support.

## Changes

- Replace the NVIDIA Hopper-specific check with a runtime FP8 capability probe.
- Run FP8 cases when the current device supports `float8_e4m3fn`.
- Skip FP8 cases with a clear reason on unsupported devices.
- Keep vLLM availability and FP8 capability checks independent in benchmarks.

## Test Results

Verified on MetaX MC550 and Hygon DCU:

- All correctness tests passed: `95 passed`
- All FP8 correctness tests passed: `9 passed`
- FP8 benchmarks for `pack_seq` and `unpack_seq` completed successfully
### Performance

MetaX MC550, FP8 (`torch.float8_e4m3fn`), kernel-mode benchmark with 10 warmup
iterations and 100 measured iterations. The reference column is the vLLM common
Triton implementation running with the vLLM-MetaX platform plugin; CUDA Graph
was not used.

| Operator | Input shape | Lengths shape | vLLM-MetaX runtime (ms) | FlagGems-vLLM (ms) | Speedup |
|---|---:|---:|---:|---:|---:|
| `pack_seq_triton` | `[512, 64]` | `[5]` | 0.072704 | 0.072960 | 0.996x |
| `pack_seq_triton` | `[4096, 128]` | `[4]` | 0.079104 | 0.079104 | 1.000x |
| `pack_seq_triton` | `[2048, 512]` | `[4]` | 0.079616 | 0.079616 | 1.000x |
| `unpack_seq_triton` | `[5, 128, 64]` | `[5]` | 0.078592 | 0.078336 | 1.003x |
| `unpack_seq_triton` | `[4, 1024, 128]` | `[4]` | 0.082944 | 0.083456 | 0.994x |
| `unpack_seq_triton` | `[4, 512, 512]` | `[4]` | 0.084224 | 0.084480 | 0.997x |

Across these six MetaX cases, the minimum speedup is **0.994x**, the maximum
speedup is **1.003x**, and the arithmetic mean speedup is **0.998x**.

Hygon BW1000, FP8 (`torch.float8_e4m3fn`), kernel-mode benchmark with 10 warmup
iterations and 100 measured iterations. The reference column is the vLLM common
Triton implementation imported by the active vLLM-HCU plugin and running on the
Hygon software stack; CUDA Graph was not used.

| Operator | Input shape | Lengths shape | vLLM-HCU runtime (ms) | FlagGems-vLLM (ms) | Speedup |
|---|---:|---:|---:|---:|---:|
| `pack_seq_triton` | `[512, 64]` | `[5]` | 0.167520 | 0.165600 | 1.012x |
| `pack_seq_triton` | `[4096, 128]` | `[4]` | 0.163040 | 0.166240 | 0.981x |
| `pack_seq_triton` | `[2048, 512]` | `[4]` | 0.162079 | 0.164480 | 0.985x |
| `unpack_seq_triton` | `[5, 128, 64]` | `[5]` | 0.171200 | 0.172640 | 0.992x |
| `unpack_seq_triton` | `[4, 1024, 128]` | `[4]` | 0.169920 | 0.173280 | 0.981x |
| `unpack_seq_triton` | `[4, 512, 512]` | `[4]` | 0.169920 | 0.171040 | 0.993x |

Across these six Hygon cases, the minimum speedup is **0.981x**, the maximum
speedup is **1.012x**, and the arithmetic mean speedup is **0.991x**.

| Platform | Cases | Minimum speedup | Maximum speedup | Arithmetic mean speedup |
|---|---:|---:|---:|---:|
| MetaX MC550 | 6 | 0.994x | 1.003x | 0.998x |
| Hygon BW1000 | 6 | 0.981x | 1.012x | 0.991x |