### PR TITLE
Optimize GDN chunk kernel on MetaX

### DIFF
--- a/src/flaggems_vllm/runtime/backend/_metax/fused/gdn_chunk.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/fused/gdn_chunk.py
@@ -16,8 +16,14 @@ import logging
 
 import torch
 import triton
-import triton.language as tl
 import triton.backends.metax.compiler as backend
+import triton.language as tl
+
+from flaggems_vllm.ops.FLA.index import prepare_chunk_indices, prepare_chunk_offsets
+from flaggems_vllm.ops.FLA.triton_ops_helper import exp
+from flaggems_vllm.ops.FLA.utils import SUPPRESS_LEVEL, tensor_cache
+from flaggems_vllm.ops.FLA.wy_fast import recompute_w_u_fwd
+from flaggems_vllm.utils import libentry, libtuner
 
 _original_compile = backend.metax.translate_llvmir_to_mcfatbin
 
@@ -32,15 +38,10 @@ def _compile_without_licm(src, mxcc, maca, options):
 
 backend.metax.translate_llvmir_to_mcfatbin = _compile_without_licm
 
-from flaggems_vllm.ops.FLA.index import prepare_chunk_indices, prepare_chunk_offsets
-from flaggems_vllm.ops.FLA.triton_ops_helper import exp
-from flaggems_vllm.ops.FLA.utils import SUPPRESS_LEVEL, tensor_cache
-from flaggems_vllm.ops.FLA.wy_fast import recompute_w_u_fwd
-from flaggems_vllm.utils import libentry, libtuner
-
 logger = logging.getLogger(__name__)
 
 FLA_CHUNK_SIZE = 64
+
 
 # ---------------------------------------------------------------------------
 # 1. Fused cumsum + scaled_dot_kkt + solve_tril
@@ -371,9 +372,10 @@ def chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
         H=H,
         Hg=Hg,
         K=K,
-        BT=BT
+        BT=BT,
     )
     return g_out, A_inv
+
 
 def _n_bucket(N: int) -> int:
     """Map request count to autotune tiers: 1, 2-8, 9-24, and 25+."""
@@ -414,6 +416,7 @@ def _skew_bucket(chunk_offsets: torch.Tensor | None, N: int) -> int:
     if chunk_offsets is None or N <= 1:
         return 0
     return _skew_bucket_cached(chunk_offsets)
+
 
 # ---------------------------------------------------------------------------
 # 2. chunk_delta_h with V-major state layout
@@ -549,99 +552,205 @@ def chunk_gated_delta_rule_fwd_kernel_h_vmajor(
         p_h0 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0))
         b_h1 += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
         if K > BK:
-            p_h0 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, BK), (BV, BK), (1, 0))
+            p_h0 = tl.make_block_ptr(
+                h0, (V, K), (K, 1), (i_v * BV, BK), (BV, BK), (1, 0)
+            )
             b_h2 += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
         if K > 2 * BK:
-            p_h0 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 2 * BK), (BV, BK), (1, 0))
+            p_h0 = tl.make_block_ptr(
+                h0, (V, K), (K, 1), (i_v * BV, 2 * BK), (BV, BK), (1, 0)
+            )
             b_h3 += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
         if K > 3 * BK:
-            p_h0 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 3 * BK), (BV, BK), (1, 0))
+            p_h0 = tl.make_block_ptr(
+                h0, (V, K), (K, 1), (i_v * BV, 3 * BK), (BV, BK), (1, 0)
+            )
             b_h4 += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
         if K > 4 * BK:
-            p_h0 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 4 * BK), (BV, BK), (1, 0))
+            p_h0 = tl.make_block_ptr(
+                h0, (V, K), (K, 1), (i_v * BV, 4 * BK), (BV, BK), (1, 0)
+            )
             b_h5 += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
         if K > 5 * BK:
-            p_h0 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 5 * BK), (BV, BK), (1, 0))
+            p_h0 = tl.make_block_ptr(
+                h0, (V, K), (K, 1), (i_v * BV, 5 * BK), (BV, BK), (1, 0)
+            )
             b_h6 += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
         if K > 6 * BK:
-            p_h0 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 6 * BK), (BV, BK), (1, 0))
+            p_h0 = tl.make_block_ptr(
+                h0, (V, K), (K, 1), (i_v * BV, 6 * BK), (BV, BK), (1, 0)
+            )
             b_h7 += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
         if K > 7 * BK:
-            p_h0 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 7 * BK), (BV, BK), (1, 0))
+            p_h0 = tl.make_block_ptr(
+                h0, (V, K), (K, 1), (i_v * BV, 7 * BK), (BV, BK), (1, 0)
+            )
             b_h8 += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
 
     # Main recurrence.
     for i_t in range(NT):
-        p_h = tl.make_block_ptr(h + i_t.to(tl.int64) * stride_h, (V, K), (K, 1),
-                                (i_v * BV, 0), (BV, BK), (1, 0))
+        p_h = tl.make_block_ptr(
+            h + i_t.to(tl.int64) * stride_h,
+            (V, K),
+            (K, 1),
+            (i_v * BV, 0),
+            (BV, BK),
+            (1, 0),
+        )
         tl.store(p_h, b_h1.to(p_h.dtype.element_ty), boundary_check=(0, 1))
         if K > BK:
-            p_h = tl.make_block_ptr(h + i_t.to(tl.int64) * stride_h, (V, K), (K, 1),
-                                    (i_v * BV, BK), (BV, BK), (1, 0))
+            p_h = tl.make_block_ptr(
+                h + i_t.to(tl.int64) * stride_h,
+                (V, K),
+                (K, 1),
+                (i_v * BV, BK),
+                (BV, BK),
+                (1, 0),
+            )
             tl.store(p_h, b_h2.to(p_h.dtype.element_ty), boundary_check=(0, 1))
         if K > 2 * BK:
-            p_h = tl.make_block_ptr(h + i_t.to(tl.int64) * stride_h, (V, K), (K, 1),
-                                    (i_v * BV, 2 * BK), (BV, BK), (1, 0))
+            p_h = tl.make_block_ptr(
+                h + i_t.to(tl.int64) * stride_h,
+                (V, K),
+                (K, 1),
+                (i_v * BV, 2 * BK),
+                (BV, BK),
+                (1, 0),
+            )
             tl.store(p_h, b_h3.to(p_h.dtype.element_ty), boundary_check=(0, 1))
         if K > 3 * BK:
-            p_h = tl.make_block_ptr(h + i_t.to(tl.int64) * stride_h, (V, K), (K, 1),
-                                    (i_v * BV, 3 * BK), (BV, BK), (1, 0))
+            p_h = tl.make_block_ptr(
+                h + i_t.to(tl.int64) * stride_h,
+                (V, K),
+                (K, 1),
+                (i_v * BV, 3 * BK),
+                (BV, BK),
+                (1, 0),
+            )
             tl.store(p_h, b_h4.to(p_h.dtype.element_ty), boundary_check=(0, 1))
         if K > 4 * BK:
-            p_h = tl.make_block_ptr(h + i_t.to(tl.int64) * stride_h, (V, K), (K, 1),
-                                    (i_v * BV, 4 * BK), (BV, BK), (1, 0))
+            p_h = tl.make_block_ptr(
+                h + i_t.to(tl.int64) * stride_h,
+                (V, K),
+                (K, 1),
+                (i_v * BV, 4 * BK),
+                (BV, BK),
+                (1, 0),
+            )
             tl.store(p_h, b_h5.to(p_h.dtype.element_ty), boundary_check=(0, 1))
         if K > 5 * BK:
-            p_h = tl.make_block_ptr(h + i_t.to(tl.int64) * stride_h, (V, K), (K, 1),
-                                    (i_v * BV, 5 * BK), (BV, BK), (1, 0))
+            p_h = tl.make_block_ptr(
+                h + i_t.to(tl.int64) * stride_h,
+                (V, K),
+                (K, 1),
+                (i_v * BV, 5 * BK),
+                (BV, BK),
+                (1, 0),
+            )
             tl.store(p_h, b_h6.to(p_h.dtype.element_ty), boundary_check=(0, 1))
         if K > 6 * BK:
-            p_h = tl.make_block_ptr(h + i_t.to(tl.int64) * stride_h, (V, K), (K, 1),
-                                    (i_v * BV, 6 * BK), (BV, BK), (1, 0))
+            p_h = tl.make_block_ptr(
+                h + i_t.to(tl.int64) * stride_h,
+                (V, K),
+                (K, 1),
+                (i_v * BV, 6 * BK),
+                (BV, BK),
+                (1, 0),
+            )
             tl.store(p_h, b_h7.to(p_h.dtype.element_ty), boundary_check=(0, 1))
         if K > 7 * BK:
