### PR TITLE
[QC][Nvidia] Fix operator IDs and test markers for acceptance

### DIFF
--- a/benchmark/test_fused_marlin_moe_w4a16_int4.py
+++ b/benchmark/test_fused_marlin_moe_w4a16_int4.py
@@ -279,7 +279,7 @@ def _gems_call(
     )
 
 
-@pytest.mark.fused_marlin_moe
+@pytest.mark.fused_marlin_moe_w4a16_int4
 @pytest.mark.skipif(
     not HAS_VLLM_FUSED_MARLIN_MOE, reason="vllm not installed; baseline unavailable"
 )

--- a/benchmark/test_fused_marlin_moe_w4a16_mxfp4.py
+++ b/benchmark/test_fused_marlin_moe_w4a16_mxfp4.py
@@ -263,7 +263,7 @@ def _gems_call_mxfp4(
     )
 
 
-@pytest.mark.fused_marlin_moe
+@pytest.mark.fused_marlin_moe_w4a16_mxfp4
 @pytest.mark.skipif(
     not HAS_VLLM_FUSED_MARLIN_MOE, reason="vllm not installed; baseline unavailable"
 )

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -327,6 +327,18 @@ ops:
       - NeuralNetwork
     stages:
       - alpha: '5.3'
+  - id: flash_mla_with_kvcache
+    description: Dense and sparse Multi-head Latent Attention decoding with a paged KV cache.
+    for:
+      - vllm.v1.attention.ops.flashmla.flash_mla_with_kvcache
+    labels:
+      - fused
+      - Attention
+      - vLLM
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.4'
   - id: fp8_fp4_mqa_logits
     description: |
       Compute weighted MQA logits with FP8 quantized Q and K tensors.
@@ -411,6 +423,30 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.4'
+  - id: fused_marlin_moe_w4a16_int4
+    description: Fused mixture-of-experts computation with GPTQ INT4 weights and 16-bit activations.
+    for:
+      - vllm.model_executor.layers.fused_moe.fused_marlin_moe.fused_marlin_moe
+    labels:
+      - fused
+      - vLLM
+      - MoE
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.4'
+  - id: fused_marlin_moe_w4a16_mxfp4
+    description: Fused mixture-of-experts computation with MXFP4 weights and 16-bit activations.
+    for:
+      - vllm.model_executor.layers.fused_moe.fused_marlin_moe.fused_marlin_moe
+    labels:
+      - fused
+      - vLLM
+      - MoE
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.4'
   - id: fused_moe
     description: The generic interface for fused MoE.
     for:

--- a/tests/test_fused_marlin_moe.py
+++ b/tests/test_fused_marlin_moe.py
@@ -501,6 +501,7 @@ def _reference_swiglu_moe(
     return out
 
 
+@pytest.mark.fused_marlin_moe_w4a16_int4
 @pytest.mark.skipif(
     not _is_hopper(),
     reason="W4A16 fast path uses Hopper-only bf16 SIMD PTX (sm_90+)",
@@ -585,6 +586,7 @@ def test_fused_marlin_moe_w8a16_int8(config, dtype):
     assert max_diff < 0.04, f"max_diff={max_diff:.4f}"
 
 
+@pytest.mark.fused_marlin_moe_w4a16_mxfp4
 @pytest.mark.skipif(
     not _is_hopper(),
     reason="MXFP4 fast path uses Hopper-only bf16/fp16 SIMD PTX (sm_90+)",


### PR DESCRIPTION
Add missing inventory entries for `flash_mla_with_kvcache` and the INT4/MXFP4 Marlin MoE variants.