-            p_h = tl.make_block_ptr(h + i_t.to(tl.int64) * stride_h, (V, K), (K, 1),
-                                    (i_v * BV, 7 * BK), (BV, BK), (1, 0))
+            p_h = tl.make_block_ptr(
+                h + i_t.to(tl.int64) * stride_h,
+                (V, K),
+                (K, 1),
+                (i_v * BV, 7 * BK),
+                (BV, BK),
+                (1, 0),
+            )
             tl.store(p_h, b_h8.to(p_h.dtype.element_ty), boundary_check=(0, 1))
 
         b_v = tl.zeros([BT, BV], dtype=tl.float32)
-        p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-        b_v += tl.dot(tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h1).to(k.dtype.element_ty))
+        p_w = tl.make_block_ptr(
+            w, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, BK), (1, 0)
+        )
+        b_v += tl.dot(
+            tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h1).to(k.dtype.element_ty)
+        )
         if K > BK:
-            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, BK), (BT, BK), (1, 0))
-            b_v += tl.dot(tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h2).to(k.dtype.element_ty))
+            p_w = tl.make_block_ptr(
+                w, (T, K), (stride_w, 1), (i_t * BT, BK), (BT, BK), (1, 0)
+            )
+            b_v += tl.dot(
+                tl.load(p_w, boundary_check=(0, 1)),
+                tl.trans(b_h2).to(k.dtype.element_ty),
+            )
         if K > 2 * BK:
-            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 2 * BK), (BT, BK), (1, 0))
-            b_v += tl.dot(tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h3).to(k.dtype.element_ty))
+            p_w = tl.make_block_ptr(
+                w, (T, K), (stride_w, 1), (i_t * BT, 2 * BK), (BT, BK), (1, 0)
+            )
+            b_v += tl.dot(
+                tl.load(p_w, boundary_check=(0, 1)),
+                tl.trans(b_h3).to(k.dtype.element_ty),
+            )
         if K > 3 * BK:
-            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 3 * BK), (BT, BK), (1, 0))
-            b_v += tl.dot(tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h4).to(k.dtype.element_ty))
+            p_w = tl.make_block_ptr(
+                w, (T, K), (stride_w, 1), (i_t * BT, 3 * BK), (BT, BK), (1, 0)
+            )
+            b_v += tl.dot(
+                tl.load(p_w, boundary_check=(0, 1)),
+                tl.trans(b_h4).to(k.dtype.element_ty),
+            )
         if K > 4 * BK:
-            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 4 * BK), (BT, BK), (1, 0))
-            b_v += tl.dot(tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h5).to(k.dtype.element_ty))
+            p_w = tl.make_block_ptr(
+                w, (T, K), (stride_w, 1), (i_t * BT, 4 * BK), (BT, BK), (1, 0)
+            )
+            b_v += tl.dot(
+                tl.load(p_w, boundary_check=(0, 1)),
+                tl.trans(b_h5).to(k.dtype.element_ty),
+            )
         if K > 5 * BK:
-            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 5 * BK), (BT, BK), (1, 0))
-            b_v += tl.dot(tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h6).to(k.dtype.element_ty))
+            p_w = tl.make_block_ptr(
+                w, (T, K), (stride_w, 1), (i_t * BT, 5 * BK), (BT, BK), (1, 0)
+            )
+            b_v += tl.dot(
+                tl.load(p_w, boundary_check=(0, 1)),
+                tl.trans(b_h6).to(k.dtype.element_ty),
+            )
         if K > 6 * BK:
-            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 6 * BK), (BT, BK), (1, 0))
-            b_v += tl.dot(tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h7).to(k.dtype.element_ty))
+            p_w = tl.make_block_ptr(
+                w, (T, K), (stride_w, 1), (i_t * BT, 6 * BK), (BT, BK), (1, 0)
+            )
+            b_v += tl.dot(
+                tl.load(p_w, boundary_check=(0, 1)),
+                tl.trans(b_h7).to(k.dtype.element_ty),
+            )
         if K > 7 * BK:
-            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 7 * BK), (BT, BK), (1, 0))
-            b_v += tl.dot(tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h8).to(k.dtype.element_ty))
+            p_w = tl.make_block_ptr(
+                w, (T, K), (stride_w, 1), (i_t * BT, 7 * BK), (BT, BK), (1, 0)
+            )
+            b_v += tl.dot(
+                tl.load(p_w, boundary_check=(0, 1)),
+                tl.trans(b_h8).to(k.dtype.element_ty),
+            )
 
-        p_v = tl.make_block_ptr(v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_v = tl.make_block_ptr(
+            v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
         b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
 
         if SAVE_NEW_VALUE:
-            p_vn = tl.make_block_ptr(v_new, (T, V), (stride_v, 1),
-                                     (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_vn = tl.make_block_ptr(
+                v_new, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+            )
             tl.store(p_vn, b_v.to(p_vn.dtype.element_ty), boundary_check=(0, 1))
 
         last_idx = min((i_t.to(tl.int64) + 1) * BT, T) - 1
         if USE_G:
             m_t = (i_t.to(tl.int64) * BT + tl.arange(0, BT)) < T
             b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
-            p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+            p_g = tl.make_block_ptr(
+                g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+            )
             b_g = tl.load(p_g, boundary_check=(0,))
             b_v = b_v * tl.where(m_t, exp(b_g_last - b_g), 0)[:, None]
             b_g_last = exp(b_g_last)
@@ -663,43 +772,65 @@ def chunk_gated_delta_rule_fwd_kernel_h_vmajor(
 
         if USE_GK:
             o_k = tl.arange(0, BK)
-            b_gk = tl.load(gk + (bos + last_idx) * H * K + i_h * K + o_k,
-                           mask=(o_k < K), other=0.0)
+            b_gk = tl.load(
+                gk + (bos + last_idx) * H * K + i_h * K + o_k, mask=(o_k < K), other=0.0
+            )
             b_h1 *= exp(b_gk)[None, :]
             if K > BK:
                 o_k = BK + tl.arange(0, BK)
-                b_gk = tl.load(gk + (bos + last_idx) * H * K + i_h * K + o_k,
-                               mask=(o_k < K), other=0.0)
+                b_gk = tl.load(
+                    gk + (bos + last_idx) * H * K + i_h * K + o_k,
+                    mask=(o_k < K),
+                    other=0.0,
+                )
                 b_h2 *= exp(b_gk)[None, :]
             if K > 2 * BK:
                 o_k = 2 * BK + tl.arange(0, BK)
-                b_gk = tl.load(gk + (bos + last_idx) * H * K + i_h * K + o_k,
-                               mask=(o_k < K), other=0.0)
+                b_gk = tl.load(
+                    gk + (bos + last_idx) * H * K + i_h * K + o_k,
+                    mask=(o_k < K),
+                    other=0.0,
+                )
                 b_h3 *= exp(b_gk)[None, :]
             if K > 3 * BK:
                 o_k = 3 * BK + tl.arange(0, BK)
-                b_gk = tl.load(gk + (bos + last_idx) * H * K + i_h * K + o_k,
-                               mask=(o_k < K), other=0.0)
+                b_gk = tl.load(
+                    gk + (bos + last_idx) * H * K + i_h * K + o_k,
+                    mask=(o_k < K),
+                    other=0.0,
+                )
                 b_h4 *= exp(b_gk)[None, :]
             if K > 4 * BK:
                 o_k = 4 * BK + tl.arange(0, BK)
-                b_gk = tl.load(gk + (bos + last_idx) * H * K + i_h * K + o_k,
-                               mask=(o_k < K), other=0.0)
+                b_gk = tl.load(
+                    gk + (bos + last_idx) * H * K + i_h * K + o_k,
+                    mask=(o_k < K),
+                    other=0.0,
+                )
                 b_h5 *= exp(b_gk)[None, :]
             if K > 5 * BK:
                 o_k = 5 * BK + tl.arange(0, BK)
-                b_gk = tl.load(gk + (bos + last_idx) * H * K + i_h * K + o_k,
-                               mask=(o_k < K), other=0.0)
+                b_gk = tl.load(
+                    gk + (bos + last_idx) * H * K + i_h * K + o_k,
+                    mask=(o_k < K),
+                    other=0.0,
+                )
                 b_h6 *= exp(b_gk)[None, :]
             if K > 6 * BK:
                 o_k = 6 * BK + tl.arange(0, BK)
-                b_gk = tl.load(gk + (bos + last_idx) * H * K + i_h * K + o_k,
-                               mask=(o_k < K), other=0.0)
+                b_gk = tl.load(
+                    gk + (bos + last_idx) * H * K + i_h * K + o_k,
+                    mask=(o_k < K),
+                    other=0.0,
+                )
                 b_h7 *= exp(b_gk)[None, :]
             if K > 7 * BK:
                 o_k = 7 * BK + tl.arange(0, BK)
-                b_gk = tl.load(gk + (bos + last_idx) * H * K + i_h * K + o_k,
-                               mask=(o_k < K), other=0.0)
+                b_gk = tl.load(
+                    gk + (bos + last_idx) * H * K + i_h * K + o_k,
+                    mask=(o_k < K),
+                    other=0.0,
+                )
                 b_h8 *= exp(b_gk)[None, :]
 
         b_v = b_v.to(k.dtype.element_ty)
@@ -728,31 +859,44 @@ def chunk_gated_delta_rule_fwd_kernel_h_vmajor(
             if K > 7 * BK and i_k == 7:
                 b_h8 += b_kv
 
-
     # Store final state.
     if STORE_FINAL_STATE:
         p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0))
         tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
         if K > BK:
-            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, BK), (BV, BK), (1, 0))
+            p_ht = tl.make_block_ptr(
+                ht, (V, K), (K, 1), (i_v * BV, BK), (BV, BK), (1, 0)
+            )
             tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
         if K > 2 * BK:
-            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 2 * BK), (BV, BK), (1, 0))
+            p_ht = tl.make_block_ptr(
+                ht, (V, K), (K, 1), (i_v * BV, 2 * BK), (BV, BK), (1, 0)
+            )
             tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
         if K > 3 * BK:
-            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 3 * BK), (BV, BK), (1, 0))
+            p_ht = tl.make_block_ptr(
+                ht, (V, K), (K, 1), (i_v * BV, 3 * BK), (BV, BK), (1, 0)
+            )
             tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
         if K > 4 * BK:
-            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 4 * BK), (BV, BK), (1, 0))
+            p_ht = tl.make_block_ptr(
+                ht, (V, K), (K, 1), (i_v * BV, 4 * BK), (BV, BK), (1, 0)
+            )
             tl.store(p_ht, b_h5.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
         if K > 5 * BK:
-            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 5 * BK), (BV, BK), (1, 0))
+            p_ht = tl.make_block_ptr(
+                ht, (V, K), (K, 1), (i_v * BV, 5 * BK), (BV, BK), (1, 0)
+            )
             tl.store(p_ht, b_h6.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
         if K > 6 * BK:
-            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 6 * BK), (BV, BK), (1, 0))
+            p_ht = tl.make_block_ptr(
+                ht, (V, K), (K, 1), (i_v * BV, 6 * BK), (BV, BK), (1, 0)
+            )
             tl.store(p_ht, b_h7.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
         if K > 7 * BK:
-            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 7 * BK), (BV, BK), (1, 0))
+            p_ht = tl.make_block_ptr(
+                ht, (V, K), (K, 1), (i_v * BV, 7 * BK), (BV, BK), (1, 0)
+            )
             tl.store(p_ht, b_h8.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
 
 
@@ -935,6 +1079,7 @@ def chunk_fwd_kernel_o(
     b_o = b_o * scale + tl.dot(b_A.to(b_v.dtype), b_v) * scale
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
 
+
 def chunk_fwd_o(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -986,7 +1131,6 @@ def chunk_fwd_o(
         N_BUCKET=N_BUCKET,
     )
     return o
-
 
 
 # ---------------------------------------------------------------------------

--- a/src/flaggems_vllm/runtime/backend/_metax/fused/gdn_chunk.py
+++ b/src/flaggems_vllm/runtime/backend/_metax/fused/gdn_chunk.py
@@ -17,17 +17,30 @@ import logging
 import torch
 import triton
 import triton.language as tl
+import triton.backends.metax.compiler as backend
+
+_original_compile = backend.metax.translate_llvmir_to_mcfatbin
+
+
+# Disable backend LICM only for the GDN H-state kernel.
+def _compile_without_licm(src, mxcc, maca, options):
+    name = backend.maca_get_kernel_name(src)
+    if name == "chunk_gated_delta_rule_fwd_kernel_h_vmajor":
+        options += " -mllvm -metaxgpu-disable-licm=true"
+    return _original_compile(src, mxcc, maca, options)
+
+
+backend.metax.translate_llvmir_to_mcfatbin = _compile_without_licm
 
 from flaggems_vllm.ops.FLA.index import prepare_chunk_indices, prepare_chunk_offsets
 from flaggems_vllm.ops.FLA.triton_ops_helper import exp
-from flaggems_vllm.ops.FLA.utils import SUPPRESS_LEVEL
+from flaggems_vllm.ops.FLA.utils import SUPPRESS_LEVEL, tensor_cache
 from flaggems_vllm.ops.FLA.wy_fast import recompute_w_u_fwd
 from flaggems_vllm.utils import libentry, libtuner
 
 logger = logging.getLogger(__name__)
 
 FLA_CHUNK_SIZE = 64
-
 
 # ---------------------------------------------------------------------------
 # 1. Fused cumsum + scaled_dot_kkt + solve_tril
@@ -40,6 +53,20 @@ def _prune_unsafe_kloop_configs(configs, named_args, *args, **kwargs):
     return pruned or configs[:1]
 
 
+@triton.jit
+def _inv_unit_lower_16(D, m_strict, I16, DP: tl.constexpr):
+    """Invert a 16x16 unit-lower-triangular matrix in registers."""
+    Q = -tl.where(m_strict, D, 0.0)
+    S = I16 + Q
+    Q = tl.dot(Q, Q, input_precision=DP)
+    S = S + tl.dot(S, Q, input_precision=DP)
+    Q = tl.dot(Q, Q, input_precision=DP)
+    S = S + tl.dot(S, Q, input_precision=DP)
+    Q = tl.dot(Q, Q, input_precision=DP)
+    S = S + tl.dot(S, Q, input_precision=DP)
+    return S
+
+
 @libentry()
 @triton.heuristics(
     {
@@ -49,9 +76,9 @@ def _prune_unsafe_kloop_configs(configs, named_args, *args, **kwargs):
 @libtuner(
     configs=[
         triton.Config({"BK": BK}, num_warps=num_warps, num_stages=num_stages)
-        for BK in [32, 64, 128]
-        for num_warps in [2, 4, 8]
-        for num_stages in [1]
+        for BK in [32, 64]
+        for num_warps in [2, 4]
+        for num_stages in [1, 2, 3]
     ],
     key=["H", "K", "BT", "IS_VARLEN"],
     prune_configs_by={"early_config_prune": _prune_unsafe_kloop_configs},
@@ -62,7 +89,6 @@ def chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril_kernel(
     g_out,
     k,
     beta,
-    A,
     A_inv,
     cu_seqlens,
     chunk_indices,
@@ -89,6 +115,8 @@ def chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril_kernel(
     else:
         bos, eos = i_b * T, i_b * T + T
 
+    DOT_PRECISION: tl.constexpr = "ieee"
+
     # ---------- cumsum ----------
     p_g_in = tl.make_block_ptr(
         g_in + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
@@ -100,117 +128,91 @@ def chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril_kernel(
     b_g = tl.cumsum(b_g, axis=0)
     tl.store(p_g_out, b_g.to(p_g_out.dtype.element_ty), boundary_check=(0,))
 
-    # ---------- KKT (write L to A) ----------
-    o_t = i_t * BT + tl.arange(0, BT)
-    m_t = o_t < T
+    g_t = tl.trans(tl.reshape(b_g, (4, 16)))
+    g_x, g_y = tl.split(tl.reshape(g_t, (16, 2, 2)))
+    b_g0, b_g2 = tl.split(g_x)
+    b_g1, b_g3 = tl.split(g_y)
+
     p_beta = tl.make_block_ptr(
         beta + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
     )
-    b_beta = tl.load(p_beta, boundary_check=(0,))
-    b_A = tl.zeros([BT, BT], dtype=tl.float32)
-    for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(
-            k + (bos * Hg + i_h // (H // Hg)) * K,
-            (T, K),
-            (Hg * K, 1),
-            (i_t * BT, i_k * BK),
-            (BT, BK),
-            (1, 0),
-        )
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_kb = b_k * b_beta[:, None]
-        b_A += tl.dot(b_kb.to(b_k.dtype), tl.trans(b_k))
-    b_g_diff = b_g[:, None] - b_g[None, :]
-    b_A = b_A * exp(b_g_diff)
-    m_A_kkt = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
-    b_A = tl.where(m_A_kkt, b_A, 0)
-    p_A = tl.make_block_ptr(
-        A + (bos * H + i_h) * BT,
-        (T, BT),
-        (H * BT, 1),
-        (i_t * BT, 0),
-        (BT, BT),
-        (1, 0),
-    )
-    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
-    tl.debug_barrier()
+    b_beta = tl.load(p_beta, boundary_check=(0,)).to(tl.float32)
+    bt_t = tl.trans(tl.reshape(b_beta, (4, 16)))
+    bt_x, bt_y = tl.split(tl.reshape(bt_t, (16, 2, 2)))
+    b_beta0, b_beta2 = tl.split(bt_x)
+    b_beta1, b_beta3 = tl.split(bt_y)
 
-    # ---------- solve_tril (read A, write A_inv), 16x16 blocked ----------
+    # ---------- KKT ----------
+    b_A_11 = tl.zeros([16, 16], dtype=tl.float32)
+    b_A_22 = tl.zeros([16, 16], dtype=tl.float32)
+    b_A_33 = tl.zeros([16, 16], dtype=tl.float32)
+    b_A_44 = tl.zeros([16, 16], dtype=tl.float32)
+    b_A_21 = tl.zeros([16, 16], dtype=tl.float32)
+    b_A_31 = tl.zeros([16, 16], dtype=tl.float32)
+    b_A_32 = tl.zeros([16, 16], dtype=tl.float32)
+    b_A_41 = tl.zeros([16, 16], dtype=tl.float32)
+    b_A_42 = tl.zeros([16, 16], dtype=tl.float32)
+    b_A_43 = tl.zeros([16, 16], dtype=tl.float32)
+    k_base = k + (bos * Hg + i_h // (H // Hg)) * K
+    for i_k in range(tl.cdiv(K, BK)):
+        p_k0 = tl.make_block_ptr(
+            k_base, (T, K), (Hg * K, 1), (i_t * BT, i_k * BK), (16, BK), (1, 0)
+        )
+        p_k1 = tl.make_block_ptr(
+            k_base, (T, K), (Hg * K, 1), (i_t * BT + 16, i_k * BK), (16, BK), (1, 0)
+        )
+        p_k2 = tl.make_block_ptr(
+            k_base, (T, K), (Hg * K, 1), (i_t * BT + 32, i_k * BK), (16, BK), (1, 0)
+        )
+        p_k3 = tl.make_block_ptr(
+            k_base, (T, K), (Hg * K, 1), (i_t * BT + 48, i_k * BK), (16, BK), (1, 0)
+        )
+
+        b_k0 = tl.load(p_k0, boundary_check=(0, 1))
+        b_k1 = tl.load(p_k1, boundary_check=(0, 1))
+        b_k2 = tl.load(p_k2, boundary_check=(0, 1))
+        b_k3 = tl.load(p_k3, boundary_check=(0, 1))
+        b_kb0 = b_k0 * b_beta0[:, None].to(b_k0.dtype)
+        b_kb1 = b_k1 * b_beta1[:, None].to(b_k1.dtype)
+        b_kb2 = b_k2 * b_beta2[:, None].to(b_k2.dtype)
+        b_kb3 = b_k3 * b_beta3[:, None].to(b_k3.dtype)
+        b_k0t = tl.trans(b_k0)
+        b_k1t = tl.trans(b_k1)
+        b_k2t = tl.trans(b_k2)
+        b_k3t = tl.trans(b_k3)
+        b_A_11 += tl.dot(b_kb0, b_k0t)
+        b_A_22 += tl.dot(b_kb1, b_k1t)
+        b_A_33 += tl.dot(b_kb2, b_k2t)
+        b_A_44 += tl.dot(b_kb3, b_k3t)
+        b_A_21 += tl.dot(b_kb1, b_k0t)
+        b_A_31 += tl.dot(b_kb2, b_k0t)
+        b_A_32 += tl.dot(b_kb2, b_k1t)
+        b_A_41 += tl.dot(b_kb3, b_k0t)
+        b_A_42 += tl.dot(b_kb3, b_k1t)
+        b_A_43 += tl.dot(b_kb3, b_k2t)
+
+    b_A_11 = b_A_11 * exp(b_g0[:, None] - b_g0[None, :])
+    b_A_22 = b_A_22 * exp(b_g1[:, None] - b_g1[None, :])
+    b_A_33 = b_A_33 * exp(b_g2[:, None] - b_g2[None, :])
+    b_A_44 = b_A_44 * exp(b_g3[:, None] - b_g3[None, :])
+    b_A_21 = b_A_21 * exp(b_g1[:, None] - b_g0[None, :])
+    b_A_31 = b_A_31 * exp(b_g2[:, None] - b_g0[None, :])
+    b_A_32 = b_A_32 * exp(b_g2[:, None] - b_g1[None, :])
+    b_A_41 = b_A_41 * exp(b_g3[:, None] - b_g0[None, :])
+    b_A_42 = b_A_42 * exp(b_g3[:, None] - b_g1[None, :])
+    b_A_43 = b_A_43 * exp(b_g3[:, None] - b_g2[None, :])
+
+    # ---------- solve_tril ----------
     o_i = tl.arange(0, 16)
     m_A = o_i[:, None] > o_i[None, :]
-    m_I = o_i[:, None] == o_i[None, :]
-    A_base = A + (bos * H + i_h) * BT
+    I16 = (o_i[:, None] == o_i[None, :]).to(tl.float32)
     A_inv_base = A_inv + (bos * H + i_h) * BT
 
-    p_A_11 = tl.make_block_ptr(
-        A_base, (T, BT), (H * BT, 1), (i_t * BT, 0), (16, 16), (1, 0)
-    )
-    p_A_22 = tl.make_block_ptr(
-        A_base, (T, BT), (H * BT, 1), (i_t * BT + 16, 16), (16, 16), (1, 0)
-    )
-    p_A_33 = tl.make_block_ptr(
-        A_base, (T, BT), (H * BT, 1), (i_t * BT + 32, 32), (16, 16), (1, 0)
-    )
-    p_A_44 = tl.make_block_ptr(
-        A_base, (T, BT), (H * BT, 1), (i_t * BT + 48, 48), (16, 16), (1, 0)
-    )
-    b_Ai_11 = tl.load(p_A_11, boundary_check=(0, 1)).to(tl.float32)
-    b_Ai_22 = tl.load(p_A_22, boundary_check=(0, 1)).to(tl.float32)
-    b_Ai_33 = tl.load(p_A_33, boundary_check=(0, 1)).to(tl.float32)
-    b_Ai_44 = tl.load(p_A_44, boundary_check=(0, 1)).to(tl.float32)
+    b_Ai_11 = _inv_unit_lower_16(b_A_11, m_A, I16, DOT_PRECISION)
+    b_Ai_22 = _inv_unit_lower_16(b_A_22, m_A, I16, DOT_PRECISION)
+    b_Ai_33 = _inv_unit_lower_16(b_A_33, m_A, I16, DOT_PRECISION)
+    b_Ai_44 = _inv_unit_lower_16(b_A_44, m_A, I16, DOT_PRECISION)
 
-    b_Ai_11 = -tl.where(m_A, b_Ai_11, 0)
-    b_Ai_22 = -tl.where(m_A, b_Ai_22, 0)
-    b_Ai_33 = -tl.where(m_A, b_Ai_33, 0)
-    b_Ai_44 = -tl.where(m_A, b_Ai_44, 0)
-
-    for i in range(2, min(16, T - i_t * BT)):
-        b_a_11 = -tl.load(A_base + (i_t * BT + i) * H * BT + o_i)
-        b_a_11 += tl.sum(b_a_11[:, None] * b_Ai_11, 0)
-        b_Ai_11 = tl.where((o_i == i)[:, None], b_a_11, b_Ai_11)
-    for i in range(16 + 2, min(32, T - i_t * BT)):
-        b_a_22 = -tl.load(A_base + (i_t * BT + i) * H * BT + o_i + 16)
-        b_a_22 += tl.sum(b_a_22[:, None] * b_Ai_22, 0)
-        b_Ai_22 = tl.where((o_i == i - 16)[:, None], b_a_22, b_Ai_22)
-    for i in range(32 + 2, min(48, T - i_t * BT)):
-        b_a_33 = -tl.load(A_base + (i_t * BT + i) * H * BT + o_i + 32)
-        b_a_33 += tl.sum(b_a_33[:, None] * b_Ai_33, 0)
-        b_Ai_33 = tl.where((o_i == i - 32)[:, None], b_a_33, b_Ai_33)
-    for i in range(48 + 2, min(64, T - i_t * BT)):
-        b_a_44 = -tl.load(A_base + (i_t * BT + i) * H * BT + o_i + 48)
-        b_a_44 += tl.sum(b_a_44[:, None] * b_Ai_44, 0)
-        b_Ai_44 = tl.where((o_i == i - 48)[:, None], b_a_44, b_Ai_44)
-    b_Ai_11 += m_I
-    b_Ai_22 += m_I
-    b_Ai_33 += m_I
-    b_Ai_44 += m_I
-
-    p_A_21 = tl.make_block_ptr(
-        A_base, (T, BT), (H * BT, 1), (i_t * BT + 16, 0), (16, 16), (1, 0)
-    )
-    p_A_31 = tl.make_block_ptr(
-        A_base, (T, BT), (H * BT, 1), (i_t * BT + 32, 0), (16, 16), (1, 0)
-    )
-    p_A_32 = tl.make_block_ptr(
-        A_base, (T, BT), (H * BT, 1), (i_t * BT + 32, 16), (16, 16), (1, 0)
-    )
-    p_A_41 = tl.make_block_ptr(
-        A_base, (T, BT), (H * BT, 1), (i_t * BT + 48, 0), (16, 16), (1, 0)
-    )
-    p_A_42 = tl.make_block_ptr(
-        A_base, (T, BT), (H * BT, 1), (i_t * BT + 48, 16), (16, 16), (1, 0)
-    )
-    p_A_43 = tl.make_block_ptr(
-        A_base, (T, BT), (H * BT, 1), (i_t * BT + 48, 32), (16, 16), (1, 0)
-    )
-    b_A_21 = tl.load(p_A_21, boundary_check=(0, 1)).to(tl.float32)
-    b_A_31 = tl.load(p_A_31, boundary_check=(0, 1)).to(tl.float32)
-    b_A_32 = tl.load(p_A_32, boundary_check=(0, 1)).to(tl.float32)
-    b_A_41 = tl.load(p_A_41, boundary_check=(0, 1)).to(tl.float32)
-    b_A_42 = tl.load(p_A_42, boundary_check=(0, 1)).to(tl.float32)
-    b_A_43 = tl.load(p_A_43, boundary_check=(0, 1)).to(tl.float32)
-
-    DOT_PRECISION: tl.constexpr = "ieee"
     b_Ai_21 = -tl.dot(
         tl.dot(b_Ai_22, b_A_21, input_precision=DOT_PRECISION),
         b_Ai_11,
@@ -337,9 +339,9 @@ def chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
     chunk_size: int = FLA_CHUNK_SIZE,
     output_dtype: torch.dtype | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Fused cumsum(g) + KKT(L) + solve_tril(L -> inv). Returns (g_cumsum, A_inv).
+    """Fused cumsum(g) + KKT(L) + solve_tril(L -> inv).
 
-    Only BT == 64 is supported (solve_tril is hard-coded as 4x4 blocks of 16).
+    Returns (g_cumsum, A_inv). Only BT=64 is supported.
     """
     B, T, Hg, K = k.shape
     H = beta.shape[-1]
@@ -350,8 +352,8 @@ def chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
-    g_out = torch.empty_like(g)
-    A = torch.empty(B, T, H, BT, device=g.device, dtype=torch.float32)
+    # Gate cumsum must remain fp32; bf16 error is amplified by the later exp.
+    g_out = torch.empty_like(g, dtype=torch.float32)
     A_inv = torch.zeros(B, T, H, BT, device=g.device, dtype=output_dtype)
 
     def grid(meta):
@@ -362,7 +364,6 @@ def chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
         g_out=g_out,
         k=k,
         beta=beta,
-        A=A,
         A_inv=A_inv,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
@@ -370,13 +371,52 @@ def chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
         H=H,
         Hg=Hg,
         K=K,
-        BT=BT,
+        BT=BT
     )
     return g_out, A_inv
 
+def _n_bucket(N: int) -> int:
+    """Map request count to autotune tiers: 1, 2-8, 9-24, and 25+."""
+    if N <= 1:
+        return 0
+    if N <= 8:
+        return 1
+    if N <= 24:
+        return 2
+    return 3
+
+
+@tensor_cache
+def _skew_bucket_cached(chunk_offsets: torch.Tensor) -> int:
+    """Map max/average chunk-count skew to an identity-cached autotune tier."""
+    N = chunk_offsets.numel() - 1
+    if N <= 1:
+        return 0
+    nt = chunk_offsets[1:] - chunk_offsets[:-1]
+    stats = torch.stack([nt.max(), nt.sum()])
+    max_nt, sum_nt = stats.tolist()  # One sync per chunk_offsets identity.
+    if sum_nt <= 0:
+        return 0
+    avg_nt = sum_nt / N
+    skew = max_nt / avg_nt if avg_nt > 0 else 1.0
+    if skew <= 1.15:
+        return 0
+    elif skew <= 1.5:
+        return 1
+    elif skew <= 2.5:
+        return 2
+    else:
+        return 3
+
+
+def _skew_bucket(chunk_offsets: torch.Tensor | None, N: int) -> int:
+    """Return the fwd_h tail-skew tier; uniform and single-request inputs use 0."""
+    if chunk_offsets is None or N <= 1:
+        return 0
+    return _skew_bucket_cached(chunk_offsets)
 
 # ---------------------------------------------------------------------------
-# 2. chunk_delta_h with K-major state layout (no tl.trans in the recurrence)
+# 2. chunk_delta_h with V-major state layout
 # ---------------------------------------------------------------------------
 @libentry()
 @triton.heuristics(
@@ -391,10 +431,12 @@ def chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
 )
 @libtuner(
     configs=[
-        triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for BK in [16, 32, 64, 128]
+        for BV in [16, 32, 64]
         for num_warps in [2, 4]
-        for num_stages in [1]
-        for BV in [32, 64]
+        # num_stages=2 triggers a MetaX pipeliner map::at failure.
+        for num_stages in [3]
     ],
     key=[
         "H",
@@ -404,10 +446,12 @@ def chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
         "IS_VARLEN",
         "USE_INITIAL_STATE",
         "STORE_FINAL_STATE",
+        "N_BUCKET",
+        "SKEW_BUCKET",
     ],
 )
 @triton.jit(do_not_specialize=["T"])
-def chunk_gated_delta_rule_fwd_kernel_h_kmajor(
+def chunk_gated_delta_rule_fwd_kernel_h_vmajor(
     k,
     v,
     w,
@@ -425,6 +469,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_kmajor(
     K: tl.constexpr,
     V: tl.constexpr,
     BT: tl.constexpr,
+    BK: tl.constexpr,
     BV: tl.constexpr,
     USE_G: tl.constexpr,
     USE_GK: tl.constexpr,
@@ -432,6 +477,8 @@ def chunk_gated_delta_rule_fwd_kernel_h_kmajor(
     STORE_FINAL_STATE: tl.constexpr,
     SAVE_NEW_VALUE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    N_BUCKET: tl.constexpr,
+    SKEW_BUCKET: tl.constexpr,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_h = i_nh // H, i_nh % H
@@ -448,224 +495,268 @@ def chunk_gated_delta_rule_fwd_kernel_h_kmajor(
         NT = tl.cdiv(T, BT)
         boh = i_n * NT
 
-    # [BK, BV]
-    b_h1 = tl.zeros([64, BV], dtype=tl.float32)
-    if K > 64:
-        b_h2 = tl.zeros([64, BV], dtype=tl.float32)
-    if K > 128:
-        b_h3 = tl.zeros([64, BV], dtype=tl.float32)
-    if K > 192:
-        b_h4 = tl.zeros([64, BV], dtype=tl.float32)
+    NK: tl.constexpr = tl.cdiv(K, BK)
 
-    # calculate offset
-    h += ((boh * H + i_h) * K * V).to(tl.int64)
+    # [BV, BK] V-major accumulators.
+    b_h1 = tl.zeros([BV, BK], dtype=tl.float32)
+    if K > BK:
+        b_h2 = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_h2 = b_h1
+    if K > 2 * BK:
+        b_h3 = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_h3 = b_h1
+    if K > 3 * BK:
+        b_h4 = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_h4 = b_h1
+    if K > 4 * BK:
+        b_h5 = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_h5 = b_h1
+    if K > 5 * BK:
+        b_h6 = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_h6 = b_h1
+    if K > 6 * BK:
+        b_h7 = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_h7 = b_h1
+    if K > 7 * BK:
+        b_h8 = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_h8 = b_h1
+
+    # Calculate offsets.
+    h += ((boh * H + i_h) * V * K).to(tl.int64)
     v += ((bos * H + i_h) * V).to(tl.int64)
     k += ((bos * Hg + i_h // (H // Hg)) * K).to(tl.int64)
     w += ((bos * H + i_h) * K).to(tl.int64)
     if SAVE_NEW_VALUE:
         v_new += ((bos * H + i_h) * V).to(tl.int64)
     stride_v = H * V
-    stride_h = H * K * V
+    stride_h = H * V * K
     stride_k = Hg * K
     stride_w = H * K
     if USE_INITIAL_STATE:
-        h0 = h0 + i_nh * K * V
+        h0 = h0 + i_nh * V * K
     if STORE_FINAL_STATE:
-        ht = ht + i_nh * K * V
+        ht = ht + i_nh * V * K
 
-    # load initial state
+    # Load initial state.
     if USE_INITIAL_STATE:
-        p_h0_1 = tl.make_block_ptr(h0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
-        if K > 64:
-            p_h0_2 = tl.make_block_ptr(
-                h0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
-            )
-            b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
-        if K > 128:
-            p_h0_3 = tl.make_block_ptr(
-                h0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
-            )
-            b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
-        if K > 192:
-            p_h0_4 = tl.make_block_ptr(
-                h0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-            )
-            b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+        p_h0 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0))
+        b_h1 += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+        if K > BK:
+            p_h0 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, BK), (BV, BK), (1, 0))
+            b_h2 += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+        if K > 2 * BK:
+            p_h0 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 2 * BK), (BV, BK), (1, 0))
+            b_h3 += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+        if K > 3 * BK:
+            p_h0 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 3 * BK), (BV, BK), (1, 0))
+            b_h4 += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+        if K > 4 * BK:
+            p_h0 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 4 * BK), (BV, BK), (1, 0))
+            b_h5 += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+        if K > 5 * BK:
+            p_h0 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 5 * BK), (BV, BK), (1, 0))
+            b_h6 += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+        if K > 6 * BK:
+            p_h0 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 6 * BK), (BV, BK), (1, 0))
+            b_h7 += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+        if K > 7 * BK:
+            p_h0 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 7 * BK), (BV, BK), (1, 0))
+            b_h8 += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
 
-    # main recurrence
+    # Main recurrence.
     for i_t in range(NT):
-        p_h1 = tl.make_block_ptr(
-            h + i_t.to(tl.int64) * stride_h,
-            (K, V),
-            (V, 1),
-            (0, i_v * BV),
-            (64, BV),
-            (1, 0),
-        )
-        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
-        if K > 64:
-            p_h2 = tl.make_block_ptr(
-                h + i_t.to(tl.int64) * stride_h,
-                (K, V),
-                (V, 1),
-                (64, i_v * BV),
-                (64, BV),
-                (1, 0),
-            )
-            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
-        if K > 128:
-            p_h3 = tl.make_block_ptr(
-                h + i_t.to(tl.int64) * stride_h,
-                (K, V),
-                (V, 1),
-                (128, i_v * BV),
-                (64, BV),
-                (1, 0),
-            )
-            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
-        if K > 192:
-            p_h4 = tl.make_block_ptr(
-                h + i_t.to(tl.int64) * stride_h,
-                (K, V),
-                (V, 1),
-                (192, i_v * BV),
-                (64, BV),
-                (1, 0),
-            )
-            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
+        p_h = tl.make_block_ptr(h + i_t.to(tl.int64) * stride_h, (V, K), (K, 1),
+                                (i_v * BV, 0), (BV, BK), (1, 0))
+        tl.store(p_h, b_h1.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+        if K > BK:
+            p_h = tl.make_block_ptr(h + i_t.to(tl.int64) * stride_h, (V, K), (K, 1),
+                                    (i_v * BV, BK), (BV, BK), (1, 0))
+            tl.store(p_h, b_h2.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+        if K > 2 * BK:
+            p_h = tl.make_block_ptr(h + i_t.to(tl.int64) * stride_h, (V, K), (K, 1),
+                                    (i_v * BV, 2 * BK), (BV, BK), (1, 0))
+            tl.store(p_h, b_h3.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+        if K > 3 * BK:
+            p_h = tl.make_block_ptr(h + i_t.to(tl.int64) * stride_h, (V, K), (K, 1),
+                                    (i_v * BV, 3 * BK), (BV, BK), (1, 0))
+            tl.store(p_h, b_h4.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+        if K > 4 * BK:
+            p_h = tl.make_block_ptr(h + i_t.to(tl.int64) * stride_h, (V, K), (K, 1),
+                                    (i_v * BV, 4 * BK), (BV, BK), (1, 0))
+            tl.store(p_h, b_h5.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+        if K > 5 * BK:
+            p_h = tl.make_block_ptr(h + i_t.to(tl.int64) * stride_h, (V, K), (K, 1),
+                                    (i_v * BV, 5 * BK), (BV, BK), (1, 0))
+            tl.store(p_h, b_h6.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+        if K > 6 * BK:
+            p_h = tl.make_block_ptr(h + i_t.to(tl.int64) * stride_h, (V, K), (K, 1),
+                                    (i_v * BV, 6 * BK), (BV, BK), (1, 0))
+            tl.store(p_h, b_h7.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+        if K > 7 * BK:
+            p_h = tl.make_block_ptr(h + i_t.to(tl.int64) * stride_h, (V, K), (K, 1),
+                                    (i_v * BV, 7 * BK), (BV, BK), (1, 0))
+            tl.store(p_h, b_h8.to(p_h.dtype.element_ty), boundary_check=(0, 1))
 
-        p_w = tl.make_block_ptr(
-            w, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, 64), (1, 0)
-        )
-        b_w = tl.load(p_w, boundary_check=(0, 1))
-        b_v = tl.dot(b_w, b_h1.to(b_w.dtype))
-        if K > 64:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_w, 1), (i_t * BT, 64), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_v += tl.dot(b_w, b_h2.to(b_w.dtype))
-        if K > 128:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_w, 1), (i_t * BT, 128), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_v += tl.dot(b_w, b_h3.to(b_w.dtype))
-        if K > 192:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_w, 1), (i_t * BT, 192), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_v += tl.dot(b_w, b_h4.to(b_w.dtype))
-        p_v = tl.make_block_ptr(
-            v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-        )
+        b_v = tl.zeros([BT, BV], dtype=tl.float32)
+        p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, BK), (1, 0))
+        b_v += tl.dot(tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h1).to(k.dtype.element_ty))
+        if K > BK:
+            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, BK), (BT, BK), (1, 0))
+            b_v += tl.dot(tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h2).to(k.dtype.element_ty))
+        if K > 2 * BK:
+            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 2 * BK), (BT, BK), (1, 0))
+            b_v += tl.dot(tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h3).to(k.dtype.element_ty))
+        if K > 3 * BK:
+            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 3 * BK), (BT, BK), (1, 0))
+            b_v += tl.dot(tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h4).to(k.dtype.element_ty))
+        if K > 4 * BK:
+            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 4 * BK), (BT, BK), (1, 0))
+            b_v += tl.dot(tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h5).to(k.dtype.element_ty))
+        if K > 5 * BK:
+            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 5 * BK), (BT, BK), (1, 0))
+            b_v += tl.dot(tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h6).to(k.dtype.element_ty))
+        if K > 6 * BK:
+            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 6 * BK), (BT, BK), (1, 0))
+            b_v += tl.dot(tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h7).to(k.dtype.element_ty))
+        if K > 7 * BK:
+            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 7 * BK), (BT, BK), (1, 0))
+            b_v += tl.dot(tl.load(p_w, boundary_check=(0, 1)), tl.trans(b_h8).to(k.dtype.element_ty))
+
+        p_v = tl.make_block_ptr(v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
         b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
 
         if SAVE_NEW_VALUE:
-            p_v = tl.make_block_ptr(
-                v_new, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-            )
-            tl.store(p_v, b_v.to(p_v.dtype.element_ty), boundary_check=(0, 1))
+            p_vn = tl.make_block_ptr(v_new, (T, V), (stride_v, 1),
+                                     (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            tl.store(p_vn, b_v.to(p_vn.dtype.element_ty), boundary_check=(0, 1))
 
         last_idx = min((i_t.to(tl.int64) + 1) * BT, T) - 1
         if USE_G:
-            m_t = (i_t * BT + tl.arange(0, BT)) < T
-            b_g_last = tl.load(g + bos * H + last_idx * H + i_h).to(tl.float32)
-            p_g = tl.make_block_ptr(
-                g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
-            )
-            b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+            m_t = (i_t.to(tl.int64) * BT + tl.arange(0, BT)) < T
+            b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
+            p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+            b_g = tl.load(p_g, boundary_check=(0,))
             b_v = b_v * tl.where(m_t, exp(b_g_last - b_g), 0)[:, None]
             b_g_last = exp(b_g_last)
             b_h1 *= b_g_last
-            if K > 64:
+            if K > BK:
                 b_h2 *= b_g_last
-            if K > 128:
+            if K > 2 * BK:
                 b_h3 *= b_g_last
-            if K > 192:
+            if K > 3 * BK:
                 b_h4 *= b_g_last
+            if K > 4 * BK:
+                b_h5 *= b_g_last
+            if K > 5 * BK:
+                b_h6 *= b_g_last
+            if K > 6 * BK:
+                b_h7 *= b_g_last
+            if K > 7 * BK:
+                b_h8 *= b_g_last
 
         if USE_GK:
-            o_k1 = tl.arange(0, 64)
-            b_gk_last1 = tl.load(
-                gk + (bos + last_idx) * H * K + i_h * K + o_k1,
-                mask=(o_k1 < K),
-                other=0.0,
-            ).to(tl.float32)
-            b_h1 *= exp(b_gk_last1)[:, None]
-            if K > 64:
-                o_k2 = 64 + o_k1
-                b_gk_last2 = tl.load(
-                    gk + (bos + last_idx) * H * K + i_h * K + o_k2,
-                    mask=(o_k2 < K),
-                    other=0.0,
-                ).to(tl.float32)
-                b_h2 *= exp(b_gk_last2)[:, None]
-            if K > 128:
-                o_k3 = 128 + o_k1
-                b_gk_last3 = tl.load(
-                    gk + (bos + last_idx) * H * K + i_h * K + o_k3,
-                    mask=(o_k3 < K),
-                    other=0.0,
-                ).to(tl.float32)
-                b_h3 *= exp(b_gk_last3)[:, None]
-            if K > 192:
-                o_k4 = 192 + o_k1
-                b_gk_last4 = tl.load(
-                    gk + (bos + last_idx) * H * K + i_h * K + o_k4,
-                    mask=(o_k4 < K),
-                    other=0.0,
-                ).to(tl.float32)
-                b_h4 *= exp(b_gk_last4)[:, None]
+            o_k = tl.arange(0, BK)
+            b_gk = tl.load(gk + (bos + last_idx) * H * K + i_h * K + o_k,
+                           mask=(o_k < K), other=0.0)
+            b_h1 *= exp(b_gk)[None, :]
+            if K > BK:
+                o_k = BK + tl.arange(0, BK)
+                b_gk = tl.load(gk + (bos + last_idx) * H * K + i_h * K + o_k,
+                               mask=(o_k < K), other=0.0)
+                b_h2 *= exp(b_gk)[None, :]
+            if K > 2 * BK:
+                o_k = 2 * BK + tl.arange(0, BK)
+                b_gk = tl.load(gk + (bos + last_idx) * H * K + i_h * K + o_k,
+                               mask=(o_k < K), other=0.0)
+                b_h3 *= exp(b_gk)[None, :]
+            if K > 3 * BK:
+                o_k = 3 * BK + tl.arange(0, BK)
+                b_gk = tl.load(gk + (bos + last_idx) * H * K + i_h * K + o_k,
+                               mask=(o_k < K), other=0.0)
+                b_h4 *= exp(b_gk)[None, :]
+            if K > 4 * BK:
+                o_k = 4 * BK + tl.arange(0, BK)
+                b_gk = tl.load(gk + (bos + last_idx) * H * K + i_h * K + o_k,
+                               mask=(o_k < K), other=0.0)
+                b_h5 *= exp(b_gk)[None, :]
+            if K > 5 * BK:
+                o_k = 5 * BK + tl.arange(0, BK)
+                b_gk = tl.load(gk + (bos + last_idx) * H * K + i_h * K + o_k,
+                               mask=(o_k < K), other=0.0)
+                b_h6 *= exp(b_gk)[None, :]
+            if K > 6 * BK:
+                o_k = 6 * BK + tl.arange(0, BK)
+                b_gk = tl.load(gk + (bos + last_idx) * H * K + i_h * K + o_k,
+                               mask=(o_k < K), other=0.0)
+                b_h7 *= exp(b_gk)[None, :]
+            if K > 7 * BK:
+                o_k = 7 * BK + tl.arange(0, BK)
+                b_gk = tl.load(gk + (bos + last_idx) * H * K + i_h * K + o_k,
+                               mask=(o_k < K), other=0.0)
+                b_h8 *= exp(b_gk)[None, :]
+
         b_v = b_v.to(k.dtype.element_ty)
 
-        p_k = tl.make_block_ptr(
-            k, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1)
-        )
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_h1 += tl.dot(b_k, b_v)
-        if K > 64:
+        # Update H with trans(v_new) @ K; this form avoids a MetaX map::at failure.
+        b_vt = tl.trans(b_v)  # [BV, BT]
+        for i_k in tl.range(NK, num_stages=2):
             p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1)
+                k, (T, K), (stride_k, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
             )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_h2 += tl.dot(b_k, b_v)
-        if K > 128:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_h3 += tl.dot(b_k, b_v)
-        if K > 192:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_h4 += tl.dot(b_k, b_v)
-    # epilogue
+            b_kv = tl.dot(b_vt, tl.load(p_k, boundary_check=(0, 1)))
+            if i_k == 0:
+                b_h1 += b_kv
+            if K > BK and i_k == 1:
+                b_h2 += b_kv
+            if K > 2 * BK and i_k == 2:
+                b_h3 += b_kv
+            if K > 3 * BK and i_k == 3:
+                b_h4 += b_kv
+            if K > 4 * BK and i_k == 4:
+                b_h5 += b_kv
+            if K > 5 * BK and i_k == 5:
+                b_h6 += b_kv
+            if K > 6 * BK and i_k == 6:
+                b_h7 += b_kv
+            if K > 7 * BK and i_k == 7:
+                b_h8 += b_kv
+
+
+    # Store final state.
     if STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+        p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0))
         tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
-        if K > 64:
-            p_ht = tl.make_block_ptr(
-                ht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
-            )
+        if K > BK:
+            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, BK), (BV, BK), (1, 0))
             tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
-        if K > 128:
-            p_ht = tl.make_block_ptr(
-                ht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
-            )
+        if K > 2 * BK:
+            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 2 * BK), (BV, BK), (1, 0))
             tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
-        if K > 192:
-            p_ht = tl.make_block_ptr(
-                ht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-            )
+        if K > 3 * BK:
+            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 3 * BK), (BV, BK), (1, 0))
             tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if K > 4 * BK:
+            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 4 * BK), (BV, BK), (1, 0))
+            tl.store(p_ht, b_h5.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if K > 5 * BK:
+            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 5 * BK), (BV, BK), (1, 0))
+            tl.store(p_ht, b_h6.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if K > 6 * BK:
+            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 6 * BK), (BV, BK), (1, 0))
+            tl.store(p_ht, b_h7.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if K > 7 * BK:
+            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 7 * BK), (BV, BK), (1, 0))
+            tl.store(p_ht, b_h8.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
 
 
-def chunk_gated_delta_rule_fwd_h(
+def chunk_gated_delta_rule_fwd_h_vmajor(
     k: torch.Tensor,
     w: torch.Tensor,
     u: torch.Tensor,
@@ -678,7 +769,7 @@ def chunk_gated_delta_rule_fwd_h(
     cu_seqlens: torch.Tensor | None = None,
     chunk_indices: torch.Tensor | None = None,
     chunk_offsets: torch.Tensor | None = None,
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     B, T, Hg, K, V = *k.shape, u.shape[-1]
     H = u.shape[-2]
     BT = chunk_size
@@ -691,19 +782,21 @@ def chunk_gated_delta_rule_fwd_h(
         N, NT = len(cu_seqlens) - 1, len(chunk_indices)
         if chunk_offsets is None:
             chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT)
-    assert K <= 256, "current kernel does not support head dimension larger than 256."
+    assert K <= 256, "head dim > 256 unsupported"
 
-    h = k.new_empty(B, NT, H, K, V)
+    h = k.new_empty(B, NT, H, V, K)  # V-major layout, matches vLLM
     final_state = (
-        k.new_empty(N, H, K, V, dtype=torch.float32) if output_final_state else None
+        k.new_empty(N, H, V, K, dtype=torch.float32) if output_final_state else None
     )
-
     v_new = torch.empty_like(u) if save_new_value else None
+
+    N_BUCKET = _n_bucket(N)
+    SKEW_BUCKET = _skew_bucket(chunk_offsets if cu_seqlens is not None else None, N)
 
     def grid(meta):
         return (triton.cdiv(V, meta["BV"]), N * H)
 
-    chunk_gated_delta_rule_fwd_kernel_h_kmajor[grid](
+    chunk_gated_delta_rule_fwd_kernel_h_vmajor[grid](
         k=k,
         v=u,
         w=w,
@@ -721,12 +814,15 @@ def chunk_gated_delta_rule_fwd_h(
         K=K,
         V=V,
         BT=BT,
+        N_BUCKET=N_BUCKET,
+        SKEW_BUCKET=SKEW_BUCKET,
+        pipeline="cpasync-mixed",
     )
     return h, v_new, final_state
 
 
 # ---------------------------------------------------------------------------
-# 3. chunk_o consuming the (K, V) h layout
+# 3. chunk_o consuming the V-major [V, K] state layout
 # ---------------------------------------------------------------------------
 @libentry()
 @triton.heuristics(
@@ -738,11 +834,12 @@ def chunk_gated_delta_rule_fwd_h(
 @libtuner(
     configs=[
         triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
-        for BK, BV in [(32, 32), (32, 64), (64, 32), (64, 64)]
-        for num_warps in [2, 4, 8]
-        for num_stages in [1, 2]
+        for BK in [32, 64]
+        for BV in [32, 64]
+        for num_warps in [4]
+        for num_stages in [1, 2, 3]
     ],
-    key=["H", "K", "V", "BT", "IS_VARLEN"],
+    key=["H", "K", "V", "BT", "IS_VARLEN", "N_BUCKET"],
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_fwd_kernel_o(
@@ -765,6 +862,7 @@ def chunk_fwd_kernel_o(
     BV: tl.constexpr,
     USE_G: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    N_BUCKET: tl.constexpr,
 ):
     i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
@@ -786,12 +884,12 @@ def chunk_fwd_kernel_o(
         i_tg = i_b * NT + i_t
         bos, eos = i_b * T, i_b * T + T
 
-    # offset calculation
     q += (bos * Hg + i_h // (H // Hg)) * K
     k += (bos * Hg + i_h // (H // Hg)) * K
     v += (bos * H + i_h) * V
     o += (bos * H + i_h) * V
-    h += (i_tg * H + i_h).to(tl.int64) * K * V
+    # h is stored as [B, NT, H, V, K].
+    h += (i_tg * H + i_h).to(tl.int64) * V * K
 
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
@@ -803,20 +901,14 @@ def chunk_fwd_kernel_o(
         p_k = tl.make_block_ptr(
             k, (K, T), (1, Hg * K), (i_k * BK, i_t * BT), (BK, BT), (0, 1)
         )
-        # h is stored as (K, V)
         p_h = tl.make_block_ptr(
-            h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
+            h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
         )
-        # [BT, BK]
         b_q = tl.load(p_q, boundary_check=(0, 1))
-        # [BK, BT]
         b_k = tl.load(p_k, boundary_check=(0, 1))
-        # [BK, BV]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_h = tl.trans(tl.load(p_h, boundary_check=(0, 1)))
 
-        # [BT, BK] @ [BK, BV] -> [BT, BV]
         b_o += tl.dot(b_q, b_h)
-        # [BT, BK] @ [BK, BT] -> [BT, BT]
         b_A += tl.dot(b_q, b_k)
 
     if USE_G:
@@ -839,10 +931,9 @@ def chunk_fwd_kernel_o(
     )
     b_v = tl.load(p_v, boundary_check=(0, 1))
 
-    # scale is applied only once at the end
+    # Apply scale once at the end.
     b_o = b_o * scale + tl.dot(b_A.to(b_v.dtype), b_v) * scale
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
-
 
 def chunk_fwd_o(
     q: torch.Tensor,
@@ -864,13 +955,16 @@ def chunk_fwd_o(
     if scale is None:
         scale = k.shape[-1] ** -0.5
 
+    N = (len(cu_seqlens) - 1) if cu_seqlens is not None else B
+    N_BUCKET = _n_bucket(N)
+
     o = torch.empty_like(v)
 
     def grid(meta):
         return (
             triton.cdiv(V, meta["BV"]),
             NT,
-            H if cu_seqlens is not None else B * H,
+            B * H,
         )
 
     chunk_fwd_kernel_o[grid](
@@ -889,13 +983,15 @@ def chunk_fwd_o(
         K=K,
         V=V,
         BT=BT,
+        N_BUCKET=N_BUCKET,
     )
     return o
 
 
+
 # ---------------------------------------------------------------------------
 # 4. Patched forward: fused cumsum+kkt+solve_tril -> recompute_w_u ->
-#    K-major chunk_delta_h -> chunk_o
+#    V-major chunk_delta_h -> chunk_o
 # ---------------------------------------------------------------------------
 def chunk_gated_delta_rule_fwd(
     q: torch.Tensor,
@@ -911,8 +1007,8 @@ def chunk_gated_delta_rule_fwd(
     chunk_offsets: torch.Tensor | None = None,
     **kwargs,
 ):
-    logger.debug("METAX GDN CHUNK FWD (K-major, fused cumsum+kkt+solve_tril)")
-    # Ensure contiguity
+    logger.debug("METAX GDN CHUNK FWD (V-major, fused cumsum+kkt+solve_tril)")
+    # Ensure contiguity.
     if not q.is_contiguous():
         q = q.contiguous()
     if not k.is_contiguous():
@@ -937,7 +1033,7 @@ def chunk_gated_delta_rule_fwd(
         chunk_size=FLA_CHUNK_SIZE,
         output_dtype=k.dtype,
     )
-    # obtain WY representation. u is actually the new v.
+    # Obtain WY representation; u is the new value.
     w, u = recompute_w_u_fwd(
         k=k,
         v=v,
@@ -946,7 +1042,8 @@ def chunk_gated_delta_rule_fwd(
         g_cumsum=g,
         cu_seqlens=cu_seqlens,
     )
-    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+
+    h, v_new, final_state = chunk_gated_delta_rule_fwd_h_vmajor(
         k=k,
         w=w,
         u=u,


### PR DESCRIPTION
<!--
 Copyright 2026 FlagOS Contributors

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->

### PR Category

Operator

### Type of Change

Performance Optimization

### Description

This PR optimizes the Gated Delta Network (GDN) chunk forward implementation for the MetaX backend, primarily targeting GDN workloads in Qwen3.6 models.

The main changes include:

- Optimize the fused `cumsum + KKT + solve_tril` kernel:
  - Split the 64×64 lower-triangular matrix into 16×16 blocks.
  - Compute unit lower-triangular matrix inverses in registers.
  - Eliminate the intermediate `A` allocation, global-memory writeback, and reload, reducing memory traffic and synchronization overhead.
  - Preserve gate cumulative sums in FP32 to prevent BF16 errors from being amplified by subsequent exponential operations.
- Change the H-state layout from K-major to V-major `[V, K]`, aligning it with the vLLM state layout and updating both the `chunk_delta_h` and `chunk_o` kernels accordingly.
- Add tunable `BK`, `BV`, warp, and pipeline configurations to the H-state kernel.
- Add request-count and variable-length workload buckets to the autotune keys:
  - `N_BUCKET` selects configurations according to the request count.
  - `SKEW_BUCKET` accounts for imbalanced chunk distributions in variable-length batches.
  - Skew bucket results are cached to avoid repeated host-device synchronization.
- Add MetaX compiler-specific handling:
  - Disable LICM only for the GDN H-state kernel to prevent register spilling caused by excessive register pressure.
- Preserve support for fixed-length and variable-length inputs, initial and final states, and grouped heads.

The fused implementation currently requires `chunk_size = 64` and retains the `K <= 256` constraint.

### Issue

N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

The optimized FlagGems MetaX implementation was benchmarked against the native vLLM implementation using Qwen3.6-35B-A3B GDN workloads through FlagTune.

The benchmark primarily covers:

- `H = 8`
- `Hg = 4`
- `K = 128`
- `V = 128`
- `BT = 64`
- Fixed-length and variable-length inputs with different request counts and chunk-skew levels

| Scenario | Rows | Average speedup | Speedup range |
| --- | ---: | ---: | ---: |
| p1024d1024 | 19 | 1.227× | 1.116×–1.538× |
| p4096d1024 | 26 | 1.188× | 1.071×–1.535× |
| p32768d1024 | 15 | 1.209× | 1.085×–1.578× |
| p65536d1024 | 15 | 1.196× | 1.068×–1.537× |

The four reports cover 75 benchmark cases. The overall arithmetic mean speedup is **1.200×**, with an overall range of **1.068×–1.584×**. Positive performance gains are observed in 74 of the 75 cases.

Representative results:

- Short sequence with `T=64`: latency decreases from `0.092214 ms` to `0.058450 ms`, providing a `1.578×` speedup.
- Long-sequence and variable-length workloads show approximately `1.08×–1.29×` speedups depending on request count and chunk skew.
[Qwen3.6-35B-A3B-p1024d1024_gdn_chunk.xlsx](https://github.com/user-attachments/files/32095702/Qwen3.6-35B-A3B-p1024d1024_gdn_chunk.xlsx)
[Qwen3.6-35B-A3B-p4096d1024_gdn_chunk.xlsx](https://github.com/user-attachments/files/32095703/Qwen3.6-35B-A3B-p4096d1024_gdn_chunk.xlsx)
[Qwen3.6-35B-A3B-p32768d1024_gdn_chunk.xlsx](https://github.com/user-attachments/files/32095705/Qwen3.6-35B-A3B-p32768d1024_gdn_chunk.xlsx)
[Qwen3.6-35B-A3B-p65536d1024_gdn_chunk.xlsx](https://github.com/user-attachments/files/32095706/Qwen3.6-35B-A3B-p65536d1024_gdn_chunk.xlsx)
